### PR TITLE
Lints all Python files via flake8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,22 @@
+---
+version: 2
+jobs:
+  lint:
+    docker:
+      - image: debian:stretch
+    steps:
+      - checkout
+      - setup_remote_docker
+      # Check version output for debugging
+      - run: apt-get update
+      - run: apt-get install -y python-pip make
+      - run: pip install flake8
+      - run: python --version
+      - run: flake8 --version
+      - run: make flake8
+
+workflows:
+  version: 2
+  securedrop_workstation_ci:
+    jobs:
+      - lint

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,11 @@ validate: assert-dom0 ## Checks for local requirements in dev env
 		{ echo "ERROR: missing 'config.json'!" && \
 		echo "Create from 'config.json.example'." && exit 1 ; }
 
+flake8: ## Lints all Python files with flake8
+# Not requiring dom0 since linting requires extra packages,
+# available only in the developer environment, i.e. Work VM.
+	@flake8 .
+
 # Explanation of the below shell command should it ever break.
 # 1. Set the field separator to ": ##" to parse lines for make targets.
 # 2. Check for second field matching, skip otherwise.

--- a/sd-journalist/dev-monitor.py
+++ b/sd-journalist/dev-monitor.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python
 
-import sys
 import datetime
-import os
-import subprocess
 import pipereader
 import sd_process_display
+
 
 def poller_cb(poller, msg, err):
     longer = "(Not a known message)"
@@ -15,6 +13,7 @@ def poller_cb(poller, msg, err):
         longer = sd_process_display.messages[msg]
 
     print "[{}] {}: {}".format(datetime.datetime.now(), msg, longer)
+
 
 reader = pipereader.PipeReader("sdfifo", poller_cb)
 

--- a/sd-journalist/pipereader.py
+++ b/sd-journalist/pipereader.py
@@ -6,6 +6,7 @@ import errno
 
 BUFFSIZE = 64
 
+
 class PipeReader():
     def __init__(self, pipe, cb):
         self._quit = False
@@ -42,7 +43,7 @@ class PipeReader():
                     # than BUFSIZE bytes. writes from our client
                     # should be atomic up to PIPE_BUF byes, which is
                     # greater than our BUF_SIZE (see
-                    # https://unix.stackexchange.com/questions/68146/what-are-guarantees-for-concurrent-writes-into-a-named-pipe). So,
+                    # https://unix.stackexchange.com/questions/68146/what-are-guarantees-for-concurrent-writes-into-a-named-pipe). So,  # noqa: E501
                     # we can immediately close this filehandle
 
                     poller.unregister(fileno)
@@ -74,10 +75,12 @@ class PipeReader():
                     fifo = os.open(pipe, os.O_RDONLY | os.O_NONBLOCK)
                     poller.register(fifo)
 
+
 def reporter(poller, msg, err):
     print "Got a message: {} (error: {})".format(msg.rstrip(), err)
     if msg.rstrip() == "quit":
         poller.quit()
+
 
 if __name__ == '__main__':
     reader = PipeReader("mypipe", reporter)

--- a/tests/base.py
+++ b/tests/base.py
@@ -22,17 +22,21 @@ class SD_VM_Local_Test(unittest.TestCase):
     #     self.vm.shutdown()
 
     def _reboot(self):
-        try:
-            for v in self.vm.connected_vms.values():
-                if v.is_running():
-                    msg = ("Need to halt connected VM {}"
-                           " before testing".format(v))
-                    print(msg)
-                    v.shutdown()
-                    while v.is_running():
-                        time.sleep(1)
-        except:
-            pass
+        # The for-loop below should be couched in a try/except block.
+        # Further testing required to determine which specific exceptions
+        # to catch; a few ideas:
+        #
+        #   * CalledProcessorError
+        #   * QubesVMError (from qubesadmin.base)
+        #   * QubesVMNotStartedError (from qubesadmin.base)
+        for v in self.vm.connected_vms.values():
+            if v.is_running():
+                msg = ("Need to halt connected VM {}"
+                       " before testing".format(v))
+                print(msg)
+                v.shutdown()
+                while v.is_running():
+                    time.sleep(1)
 
         if self.vm.is_running():
             self.vm.shutdown()

--- a/tests/base.py
+++ b/tests/base.py
@@ -57,12 +57,12 @@ class SD_VM_Local_Test(unittest.TestCase):
         print "".join(difflib.unified_diff(remote_content, content))
         self.assertTrue(remote_content == content)
 
-    def assertFileHasLine(self, remote_path, line):
+    def assertFileHasLine(self, remote_path, wanted_line):
         remote_content = self._get_file_contents(remote_path)
         lines = remote_content.splitlines()
-        for l in lines:
-            if l == line:
+        for line in lines:
+            if line == wanted_line:
                 return True
         msg = "File {} does not contain expected line {}".format(remote_path,
-                                                                 line)
+                                                                 wanted_line)
         raise AssertionError(msg)

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,7 +1,3 @@
-from distutils import spawn
-
-import os
-import re
 import subprocess
 import time
 import unittest
@@ -10,58 +6,63 @@ from qubesadmin import Qubes
 
 # base class for per-VM testing
 
+
 class SD_VM_Local_Test(unittest.TestCase):
 
-  def setUp(self):
-    self.app = Qubes()
-    self.vm = self.app.domains[self.vm_name]
-    #self._reboot()
-    if self.vm.is_running():
-      pass
-    else:
-      self.vm.start()
+    def setUp(self):
+        self.app = Qubes()
+        self.vm = self.app.domains[self.vm_name]
+        # self._reboot()
+        if self.vm.is_running():
+            pass
+        else:
+            self.vm.start()
 
-  # def tearDown(self):
-  #   self.vm.shutdown()
+    # def tearDown(self):
+    #     self.vm.shutdown()
 
-  def _reboot(self):
-    try:
-      for v in self.vm.connected_vms.values():
-        if v.is_running():
-          print "Need to halt connected VM {} before testing".format(v)
-          v.shutdown()
-          while v.is_running():
+    def _reboot(self):
+        try:
+            for v in self.vm.connected_vms.values():
+                if v.is_running():
+                    msg = ("Need to halt connected VM {}"
+                           " before testing".format(v))
+                    print(msg)
+                    v.shutdown()
+                    while v.is_running():
+                        time.sleep(1)
+        except:
+            pass
+
+        if self.vm.is_running():
+            self.vm.shutdown()
+
+        while self.vm.is_running():
             time.sleep(1)
-    except:
-      pass
 
-    if self.vm.is_running():
-      self.vm.shutdown()
+        self.vm.start()
 
-    while self.vm.is_running():
-      time.sleep(1)
+    def _get_file_contents(self, path):
+        contents = subprocess.check_output(["qvm-run", "-p", self.vm_name,
+                                            "/bin/cat {}".format(path)])
+        return contents
 
-    self.vm.start()
+    def assertFilesMatch(self, remote_path, local_path):
+        remote_content = self._get_file_contents(remote_path)
 
-  def _get_file_contents(self, path):
-    contents = subprocess.check_output(["qvm-run", "-p", self.vm_name,
-                                        "/bin/cat {}".format(path)])
-    return contents
+        content = False
+        with open(local_path) as f:
+            content = f.read()
+        import difflib
+        print "".join(difflib.unified_diff(remote_content, content))
+        self.assertTrue(remote_content == content)
 
-  def assertFilesMatch(self, remote_path, local_path):
-    remote_content = self._get_file_contents(remote_path)
-
-    content = False
-    with open(local_path) as f:
-      content = f.read()
-    import difflib
-    print "".join(difflib.unified_diff(remote_content, content))
-    self.assertTrue(remote_content == content)
-
-  def assertFileHasLine(self, remote_path, line):
-    remote_content = self._get_file_contents(remote_path)
-    lines = remote_content.splitlines()
-    for l in lines:
-      if l == line:
-       return True
-    raise AssertionError("File {} does not contain expected line {}".format(remote_path, line))
+    def assertFileHasLine(self, remote_path, line):
+        remote_content = self._get_file_contents(remote_path)
+        lines = remote_content.splitlines()
+        for l in lines:
+            if l == line:
+                return True
+        msg = "File {} does not contain expected line {}".format(remote_path,
+                                                                 line)
+        raise AssertionError(msg)

--- a/tests/test_decrypt.py
+++ b/tests/test_decrypt.py
@@ -1,9 +1,3 @@
-from distutils import spawn
-
-import os
-import re
-import subprocess
-import time
 import unittest
 
 from base import SD_VM_Local_Test
@@ -11,35 +5,31 @@ from base import SD_VM_Local_Test
 
 class SD_Decrypt_Tests(SD_VM_Local_Test):
 
-  def setUp(self):
-    self.vm_name = "sd-decrypt"
-    super(SD_Decrypt_Tests, self).setUp()
+    def setUp(self):
+        self.vm_name = "sd-decrypt"
+        super(SD_Decrypt_Tests, self).setUp()
 
+    def test_decrypt_sd_submission(self):
+        self.assertFilesMatch(
+          "/usr/local/bin/decrypt-sd-submission",
+          "sd-decrypt/decrypt-sd-submission")
 
-  def test_decrypt_sd_submission(self):
-    self.assertFilesMatch(
-      "/usr/local/bin/decrypt-sd-submission",
-      "sd-decrypt/decrypt-sd-submission"
-    )
+    def test_application_x_sd_xfer(self):
+        self.assertFilesMatch(
+          "/usr/local/share/mime/packages/application-x-sd-xfer.xml",
+          "sd-decrypt/application-x-sd-xfer.xml")
 
-  def test_application_x_sd_xfer(self):
-    self.assertFilesMatch(
-      "/usr/local/share/mime/packages/application-x-sd-xfer.xml",
-      "sd-decrypt/application-x-sd-xfer.xml"
-    )
+    def test_decrypt_sd_submission_desktop(self):
+        self.assertFilesMatch(
+          "/usr/local/share/applications/decrypt-sd-submission.desktop",
+          "sd-decrypt/decrypt-sd-submission.desktop")
 
-  def test_decrypt_sd_submission_desktop(self):
-    self.assertFilesMatch(
-      "/usr/local/share/applications/decrypt-sd-submission.desktop",
-      "sd-decrypt/decrypt-sd-submission.desktop"
-    )
+    def test_decrypt_sd_user_profile(self):
+        self.assertFilesMatch(
+          "/home/user/.profile",
+          "sd-decrypt/dot-profile")
 
-  def test_decrypt_sd_submission_desktop(self):
-    self.assertFilesMatch(
-      "/home/user/.profile",
-      "sd-decrypt/dot-profile"
-    )
 
 def load_tests(loader, tests, pattern):
-  suite = unittest.TestLoader().loadTestsFromTestCase(SD_Decrypt_Tests)
-  return suite
+    suite = unittest.TestLoader().loadTestsFromTestCase(SD_Decrypt_Tests)
+    return suite

--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -1,45 +1,48 @@
-from distutils import spawn
-
-import os
 import re
 import subprocess
-import time
 import unittest
 
 from base import SD_VM_Local_Test
 
+
 def find_fp_from_gpg_output(gpg):
 
-  lines = gpg.split("\n")
+    lines = gpg.split("\n")
 
-  for line in lines:
-    m = re.match('\s*Key fingerprint = (.*)$', line)
-    if m is not None:
-      fp = m.groups()[0]
-      return fp
+    for line in lines:
+        m = re.match('\s*Key fingerprint = (.*)$', line)
+        if m is not None:
+            fp = m.groups()[0]
+            return fp
 
 
 def get_local_fp():
 
-  p = subprocess.check_output(["gpg", "--with-fingerprint", "sd-journalist.sec"])
+    cmd = ["gpg", "--with-fingerprint", "sd-journalist.sec"]
+    p = subprocess.check_output(cmd)
 
-  return find_fp_from_gpg_output(p)
+    return find_fp_from_gpg_output(p)
+
 
 def get_remote_fp():
-  p = subprocess.check_output(["qvm-run", "-p", "sd-gpg", "/usr/bin/gpg --list-secret-keys --fingerprint"])
+    cmd = ["qvm-run", "-p", "sd-gpg",
+           "/usr/bin/gpg --list-secret-keys --fingerprint"]
 
-  return find_fp_from_gpg_output(p)
+    p = subprocess.check_output(cmd)
+
+    return find_fp_from_gpg_output(p)
 
 
 class SD_GPG_Tests(SD_VM_Local_Test):
 
-  def setUp(self):
-    self.vm_name = "sd-gpg"
-    super(SD_GPG_Tests, self).setUp()
+    def setUp(self):
+        self.vm_name = "sd-gpg"
+        super(SD_GPG_Tests, self).setUp()
 
-  def test_we_have_the_key(self):
-    self.assertEqual(get_local_fp(), get_remote_fp())
+    def test_we_have_the_key(self):
+        self.assertEqual(get_local_fp(), get_remote_fp())
+
 
 def load_tests(loader, tests, pattern):
-  suite = unittest.TestLoader().loadTestsFromTestCase(SD_GPG_Tests)
-  return suite
+    suite = unittest.TestLoader().loadTestsFromTestCase(SD_GPG_Tests)
+    return suite

--- a/tests/test_journalist_vm.py
+++ b/tests/test_journalist_vm.py
@@ -1,33 +1,34 @@
-from distutils import spawn
-
-import os
-import re
-import subprocess
-import time
 import unittest
 
 from base import SD_VM_Local_Test
 
+
 class SD_Journalist_Tests(SD_VM_Local_Test):
-  def setUp(self):
-    self.vm_name = "sd-journalist"
-    super(SD_Journalist_Tests, self).setUp()
+    def setUp(self):
+        self.vm_name = "sd-journalist"
+        super(SD_Journalist_Tests, self).setUp()
 
-  def test_move_to_svs(self):
-    self.assertFilesMatch("/usr/local/bin/move-to-svs", "sd-journalist/move-to-svs")
+    def test_move_to_svs(self):
+        self.assertFilesMatch("/usr/local/bin/move-to-svs",
+                              "sd-journalist/move-to-svs")
 
-  def test_sd_process_download(self):
-    self.assertFilesMatch("/usr/local/bin/sd-process-download", "sd-journalist/sd-process-download")
+    def test_sd_process_download(self):
+        self.assertFilesMatch("/usr/local/bin/sd-process-download",
+                              "sd-journalist/sd-process-download")
 
-  def test_do_not_open_here(self):
-    self.assertFilesMatch("/usr/local/bin/do-not-open-here", "sd-journalist/do-not-open-here")
+    def test_do_not_open_here(self):
+        self.assertFilesMatch("/usr/local/bin/do-not-open-here",
+                              "sd-journalist/do-not-open-here")
 
-  def test_sd_process_feedback(self):
-    self.assertFilesMatch("/usr/local/bin/sd-process-feedback", "sd-journalist/sd-process-feedback")
+    def test_sd_process_feedback(self):
+        self.assertFilesMatch("/usr/local/bin/sd-process-feedback",
+                              "sd-journalist/sd-process-feedback")
 
-  def test_sd_process_display(self):
-    self.assertFilesMatch("/usr/local/bin/sd-process-display", "sd-journalist/sd-process-display")
+    def test_sd_process_display(self):
+        self.assertFilesMatch("/usr/local/bin/sd-process-display",
+                              "sd-journalist/sd-process-display")
+
 
 def load_tests(loader, tests, pattern):
-  suite = unittest.TestLoader().loadTestsFromTestCase(SD_Journalist_Tests)
-  return suite
+    suite = unittest.TestLoader().loadTestsFromTestCase(SD_Journalist_Tests)
+    return suite

--- a/tests/test_sd_whonix.py
+++ b/tests/test_sd_whonix.py
@@ -1,32 +1,25 @@
-from distutils import spawn
-
-import os
-import re
-import subprocess
-import time
 import unittest
 import json
 from jinja2 import Template
 
-from qubesadmin import Qubes
-
 from base import SD_VM_Local_Test
 
+
 class SD_Whonix_Tests(SD_VM_Local_Test):
-  def setUp(self):
-    self.vm_name = "sd-whonix"
-    super(SD_Whonix_Tests, self).setUp()
+    def setUp(self):
+        self.vm_name = "sd-whonix"
+        super(SD_Whonix_Tests, self).setUp()
 
-  def test_accept_sd_xfer_extracted_file(self):
-    with open("config.json") as c:
-      config = json.load(c)
-      t = Template("HidServAuth {{ d.hidserv.hostname }} {{ d.hidserv.key }}")
-      line = t.render(d=config)
+    def test_accept_sd_xfer_extracted_file(self):
+        with open("config.json") as c:
+            config = json.load(c)
+            t = Template("HidServAuth {{ d.hidserv.hostname }}"
+                         " {{ d.hidserv.key }}")
+            line = t.render(d=config)
 
-      self.assertFileHasLine(
-        "/etc/tor/torrc",
-        line)
+            self.assertFileHasLine("/etc/tor/torrc", line)
+
 
 def load_tests(loader, tests, pattern):
-  suite = unittest.TestLoader().loadTestsFromTestCase(SD_Whonix_Tests)
-  return suite
+    suite = unittest.TestLoader().loadTestsFromTestCase(SD_Whonix_Tests)
+    return suite

--- a/tests/test_svs.py
+++ b/tests/test_svs.py
@@ -1,45 +1,39 @@
-from distutils import spawn
-
-import os
-import re
-import subprocess
-import time
 import unittest
 
 from base import SD_VM_Local_Test
 
-from qubesadmin import Qubes
 
 class SD_SVS_Tests(SD_VM_Local_Test):
-  def setUp(self):
-    self.vm_name = "sd-svs"
-    super(SD_SVS_Tests, self).setUp()
+    def setUp(self):
+        self.vm_name = "sd-svs"
+        super(SD_SVS_Tests, self).setUp()
 
-  def test_accept_sd_xfer_extracted_file(self):
-    self.assertFilesMatch(
-     "/usr/local/bin/accept-sd-xfer-extracted",
-     "sd-svs/accept-sd-xfer-extracted")
+    def test_accept_sd_xfer_extracted_file(self):
+        self.assertFilesMatch(
+            "/usr/local/bin/accept-sd-xfer-extracted",
+            "sd-svs/accept-sd-xfer-extracted")
 
-  def test_xfer_extracted_mime_type(self):
-    self.assertFilesMatch(
-      "/usr/local/share/mime/packages/application-x-sd-xfer-extracted.xml",
-      "sd-svs/application-x-sd-xfer-extracted.xml")
+    def test_xfer_extracted_mime_type(self):
+        self.assertFilesMatch(
+            "/usr/local/share/mime/packages/application-x-sd-xfer-extracted.xml",  # noqa: E501
+            "sd-svs/application-x-sd-xfer-extracted.xml")
 
-  def test_xfer_extracted_desktop(self):
-    self.assertFilesMatch(
-      "/usr/local/share/applications/accept-sd-xfer-extracted.desktop",
-      "sd-svs/accept-sd-xfer-extracted.desktop")
+    def test_xfer_extracted_desktop(self):
+        self.assertFilesMatch(
+           "/usr/local/share/applications/accept-sd-xfer-extracted.desktop",
+           "sd-svs/accept-sd-xfer-extracted.desktop")
 
-  def test_open_in_dvm_desktop(self):
-    self.assertFilesMatch(
-      "/usr/local/share/applications/open-in-dvm.desktop",
-      "sd-svs/open-in-dvm.desktop")
+    def test_open_in_dvm_desktop(self):
+        self.assertFilesMatch(
+          "/usr/local/share/applications/open-in-dvm.desktop",
+          "sd-svs/open-in-dvm.desktop")
 
-  def test_mimeapps(self):
-    self.assertFilesMatch(
-      "/home/user/.config/mimeapps.list",
-      "sd-svs/mimeapps.list")
+    def test_mimeapps(self):
+        self.assertFilesMatch(
+          "/home/user/.config/mimeapps.list",
+          "sd-svs/mimeapps.list")
+
 
 def load_tests(loader, tests, pattern):
-  suite = unittest.TestLoader().loadTestsFromTestCase(SD_SVS_Tests)
-  return suite
+    suite = unittest.TestLoader().loadTestsFromTestCase(SD_SVS_Tests)
+    return suite

--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -1,57 +1,55 @@
-from distutils import spawn
-
-import os
-import re
-import subprocess
-import time
 import unittest
 
 from qubesadmin import Qubes
 
+
 class SD_VM_Tests(unittest.TestCase):
-  def setUp(self):
-    self.app = Qubes()
+    def setUp(self):
+        self.app = Qubes()
 
-  def tearDown(self):
-    pass
+    def tearDown(self):
+        pass
 
-  def test_expected(self):
-    vm_set = set(self.app.domains)
+    def test_expected(self):
+        vm_set = set(self.app.domains)
 
-    for test_vm in ["sd-whonix", "sd-journalist", "sd-svs", "sd-decrypt","sd-svs-disp","sd-gpg"]:
-      self.assertTrue(test_vm in vm_set)
+        wanted_vms = ["sd-whonix", "sd-journalist",
+                      "sd-svs", "sd-decrypt",
+                      "sd-svs-disp", "sd-gpg"]
+        for test_vm in wanted_vms:
+            self.assertTrue(test_vm in vm_set)
 
-  def test_sd_whonix_net(self):
-    vm = self.app.domains["sd-whonix"]
-    nvm = vm.netvm
-    self.assertTrue(nvm.name == "sys-firewall")
+    def test_sd_whonix_net(self):
+        vm = self.app.domains["sd-whonix"]
+        nvm = vm.netvm
+        self.assertTrue(nvm.name == "sys-firewall")
 
-  def test_sd_journalist_net(self):
-    vm = self.app.domains["sd-journalist"]
-    nvm = vm.netvm
-    self.assertTrue(nvm.name == "sd-whonix")
+    def test_sd_journalist_net(self):
+        vm = self.app.domains["sd-journalist"]
+        nvm = vm.netvm
+        self.assertTrue(nvm.name == "sd-whonix")
 
-  def test_sd_svs_net(self):
-    vm = self.app.domains["sd-svs"]
-    nvm = vm.netvm
-    self.assertTrue(nvm is None)
+    def test_sd_svs_net(self):
+        vm = self.app.domains["sd-svs"]
+        nvm = vm.netvm
+        self.assertTrue(nvm is None)
 
-  def test_sd_decrypt_net(self):
-    vm = self.app.domains["sd-decrypt"]
-    nvm = vm.netvm
-    self.assertTrue(nvm is None)
+    def test_sd_decrypt_net(self):
+        vm = self.app.domains["sd-decrypt"]
+        nvm = vm.netvm
+        self.assertTrue(nvm is None)
 
-  def test_sd_svs_disp_net(self):
-    vm = self.app.domains["sd-svs-disp"]
-    nvm = vm.netvm
-    self.assertTrue(nvm is None)
+    def test_sd_svs_disp_net(self):
+        vm = self.app.domains["sd-svs-disp"]
+        nvm = vm.netvm
+        self.assertTrue(nvm is None)
 
-  def test_sd_gpg_net(self):
-    vm = self.app.domains["sd-gpg"]
-    nvm = vm.netvm
-    self.assertTrue(nvm is None)
+    def test_sd_gpg_net(self):
+        vm = self.app.domains["sd-gpg"]
+        nvm = vm.netvm
+        self.assertTrue(nvm is None)
 
 
 def load_tests(loader, tests, pattern):
-  suite = unittest.TestLoader().loadTestsFromTestCase(SD_VM_Tests)
-  return suite
+    suite = unittest.TestLoader().loadTestsFromTestCase(SD_VM_Tests)
+    return suite


### PR DESCRIPTION
Cosmetic changes throughout, guided by `flake8`. The vast majority of changes were whitespace-related—pretty standard for Python projects—although in at least one case, the linter caught a genuine error in code, in which the test name `test_decrypt_sd_submission_desktop` was used twice, causing clobbering. That's resolved now.

Note that it's not easy to run `make flake8` in the development environment: you'll need to run `sudo dnf install python2-flake8` in the Work VM in order to use it. The goal is at least to get coverage in CI working, so that we have flake8 validation running prior to every PR merge.

Partial completion toward #56.

~~Marking this PR as "WIP" until I confirm CI is working as expected.~~ **Done, CI is passing.**