### PR TITLE
Preliminary tests for platform (App VM base OS)

### DIFF
--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -1,0 +1,55 @@
+import unittest
+
+from qubesadmin import Qubes
+
+
+SUPPORTED_PLATFORMS = [
+    "Fedora 25 (Twenty Five)",
+    "Debian GNU/Linux 8 (jessie)",
+]
+
+WANTED_VMS = [
+    "sd-decrypt",
+    "sd-gpg",
+    "sd-journalist",
+    "sd-svs",
+    "sd-svs-disp",
+    "sd-whonix",
+]
+
+
+class SD_VM_Platform_Tests(unittest.TestCase):
+    def setUp(self):
+        self.app = Qubes()
+
+    def tearDown(self):
+        pass
+
+    def _get_platform_info(self, vm):
+        cmd = "perl -nE '/^PRETTY_NAME=\"(.*)\"$/ and say $1' /etc/os-release"
+        stdout, stderr = vm.run(cmd)
+        platform = stdout.rstrip("\n")
+        return platform
+
+    def _validate_vm_platform(self, vm):
+        platform = self._get_platform_info(vm)
+        self.assertIn(platform, SUPPORTED_PLATFORMS)
+
+    def test_sd_journalist_template(self):
+        vm = self.app.domains["sd-journalist"]
+        self._validate_vm_platform(vm)
+
+    def test_all_sd_vm_platforms(self):
+        """
+        Test all VM platforms iteratively.
+        """
+        # Would prefer to use a feature like pytest.mark.parametrize
+        # for better error output here, but not available in dom0.
+        for vm_name in WANTED_VMS:
+            vm = self.app.domains[vm_name]
+            self._validate_vm_platform(vm)
+
+
+def load_tests(loader, tests, pattern):
+    suite = unittest.TestLoader().loadTestsFromTestCase(SD_VM_Platform_Tests)
+    return suite


### PR DESCRIPTION
**This PR depends on #62, so review and merge that first.** Without the changes in #62, CI will never pass here.

Partial progress toward #48.

Trying to write pass/fail tests for supported platforms for all VMs.
Aiming for a hard fail on EOL Fedora 25, in support of migration to Fedora
26, but focusing on the test structure for now.

The hardcoded copypasta in the form of the VM list is not DRY, and
suggests to me we should consider a more declarative format for the test
assumptions, e.g. a single YAML file describing the VM layout and
attributes, which all tests can import once and reuse.

These tests are currently passing, and intended to. As we migrate to F26 as
described in #48, we should see these tests start failing.