### PR TITLE
[WIP] Adds GUI dialogue when user tries to open file in sd-journalist

### DIFF
--- a/dom0/sd-journalist-files.sls
+++ b/dom0/sd-journalist-files.sls
@@ -23,9 +23,9 @@
     - group: root
     - mode: 755
 
-/usr/local/bin/do-not-open:
+/usr/local/bin/do-not-open-here:
   file.managed:
-    - source: salt://sd/sd-journalist/do-not-open
+    - source: salt://sd/sd-journalist/do-not-open-here
     - user: root
     - group: root
     - mode: 755

--- a/sd-journalist/do-not-open-here
+++ b/sd-journalist/do-not-open-here
@@ -1,11 +1,16 @@
 #!/usr/bin/python
 
 import sys
-from PyQt4 import Qt
+from PyQt4 import QtGui
 
-a = Qt.QApplication(sys.argv)
+def main():
+    app = QtGui.QApplication(sys.argv)
+    w = QtGui.QWidget()
 
-nope = Qt.QLabel("Please do not use this VM to open any files aside from those downloaded from SecureDrop.")
+    QtGui.QMessageBox.warning(w, "Please do not open here",
+     "Please do not use this VM for opening files other than those downloaded from the SecureDrop Journalist interface.")
 
-nope.show()
-a.exec_()
+    sys.exit()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Opening this as an example of how to open QT Dialogues. In this case, we alert the user when they try to open a file in the sd-journalist VM (which, I believe, should only be used to download submissions from the SD Journalist interface, not for general-use computering).