### PR TITLE
[WIP] Make sure to close tars before using them

### DIFF
--- a/decrypt/decrypt-sd-submission
+++ b/decrypt/decrypt-sd-submission
@@ -18,7 +18,7 @@ tmpdir = tempfile.mkdtemp()
 # we get given a tarball of everything the user has downloaded.
 # first step, extract that archive
 with tarfile.open(input) as tar:
-  # potentially unsafe, can create arbitrary files on the filesystem 
+  # potentially unsafe, can create arbitrary files on the filesystem
   # given a malicious tarball
   tar.extractall(tmpdir)
 
@@ -49,9 +49,11 @@ for root, dirnames, filenames in os.walk(tmpdir):
 # ok. we're going to send all the decrypted stuff to the svs vm.
 # let's tar it all up again, so we can `qvm-open-in-vm` it.
 fh = tempfile.NamedTemporaryFile(suffix=".sd-xfer-extracted", delete=False)
-print "extracted fh name " + fh.name
 out_tar = tarfile.open(mode='w', fileobj=fh)
 out_tar.add(os.path.join(tmpdir, "extracted"), arcname="extracted")
+out_tar.close()
+fh.close()
+
 shutil.rmtree(tmpdir)
 
 # finally! ship this off to sd-svs

--- a/sd-journalist/move-to-svs
+++ b/sd-journalist/move-to-svs
@@ -25,6 +25,7 @@ out_tar = tarfile.open(mode='w', fileobj=fh)
 for f in probable_sd_downloads:
   out_tar.add(os.path.join(TB_DL_LOC, f), arcname=f)
 
+out_tar.close()
 fh.close()
 
 # ship this to the next phase

--- a/sd-journalist/sd-process-download
+++ b/sd-journalist/sd-process-download
@@ -17,6 +17,7 @@ fn = sys.argv[1]
 fh = tempfile.NamedTemporaryFile(suffix=".sd-xfer", delete=False)
 out_tar = tarfile.open(mode='w', fileobj=fh)
 out_tar.add(fn, arcname=os.path.basename(fn))
+out_tar.close()
 fh.close()
 
 # ship this to the next phase


### PR DESCRIPTION
This hasn't been end-to-end tested yet, but should address bug #2. We were not properly closing the python Tar object after creating it on the disp VM, which in certain instances seemed to lead to some submissions not making to to `sd-svs`. This takes care of that bug, plus adds proper closing to other places where we use python's `tarfile`. I'll update this once it's been tested on a freshly built installation.