### PR TITLE
Support *gpg single file downloads

### DIFF
--- a/decrypt/decrypt-sd-submission
+++ b/decrypt/decrypt-sd-submission
@@ -22,8 +22,8 @@ with tarfile.open(input) as tar:
   # given a malicious tarball
   tar.extractall(tmpdir)
 
-# everything in the archive should be zips, as created by SD
-# let's unzip those here
+# some files may be zips, some may be .gpg
+# let's unzip the zip files here to produce .gpg files
 zips = glob.glob(tmpdir + "/*zip")
 for z in zips:
   with zipfile.ZipFile(z) as zf:

--- a/sd-journalist/move-to-svs
+++ b/sd-journalist/move-to-svs
@@ -9,9 +9,11 @@ import subprocess
 
 TB_DL_LOC="/home/user/.tb/tor-browser/Browser/Downloads"
 
+# Files downloaded from SecureDrop can end in .zip or .gpg
 zips = glob.glob(TB_DL_LOC + "/*.zip")
+gpgs = glob.glob(TB_DL_LOC + "/*.gpg")
 
-matched_sd_pattern = [re.match('[a-z]+\_[a-z]+[\d-]+\.zip', os.path.basename(z)) for z in zips]
+matched_sd_pattern = [re.match('[a-z]+\_[a-z]+[\d-]+\.zip', os.path.basename(z)) for z in zips + gpgs]
 
 probable_sd_downloads = [z.group(0) for z in matched_sd_pattern if z]
 

--- a/sd-journalist/sd-process-download.desktop
+++ b/sd-journalist/sd-process-download.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
 Type=Application
-MimeType=application/zip
+MimeType=application/zip;application/pgp-encrypted
 Name=Process SecureDrop Download
 Exec=/usr/local/bin/sd-process-download


### PR DESCRIPTION
## Description

Closes #8.

This PR:
  * Extends the "Process SecureDrop Download" handler to the `application/pgp-encrypted` MimeType
  * Extends the `move-to-svs` script to also move `*.gpg` files to the SVS AppVM

## Testing

1. In `dom0` as a regular user in the directory with the `securedrop-workstation` repo code copied:

```
./reset.sh
```

2. Checkout this branch in your `work` AppVM and copy it to `dom0`.

3. In `dom0` as a regular user in the directory with the `securedrop-workstation` repo code copied:

```
./run.sh
```

4. When complete, start the `sd-journalist` AppVM, go to the journalist interface and download a single file by clicking this button:

![howtodownloadgpg](https://user-images.githubusercontent.com/7832803/30042097-f5327756-91a3-11e7-8401-b6086299b83a.png)

5. Verify that the _default_ handler is "Process SecureDrop Download" and that a DispVM starts.
