### PR TITLE
Keep feedback UI from hanging.

### DIFF
--- a/sd-journalist/sd-process-display
+++ b/sd-journalist/sd-process-display
@@ -104,7 +104,7 @@ if __name__ == '__main__':
     app = QApplication([])
     d = SDDialog()
 
-    reader = pipereader.PipeReader("sdfifo", poller_cb)
+    reader = pipereader.PipeReader("/home/user/sdfifo", poller_cb)
     t = threading.Thread(target=reader.read)
 
     t.start()


### PR DESCRIPTION
This closes #59.

The Python script which runs the UI for the feedback process reads a stream of updates off a FIFO (and messages are placed on the FIFO via a custom qrexec service triggered by events on remote SD VMs). 

The script had a relative path to the FIFO, which worked when testing the script by hand directly on sd-journalist. But when triggered automatically by Tor Browser upon downloading SD submissions, the UI script could not find the FIFO to read from. 

This fixes that problem by using an absolute path to the FIFO.