### PR TITLE
Adds "clean-salt" Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ sd-svs-disp: prep-salt ## Provisions SD Submission Viewing VM
 clean-salt: assert-dom0 ## Purges SD Salt configuration from dom0
 	sudo rm -rf /srv/salt/sd
 	sudo find /srv/salt -maxdepth 1 -type f -iname 'sd*' -delete
-	sudo find /srv/salt/_tops -type l -delete
+	sudo find /srv/salt/_tops -lname '/srv/salt/sd-*' -delete
 
 prep-salt: assert-dom0 ## Configures Salt layout for SD workstation VMs
 	sudo mkdir /srv/salt/sd

--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,12 @@ sd-svs-disp: prep-salt ## Provisions SD Submission Viewing VM
 	sudo qubesctl top.enable sd-svs-disp
 	sudo qubesctl --targets sd-svs-disp state.highstate
 
+clean-salt: assert-dom0 ## Purges SD Salt configuration from dom0
+	sudo rm -rf /srv/salt/sd
+	sudo find /srv/salt -maxdepth 1 -type f -iname 'sd*' -delete
+	sudo find /srv/salt/_tops -type l -delete
+
 prep-salt: assert-dom0 ## Configures Salt layout for SD workstation VMs
-	-sudo rm -rf /srv/salt/sd
 	sudo mkdir /srv/salt/sd
 	sudo cp config.json /srv/salt/sd
 	sudo cp sd-journalist.sec /srv/salt/sd
@@ -87,7 +91,7 @@ remove-sd-gpg: assert-dom0 ## Destroys SD GPG keystore VM
 	-qvm-remove -f sd-gpg
 
 clean: assert-dom0 remove-sd-gpg remove-sd-svs remove-sd-journalist \
-	remove-sd-svs-disp remove-sd-decrypt remove-sd-whonix ## Destroys all SD VMs
+	remove-sd-svs-disp remove-sd-decrypt remove-sd-whonix clean-salt ## Destroys all SD VMs
 	@echo "Reset all VMs"
 
 test: assert-dom0 ## Runs all application tests (no integration tests yet)


### PR DESCRIPTION
We already have "prep-salt", but we noticed in #50 that simply adding new files
isn't always backwards-compatible: some legacy files can persist in /srv/salt,
causing problems with non-unique salt IDs when newer versions of the config are run.

Let's purge all SD-Workstation-related Salt configs prior to writing the new,
current ones each time. Note that the "clean-salt" action runs as part of the
general "clean" step, *not* as a dependency of "prep-salt", since prep-salt runs
prior to each and every VM creation.

Closes #50.