### PR TITLE
Makefile and README update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,90 @@
+DEVVM=work
+DEVDIR=/home/user/projects/qubes-sd # important: no trailing slash
+
+all: clean sd-whonix sd-svs sd-gpg sd-journalist disp-vm
+
+proj-tar:
+	qvm-run --pass-io $(DEVVM) 'tar -c -C $(dir $(DEVDIR)) $(notdir $(DEVDIR))' > ./proj.tar
+
+clone: proj-tar
+	tar xvf proj.tar --strip-components=1
+
+sd-journalist: prep-salt
+	sudo qubesctl top.enable sd-journalist
+	sudo qubesctl top.enable sd-journalist-files
+	sudo qubesctl --targets sd-journalist state.highstate
+
+sd-gpg: prep-salt
+	sudo qubesctl top.enable sd-gpg
+	sudo qubesctl top.enable sd-gpg-files
+	sudo qubesctl --targets sd-gpg state.highstate
+
+sd-svs: prep-salt
+	sudo qubesctl top.enable sd-svs
+	sudo qubesctl top.enable sd-svs-files
+	sudo qubesctl --targets sd-svs state.highstate
+
+sd-whonix: prep-salt
+	sudo qubesctl top.enable sd-whonix
+	sudo qubesctl top.enable sd-whonix-hidserv-key
+	sudo qubesctl --targets sd-whonix state.highstate
+
+disp-vm: prep-salt
+	qvm-clone fedora-23 fedora-23-sd-dispvm
+	sudo qubesctl top.enable sd-dispvm-files
+	sudo qubesctl --targets fedora-23-sd-dispvm state.highstate
+	qvm-create-default-dvm fedora-23-sd-dispvm
+
+prep-salt:
+	sudo [ -d /srv/salt/sd/ ] && sudo rm -rf /srv/salt/sd
+	sudo mkdir /srv/salt/sd
+	sudo cp config.json /srv/salt/sd
+	sudo cp sd-journalist.sec /srv/salt/sd
+	sudo cp -r decrypt /srv/salt/sd
+	sudo cp -r sd-journalist /srv/salt/sd
+	sudo cp -r sd-svs /srv/salt/sd
+	sudo cp dom0/* /srv/salt/
+
+remove-sd-whonix:
+	-qvm-kill sd-whonix
+	-qvm-remove sd-whonix
+
+remove-fedora-23-sd-dispvm:
+	-qvm-kill fedora-23-sd-dispvm
+	-qvm-remove fedora-23-sd-dispvm
+
+remove-fedora-23-sd-dispvm-dvm:
+	-qvm-kill fedora-23-sd-dispvm-dvm
+	-qvm-remove fedora-23-sd-dispvm-dvm
+
+remove-sd-journalist:
+	-qvm-kill sd-journalist
+	-qvm-remove sd-journalist
+
+remove-sd-svs:
+	-qvm-kill sd-svs
+	-qvm-remove sd-svs
+
+remove-sd-gpg:
+	-qvm-kill sd-gpg
+	-qvm-remove sd-gpg
+
+clean: remove-sd-gpg remove-sd-svs remove-sd-journalist \
+	remove-fedora-23-sd-dispvm-dvm remove-fedora-23-sd-dispvm \
+	remove-sd-whonix
+	@echo "Reset all VMs"
+
+test:
+	python -m unittest -v tests    # will run all tests
+
+test-svs:
+	python -m unittest -v tests.svs-test
+
+test-journalist:
+	python -m unittest -v tests.test_journalist_vm
+
+test-whonix:
+	python -m unittest -v tests.test_sd_whonix
+
+test-disp:
+	python -m unittest -v tests.test_dispvm

--- a/README.md
+++ b/README.md
@@ -45,49 +45,43 @@ Qubes uses SaltStack internally for VM provisionining and configuration manageme
 
 `config.json.orig` is an example config file for the provisioning process. Before use, you should copy it to `config.json`, and adjust to reflect your environment.
 
-`run.sh` is used to provision the entire SecureDrop installation.
-
-`reset.sh` will remove all traces of a SecureDrop installation from your Qubes.
+`Makefile` is used with the `make` command on dom0 to build the Qubes/SecureDrop installation, and also contains some development and testing features
 
 ### Using this repo
 
+What follows describes how to configure and use this repo for development and testing. We don't yet have a full story for production deployment- see #17 for discussion about that.
+
 First install Qubes 3.2 and accept the default VM configuration during the install process.
 
-Next, some SecureDrop-specific configuration: edit `config.json` to include your values for the Journalist hidden service `.onion` hostname and PSK. Replace `sd-journalist.sec` with the GPG private key used to encrypt submissions.
+Next, some SecureDrop-specific configuration: edit `config.json` to include your values for the Journalist hidden service `.onion` hostname and PSK. Replace `sd-journalist.sec` with the GPG private key used to encrypt submissions. Edit `Makefile` and replace `DEVVM` and `DEVDIR` to reflect the VM and directory to which you've cloned this repo. Note that `DEVDIR` must not include a trailing slash.
 
-Qubes provisioning is handled by Salt on `dom0`, so this project must be copied there. That process is a little tricky, but here's one way to do it: assuming this code is checked out in your `work` VM at `/home/user/projects/securedrop-workstation`, run the following in `dom0`.
+Qubes provisioning is handled by Salt on `dom0`, so this project must be copied there from your development VM. That process is a little tricky, but here's one way to do it: assuming this code is checked out in your `work` VM at `/home/user/projects/securedrop-workstation`, run the following in `dom0`.
 
     qvm-run --pass-io work 'tar -c -C /home/user/projects securedrop-workstation' | tar xvf -
 
-Once the configuration is done and this directory is copied to `dom0`, `run.sh` can be executed to handle all provisioning and configuration. It should be run as your unprivileged user in `dom0`:
+After that initial manual step, the code in your development VM may be copied into place on `dom0` by running `make clone` on from the root of the project on `dom0`.
+
+Once the configuration is done and this directory is copied to `dom0`, `make` can be used to handle all provisioning and configuration by your unprivledged user:
 
     $ cd securedrop-workstation
-    $ ./run.sh
+    $ make all
 
 ### Development
 
-Development is a little tricky, since:
+My development workflow is different depending on if I'm working on provisioning components or submission-handling scripts.
 
-- presumably you don't want to do much real development in your SD AppVMs
-- you must run these scripts from `dom0`, but it's very unergonomic to work there (since it's nearly impossible to commit changes from `dom0`)
+For developing salt states and other provisioning component, I work in a development VM and make changes to individual state and top files there. Then, in the `dom0` copy of this project, I'll `make clone` to copy over the updated files, then use `make <vm-name>` to rebuilt an individual VM, or `make all` to rebuild the full installation. Current valid target VM names are `sd-journalist`, `sd-gpg`, `sd-whonix`, `disp-vm`.
 
-So, you should develop in a work VM, then copy changes to `dom0` for provisioning, then use salt to push changes to the SD AppVMs.
-
-For example, for developing the scripts which run in `sd-journalist`, I'll edit files in a checkout of this repo in my `work` VM (in, for example, `~/projects/securedrop-workstation`). Then, in `dom0`, I'll run:
-
-    $ cd /home/joshua ; qvm-run --pass-io work 'tar -c -C /home/user/projects securedrop-workstation' | tar xvf - ; cd /home/joshua/securedrop-workstation
-
-    $ sudo cp -r sd-journalist /srv/salt/sd ; sudo cp -r dom0/* /srv/salt/ ; sudo qubesctl --targets sd-journalist state.highstate
-
-The first command clones the repo into `~/securedrop-workstation` in dom0 and drops you in the root of the repo. The second command copies the appropriate files into place for the salt ecosystem, then uses salt (via `qubesctl`) to apply any changes. If you're making other changes (ie, not to `sd-journalist` or `sd-journalist-files`), you may need to alter which files are copied into the system salt config directories. See `run.sh` for inspiration.
+For developing submission processing scripts I often work directly in the virtual machine running the component I'm working on. When I'm at a good checkpoint, I'll copy the updated files to my work VM with `qvm-copy-to-vm ...`, move the copied files into place in the repo, and commit the changes there. This process is a little awkward, and it would be nice to make it better.
 
 ### Testing
 
 Tests should cover two broad domains. First, we should assert that all the expected VMs exist and are configured as we expect (with the correct NetVM, with the expected files in the correct place). Second, we should end-to-end test the document handlng scripts, asserting that files present in the sd-journalist VM correctly make their way to the sd-svs AppVM, and are opened correctly in disposable VMs.
 
-Tests can be found in the `tests/` directory. They use Python's `unittest` library, and so can be run from the project's root directory with:
+Tests can be found in the `tests/` directory. They use Python's `unittest` library, and so can be run from the project's root directory on `dom0` with:
 
-    python -m unittest -v tests    # will run all tests
-    python -m unittest -v svs-test # run an individual test (in this case, test the svs AppVM)
+    make test
 
-Be aware that running tests *will power down running SecureDrop VMs, and may result in data loss*. Only run tests in a development / testing environment. Tests should be run from `dom0`.
+Individual tests can be run with `make <test-name>`, where `test-name` is one of `test-svs`, `test-journalist`, `test-whonix`, or `test-disp`.
+
+Be aware that running tests *will power down running SecureDrop VMs, and may result in data loss*. Only run tests in a development / testing environment.

--- a/README.md
+++ b/README.md
@@ -78,9 +78,11 @@ For developing submission processing scripts I often work directly in the virtua
 
 Tests should cover two broad domains. First, we should assert that all the expected VMs exist and are configured as we expect (with the correct NetVM, with the expected files in the correct place). Second, we should end-to-end test the document handlng scripts, asserting that files present in the sd-journalist VM correctly make their way to the sd-svs AppVM, and are opened correctly in disposable VMs.
 
-Tests can be found in the `tests/` directory. They use Python's `unittest` library, and so can be run from the project's root directory on `dom0` with:
+Tests can be found in the `tests/` directory. They can be run from the project's root directory on `dom0` with:
 
     make test
+
+Note that since tests assert confirm the state of provisioned VMs, tests should be run _after_ all the VMs have been built with `make all`.
 
 Individual tests can be run with `make <test-name>`, where `test-name` is one of `test-svs`, `test-journalist`, `test-whonix`, or `test-disp`.
 

--- a/dom0/sd-journalist-files.sls
+++ b/dom0/sd-journalist-files.sls
@@ -30,34 +30,6 @@
     - group: root
     - mode: 755
 
-/usr/local/bin/sd-process-feedback:
-  file.managed:
-    - source: salt://sd/sd-journalist/sd-process-feedback
-    - user: root
-    - group: root
-    - mode: 755
-
-/usr/local/bin/mm.py:
-  file.managed:
-    - source: salt://sd/sd-journalist/mm.py
-    - user: root
-    - group: root
-    - mode: 755
-
-/usr/local/bin/pipereader.py:
-  file.managed:
-    - source: salt://sd/sd-journalist/pipereader.py
-    - user: root
-    - group: root
-    - mode: 755
-
-/etc/qubes-rpc/sd-process.Feedback:
-  file.managed:
-    - source: salt://sd/sd-journalist/sd-process.Feedback
-    - user: root
-    - group: root
-    - mode: 755
-
 /usr/local/share/applications/sd-process-download.desktop:
   file.managed:
     - source: salt://sd/sd-journalist/sd-process-download.desktop

--- a/dom0/sd-journalist-files.sls
+++ b/dom0/sd-journalist-files.sls
@@ -30,6 +30,34 @@
     - group: root
     - mode: 755
 
+/usr/local/bin/sd-process-feedback:
+  file.managed:
+    - source: salt://sd/sd-journalist/sd-process-feedback
+    - user: root
+    - group: root
+    - mode: 755
+
+/usr/local/bin/mm.py:
+  file.managed:
+    - source: salt://sd/sd-journalist/mm.py
+    - user: root
+    - group: root
+    - mode: 755
+
+/usr/local/bin/pipereader.py:
+  file.managed:
+    - source: salt://sd/sd-journalist/pipereader.py
+    - user: root
+    - group: root
+    - mode: 755
+
+/etc/qubes-rpc/sd-process.Feedback:
+  file.managed:
+    - source: salt://sd/sd-journalist/sd-process.Feedback
+    - user: root
+    - group: root
+    - mode: 755
+
 /usr/local/share/applications/sd-process-download.desktop:
   file.managed:
     - source: salt://sd/sd-journalist/sd-process-download.desktop
@@ -56,4 +84,3 @@
 
 sudo update-desktop-database /usr/local/share/applications:
   cmd.run
-


### PR DESCRIPTION
This moves away from the `run.py`-based workflow, in favor of a Makefile which is able to clone, build, clean, and run tests on the installation. It also includes a small unrelated feature: it provides a desktop notification when decryption fails in the disp vm... that was a git mistake, but we may as well get it in master at some point.