### PR TITLE
Completes flake8 linting of Python files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,9 @@ flake8: ## Lints all Python files with flake8
 # Not requiring dom0 since linting requires extra packages,
 # available only in the developer environment, i.e. Work VM.
 	@flake8 .
+	@find -type f -exec file -i {} + \
+		| perl -F':\s+' -nE '$$F[1] =~ m/text\/x-python/ and say $$F[0]' \
+		| xargs flake8
 
 # Explanation of the below shell command should it ever break.
 # 1. Set the field separator to ": ##" to parse lines for make targets.

--- a/sd-decrypt/decrypt-sd-submission
+++ b/sd-decrypt/decrypt-sd-submission
@@ -17,6 +17,7 @@ def send_progress(msg):
                          stdin=subprocess.PIPE)
     p.communicate(msg)
 
+
 input = sys.argv[1]
 
 send_progress("DECRYPTION_PROCESS_START")

--- a/sd-decrypt/decrypt-sd-submission
+++ b/sd-decrypt/decrypt-sd-submission
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 import sys
 import tarfile
 import tempfile
@@ -12,11 +11,11 @@ import shutil
 
 
 def send_progress(msg):
-  p = subprocess.Popen(["qrexec-client-vm","sd-journalist",
-                        "sd-process.Feedback"],
-                       close_fds=True,
-                       stdin=subprocess.PIPE)
-  p.communicate(msg)
+    p = subprocess.Popen(["qrexec-client-vm", "sd-journalist",
+                         "sd-process.Feedback"],
+                         close_fds=True,
+                         stdin=subprocess.PIPE)
+    p.communicate(msg)
 
 input = sys.argv[1]
 
@@ -29,16 +28,17 @@ tmpdir = tempfile.mkdtemp()
 # first step, extract that archive
 try:
 
-  with tarfile.open(input) as tar:
-  # potentially unsafe, can create arbitrary files on the filesystem
-  # given a malicious tarball
-    tar.extractall(tmpdir)
+    with tarfile.open(input) as tar:
+        # potentially unsafe, can create arbitrary files on the filesystem
+        # given a malicious tarball
+        tar.extractall(tmpdir)
 
 except Exception as e:
-  send_progress("DECRYPTION_BUNDLE_OPEN_FAILURE")
-  sys.exit(0) # although we're exiting with failure, we return a
-              # 0 exit code so xdg does not try to re-open this file with
-              # another application
+    send_progress("DECRYPTION_BUNDLE_OPEN_FAILURE")
+    # although we're exiting with failure, we return a
+    # 0 exit code so xdg does not try to re-open this file with
+    # another application
+    sys.exit(0)
 
 send_progress("SUBMISSION_BUNDLE_UNBUNDLED")
 
@@ -46,44 +46,45 @@ send_progress("SUBMISSION_BUNDLE_UNBUNDLED")
 # let's unzip those here
 zips = glob.glob(tmpdir + "/*zip")
 for z in zips:
-  with zipfile.ZipFile(z) as zf:
-    zf.extractall(tmpdir + "/extracted/")
-  os.unlink(z)
+    with zipfile.ZipFile(z) as zf:
+        zf.extractall(tmpdir + "/extracted/")
+    os.unlink(z)
 
 send_progress("SUBMISSION_FILES_EXTRACTED")
 
 # great, we should be left with a directory tree filled with files
 # encrypted to our public key. let's find those and decrypt them
 for root, dirnames, filenames in os.walk(tmpdir):
-  for fn in fnmatch.filter(filenames, '*.gpg'):
-    [fn_no_ext, _] = os.path.splitext(fn)
+    for fn in fnmatch.filter(filenames, '*.gpg'):
+        [fn_no_ext, _] = os.path.splitext(fn)
 
-    out = open(os.path.join(root, fn_no_ext), 'w')
-    err = tempfile.NamedTemporaryFile(suffix=".gpg-err")
-    res = subprocess.call(["qubes-gpg-client", "--decrypt" , os.path.join(root, fn)], stdout=out, stderr=err)
-    out.close()
-    os.unlink(os.path.join(root, fn))
-    if res != 0:
-      os.unlink(os.path.join(root, fn_no_ext))
-      with open(err.name) as e:
-        msg = e.read()
-        send_progress("SUBMISSION_FILE_DECRYPTION_FAILED")
-    else:
-      send_progress("SUBMISSION_FILE_DECRYPTION_SUCCEEDED")
-    err.close()
+        out = open(os.path.join(root, fn_no_ext), 'w')
+        err = tempfile.NamedTemporaryFile(suffix=".gpg-err")
+        cmd = ["qubes-gpg-client", "--decrypt", os.path.join(root, fn)]
+        res = subprocess.call(cmd, stdout=out, stderr=err)
+        out.close()
+        os.unlink(os.path.join(root, fn))
+        if res != 0:
+            os.unlink(os.path.join(root, fn_no_ext))
+            with open(err.name) as e:
+                msg = e.read()
+                send_progress("SUBMISSION_FILE_DECRYPTION_FAILED")
+        else:
+            send_progress("SUBMISSION_FILE_DECRYPTION_SUCCEEDED")
+        err.close()
 
 # almost done. docs are gzipped. let's ungzip them.
 any_files = False
 for root, dirnames, filenames in os.walk(tmpdir):
-  for fn in fnmatch.filter(filenames, '*.gz'):
-    any_files = True
-    # maybe sorta lazy, could do this using python gzip module.
-    # XXX also catch errors here...
-    subprocess.call(["gunzip", os.path.join(root, fn)])
+    for fn in fnmatch.filter(filenames, '*.gz'):
+        any_files = True
+        # maybe sorta lazy, could do this using python gzip module.
+        # XXX also catch errors here...
+        subprocess.call(["gunzip", os.path.join(root, fn)])
 
 if not any_files:
-  send_progress("SUBMISSION_FILE_NO_FILES_FOUND")
-  sys.exit(0)
+    send_progress("SUBMISSION_FILE_NO_FILES_FOUND")
+    sys.exit(0)
 
 # ok. we're going to send all the decrypted stuff to the svs vm.
 # let's tar it all up again, so we can `qvm-open-in-vm` it.

--- a/sd-journalist/do-not-open-here
+++ b/sd-journalist/do-not-open-here
@@ -3,9 +3,11 @@
 import sys
 from PyQt4 import Qt
 
+
 a = Qt.QApplication(sys.argv)
 
-nope = Qt.QLabel("Please do not use this VM to open any files aside from those downloaded from SecureDrop.")
+nope = Qt.QLabel("Please do not use this VM to open any files"
+                 " aside from those downloaded from SecureDrop.")
 
 nope.show()
 a.exec_()

--- a/sd-journalist/move-to-svs
+++ b/sd-journalist/move-to-svs
@@ -7,11 +7,12 @@ import tempfile
 import os.path
 import subprocess
 
-TB_DL_LOC="/home/user/.tb/tor-browser/Browser/Downloads"
+TB_DL_LOC = "/home/user/.tb/tor-browser/Browser/Downloads"
 
 zips = glob.glob(TB_DL_LOC + "/*.zip")
 
-matched_sd_pattern = [re.match('[a-z]+\_[a-z]+[\d-]+\.zip', os.path.basename(z)) for z in zips]
+matched_sd_pattern = [
+    re.match('[a-z]+\_[a-z]+[\d-]+\.zip', os.path.basename(z)) for z in zips]
 
 probable_sd_downloads = [z.group(0) for z in matched_sd_pattern if z]
 
@@ -23,10 +24,11 @@ print "fh name " + fh.name
 out_tar = tarfile.open(mode='w', fileobj=fh)
 
 for f in probable_sd_downloads:
-  out_tar.add(os.path.join(TB_DL_LOC, f), arcname=f)
+    out_tar.add(os.path.join(TB_DL_LOC, f), arcname=f)
 
 out_tar.close()
 fh.close()
 
 # ship this to the next phase
-subprocess.call(["qvm-open-in-vm", "$dispvm:sd-dispvm", os.path.join(TB_DL_LOC, fh.name)])
+cmd = ["qvm-open-in-vm", "$dispvm:sd-dispvm", os.path.join(TB_DL_LOC, fh.name)]
+subprocess.call(cmd)

--- a/sd-journalist/sd-process-display
+++ b/sd-journalist/sd-process-display
@@ -1,14 +1,15 @@
 import sys
 import PyQt4.QtCore as QtCore
-from PyQt4.QtGui import QDialog, QDialogButtonBox, QApplication, QLabel, QVBoxLayout, QImage, QPixmap
+from PyQt4.QtGui import QDialog, QDialogButtonBox, QApplication, \
+         QLabel, QVBoxLayout, QImage, QPixmap
 from PyQt4.QtCore import Qt
 import os
-import errno
 import threading
 import pipereader
 
+
 class SDDialog(QDialog):
-    def __init__(self, parent = None):
+    def __init__(self, parent=None):
         fn = r'/usr/local/share/sd/logo-small.png'
         image = QImage(fn)
         self.logo = QLabel()
@@ -36,31 +37,46 @@ class SDDialog(QDialog):
 
 messages = {
     # bootstrapping
-    'EXISTING_SIGFILE': ("error", "Internal error: signal file given by caller already exists"),
-    'POLLING_ERROR': {"error": "An internal error occurred while listening for events from VMs."},
+    'EXISTING_SIGFILE': (
+        "error", "Internal error: signal file given by caller already exists"),
+    'POLLING_ERROR': {
+        "error": ("An internal error occurred while listening"
+                  " for events from VMs.")},
 
     # sd-journalist
-    'DOWNLOAD_FILE_MISSING': ("error", "The file downloaded from SecureDrop wasn't found."),
+    'DOWNLOAD_FILE_MISSING': (
+        "error", "The file downloaded from SecureDrop wasn't found."),
     'DOWNLOAD_BUNDLE_CREATED': ("success", "Initial download bundle created."),
 
     # decrypt
     'DECRYPTION_PROCESS_START': ("success", "Decryption process started."),
-    'DECRYPTION_BUNDLE_OPEN_FAILURE': ("error", "Decryption bundle could not be opened."),
-    'SUBMISSION_BUNDLE_UNBUNDLED': ("success", "Submission bundle looks valid."),
-    'SUBMISSION_FILES_EXTRACTED': ("success", "Submission bundle files extracted."),
-    'SUBMISSION_FILE_DECRYPTION_FAILED': ('error', "Submission file decryption failed."),
-    'SUBMISSION_FILE_DECRYPTION_SUCCEEDED': ("success", "Submission file decrypted."),
-    'SUBMISSION_DECRYPTED': ("success", "All submission files decrypted"),
+    'DECRYPTION_BUNDLE_OPEN_FAILURE':
+        ("error", "Decryption bundle could not be opened."),
+    'SUBMISSION_BUNDLE_UNBUNDLED':
+        ("success", "Submission bundle looks valid."),
+    'SUBMISSION_FILES_EXTRACTED':
+        ("success", "Submission bundle files extracted."),
+    'SUBMISSION_FILE_DECRYPTION_FAILED':
+        ('error', "Submission file decryption failed."),
+    'SUBMISSION_FILE_DECRYPTION_SUCCEEDED':
+        ("success", "Submission file decrypted."),
+    'SUBMISSION_DECRYPTED':
+        ("success", "All submission files decrypted"),
 
     # SVS
-    'DECRYPTED_BUNDLE_ON_SVS': ("success", "Decrypted file bundle arrived on SVS."),
-    'DECRYPTED_FILES_AVAILABLE': ("success", "Submitted files available for use on SVS."),
-    'DECRYPTED_BUNDLE UNBUNDLE_ERROR': ("error", "Bundle of decrypted files could not be unbundle on SVS." )
+    'DECRYPTED_BUNDLE_ON_SVS':
+        ("success", "Decrypted file bundle arrived on SVS."),
+    'DECRYPTED_FILES_AVAILABLE':
+        ("success", "Submitted files available for use on SVS."),
+    'DECRYPTED_BUNDLE UNBUNDLE_ERROR':
+        ("error", "Bundle of decrypted files could not be unbundle on SVS.")
 }
+
 
 def finish():
     d.buttons.hide()
     d.layout.removeWidget(d.buttons)
+
 
 def display(keyword):
 
@@ -69,6 +85,7 @@ def display(keyword):
     else:
         # XXX dev only, remove before deploying!
         d.display.setText("bad keyword: {}".format(keyword))
+
 
 def poller_cb(poller, msg, err):
     # we're called with a keyword in `msg`. We look up that keyword
@@ -90,9 +107,9 @@ def create_sigfile(sigfile):
         display('EXISTING_SIGFILE')
     else:
         try:
-            with open(sigfile,'a'):
+            with open(sigfile, 'a'):
                 pass
-        except Exception as e:
+        except Exception:
             display('BAD_SIGFILE')
 
 
@@ -111,7 +128,7 @@ if __name__ == '__main__':
     d.show()
 
     if sigfile != "":
-        # tyvm https://stackoverflow.com/questions/6215690/how-to-execute-a-method-automatically-after-entering-qt-event-loop
+        # tyvm https://stackoverflow.com/questions/6215690/how-to-execute-a-method-automatically-after-entering-qt-event-loop  # noqa: E501
         def on_start():
             create_sigfile(sigfile)
 

--- a/sd-journalist/sd-process-download
+++ b/sd-journalist/sd-process-download
@@ -10,13 +10,14 @@ import subprocess
 
 fn = sys.argv[1]
 
+
 # remember your Stevens and do a double fork
 def spawn_monitor_process(sigfile):
 
     try:
         pid = os.fork()
         if pid > 0:
-        # congrats, new parent!
+            # congrats, new parent!
             return
     except OSError as e:
         print >>sys.stderr, "fork #1 failed: %d (%s)" % (e.errno, e.strerror)
@@ -75,7 +76,8 @@ fh.close()
 
 # this is sort of a one-off... how shall we send messages to the GUI
 # from the same machine? This can only happen on sd-journalist.
-c = subprocess.Popen(["/usr/local/bin/sd-process-feedback"], stdin=subprocess.PIPE)
+c = subprocess.Popen(["/usr/local/bin/sd-process-feedback"],
+                     stdin=subprocess.PIPE)
 c.communicate(input="DOWNLOAD_BUNDLE_CREATED\n")
 
 # ship this to the next phase

--- a/sd-journalist/sd-process-download
+++ b/sd-journalist/sd-process-download
@@ -51,6 +51,7 @@ def wait_for_sigfile(sigfile):
 
     os.remove(sigfile)
 
+
 # spawn the GUI monitoring process, then wait for it to be available...
 sigfile = tempfile.mktemp()
 spawn_monitor_process(sigfile)

--- a/sd-svs/accept-sd-xfer-extracted
+++ b/sd-svs/accept-sd-xfer-extracted
@@ -6,18 +6,21 @@ import os
 
 fn = sys.argv[1]
 
-## pull this in to a library... XXX
+
+# TODO: pull this in to a library... XXX
 def send_progress(msg):
-  p = subprocess.Popen(["qrexec-client-vm","sd-journalist",
-                        "sd-process.Feedback"],
-                       close_fds=True,
-                       stdin=subprocess.PIPE)
-  p.communicate(msg)
+    p = subprocess.Popen(["qrexec-client-vm", "sd-journalist",
+                         "sd-process.Feedback"],
+                         close_fds=True,
+                         stdin=subprocess.PIPE)
+    p.communicate(msg)
 
 send_progress("DECRYPTED_BUNDLE_ON_SVS")
 
 try:
-    res = subprocess.call(["tar", "-xf", fn, "--strip-components=1", "-C", "/home/user/Sources"])
+    cmd = ["tar", "-xf", fn,
+           "--strip-components=1", "-C", "/home/user/Sources"]
+    res = subprocess.call(cmd)
     if res != 0:
         send_progress("DECRYPTED_BUNDLE_UNBUNDLE_ERROR")
         sys.exit(1)

--- a/sd-svs/accept-sd-xfer-extracted
+++ b/sd-svs/accept-sd-xfer-extracted
@@ -15,6 +15,7 @@ def send_progress(msg):
                          stdin=subprocess.PIPE)
     p.communicate(msg)
 
+
 send_progress("DECRYPTED_BUNDLE_ON_SVS")
 
 try:

--- a/tests/integration/test_integration
+++ b/tests/integration/test_integration
@@ -1,50 +1,76 @@
 #!/usr/bin/python
 
 import sys
-sys.path.insert(0, "/usr/local/bin")
-
-import time
-import unittest
-
 import pipereader
 import threading
-import signal
-import subprocess
+
+# Adding /usr/local/bin allows shorthand command references,
+# e.g. "qvm-open-in-vm" rather than "/usr/local/bin/qvm-open-in-vm".
+# TODO: remove sys.path insert and switch to hardcoding fullpaths to binaries.
+sys.path.insert(0, "/usr/local/bin")
 
 arg = "all"
 if len(sys.argv) > 1:
     arg = sys.argv[1]
 
-def prRed(skk): print("\033[91m {}\033[00m" .format(skk))
-def prGreen(skk): print("\033[92m {}\033[00m" .format(skk))
-def prYellow(skk): print("\033[93m {}\033[00m" .format(skk))
-def prLightPurple(skk): print("\033[94m {}\033[00m" .format(skk))
-def prPurple(skk): print("\033[95m {}\033[00m" .format(skk))
-def prCyan(skk): print("\033[96m {}\033[00m" .format(skk))
-def prLightGray(skk): print("\033[97m {}\033[00m" .format(skk))
-def prBlack(skk): print("\033[98m {}\033[00m" .format(skk))
 
-tests = ["all","full-success","empty-download"]
+def prRed(skk):
+    print("\033[91m {}\033[00m" .format(skk))
+
+
+def prGreen(skk):
+    print("\033[92m {}\033[00m" .format(skk))
+
+
+def prYellow(skk):
+    print("\033[93m {}\033[00m" .format(skk))
+
+
+def prLightPurple(skk):
+    print("\033[94m {}\033[00m" .format(skk))
+
+
+def prPurple(skk):
+    print("\033[95m {}\033[00m" .format(skk))
+
+
+def prCyan(skk):
+    print("\033[96m {}\033[00m" .format(skk))
+
+
+def prLightGray(skk):
+    print("\033[97m {}\033[00m" .format(skk))
+
+
+def prBlack(skk):
+    print("\033[98m {}\033[00m" .format(skk))
+
+
+tests = ["all", "full-success", "empty-download"]
+
 
 def usage(err=None):
     if err:
         prRed(err)
     else:
-        print "{}: Run SecureDrop journalist workstation integration tests".format(sys.argv[0])
-        print ; print "These tests must be run from sd-journalist."
-    print "Usage: {} test-name ".format(sys.argv[0])
-    print "    test-name should one of the following, or leave it blank to run all tests."
-    print tests
+        print("{}: Run SecureDrop journalist workstation"
+              " integration tests".format(sys.argv[0]))
+        print("\nThese tests must be run from sd-journalist.")
+    print("Usage: {} test-name ".format(sys.argv[0]))
+    print("    test-name should one of the following,"
+          " or leave it blank to run all tests.")
+    print(tests)
     sys.exit(1)
 
 if arg == "all":
     prLightGray("Running all integration tests")
 elif arg in tests:
     prLightGray("Running test {}".format(arg))
-elif arg in ["help","--help","-h"]:
+elif arg in ["help", "--help", "-h"]:
     usage()
 else:
     usage("Bad test name!")
+
 
 class StatefulListener():
     def __init__(self):
@@ -58,11 +84,14 @@ class StatefulListener():
     def test(self):
         prYellow("Running test: {}".format(self.test_name))
         self._in_test = True
-        result = subprocess.call(self.cmd)
+        # Result of command not needed at present...
+        # result = subprocess.call(self.cmd)
         if self._errors:
-            prRed("-------- test \"{}\" completed with errors".format(self.test_name))
+            prRed("-------- test \"{}\""
+                  " completed with errors".format(self.test_name))
         else:
-            prGreen("-------- test \"{}\" completed without errors".format(self.test_name))
+            prGreen("-------- test \"{}\""
+                    " completed without errors".format(self.test_name))
 
         self._in_test = False
         self._errors = False
@@ -74,20 +103,24 @@ class StatefulListener():
     def poller_cb(self, poller, msg, err):
 
         if not self._in_test:
-            prRed("Error: got a message outside a test. Message: {}".format(msg))
+            prRed("Error: got a message outside a test."
+                  " Message: {}".format(msg))
         elif self.on_state >= len(self.expected_states):
-            prRed("Error: got too many messages from my VMs. Message: {}".format(msg))
+            prRed("Error: got too many messages from my VMs."
+                  " Message: {}".format(msg))
             self._errors = True
         elif msg == self.expected_states[self.on_state]:
             prGreen("Got expected state {}".format(msg))
         else:
-            prRed("Error: got state {} but expected {}".format(msg, self.expected_states[self.on_state]))
+            prRed("Error: got state {} but expected {}".format(msg,
+                  self.expected_states[self.on_state]))
             self._errors = True
 
         self.on_state += 1
 
-        #if self.on_state < len(self.expected_states):
-        #    prYellow("  ...next expected state: {}".format(self.expected_states[self.on_state]))
+        # if self.on_state < len(self.expected_states):
+        #     prYellow("  ...next expected state: {}".format(
+        #         self.expected_states[self.on_state]))
 
 receiver = StatefulListener()
 reader = pipereader.PipeReader("/home/user/sdfifo", receiver.poller_cb)
@@ -95,6 +128,7 @@ t = threading.Thread(target=reader.read)
 
 t.daemon = True
 t.start()
+
 
 def run_q(n):
     if arg == "all":
@@ -104,25 +138,38 @@ def run_q(n):
     return False
 
 if run_q("full-success"):
-    receiver.expected_states = ["DECRYPTION_PROCESS_START","SUBMISSION_BUNDLE_UNBUNDLED", \
-                                "SUBMISSION_FILES_EXTRACTED", "SUBMISSION_FILE_DECRYPTION_SUCCEEDED", \
-                                "SUBMISSION_FILE_DECRYPTION_SUCCEEDED", "DECRYPTED_BUNDLE_ON_SVS", \
-                                "DECRYPTED_FILES_AVAILABLE"]
-    receiver.cmd = ["qvm-open-in-vm","sd-decrypt","./all.sd-xfer"]
+    receiver.expected_states = [
+            "DECRYPTION_PROCESS_START",
+            "SUBMISSION_BUNDLE_UNBUNDLED",
+            "SUBMISSION_FILES_EXTRACTED",
+            "SUBMISSION_FILE_DECRYPTION_SUCCEEDED",
+            "SUBMISSION_FILE_DECRYPTION_SUCCEEDED",
+            "DECRYPTED_BUNDLE_ON_SVS",
+            "DECRYPTED_FILES_AVAILABLE",
+    ]
+    receiver.cmd = ["qvm-open-in-vm", "sd-decrypt", "./all.sd-xfer"]
     receiver.test_name = "full successful open"
     receiver.test()
 
 if run_q("empty-download"):
-    receiver.expected_states = ["DECRYPTION_PROCESS_START","DECRYPTION_BUNDLE_OPEN_FAILURE"]
-    receiver.cmd = ["qvm-open-in-vm","sd-decrypt","./empty.sd-xfer"]
+    receiver.expected_states = [
+            "DECRYPTION_PROCESS_START",
+            "DECRYPTION_BUNDLE_OPEN_FAILURE",
+    ]
+    receiver.cmd = ["qvm-open-in-vm", "sd-decrypt", "./empty.sd-xfer"]
     receiver.test_name = "empty sd-xfer"
     receiver.test()
 
 if run_q("bad-gpg-key"):
-    receiver.expected_states = ["DECRYPTION_PROCESS_START","SUBMISSION_BUNDLE_UNBUNDLED", \
-                                "SUBMISSION_FILES_EXTRACTED", "SUBMISSION_FILE_DECRYPTION_FAILED", \
-                                "SUBMISSION_FILE_DECRYPTION_FAILED", "SUBMISSION_FILE_NO_FILES_FOUND"]
-    receiver.cmd = ["qvm-open-in-vm","sd-decrypt","./bad-key.sd-xfer"]
+    receiver.expected_states = [
+            "DECRYPTION_PROCESS_START",
+            "SUBMISSION_BUNDLE_UNBUNDLED",
+            "SUBMISSION_FILES_EXTRACTED",
+            "SUBMISSION_FILE_DECRYPTION_FAILED",
+            "SUBMISSION_FILE_DECRYPTION_FAILED",
+            "SUBMISSION_FILE_NO_FILES_FOUND",
+    ]
+    receiver.cmd = ["qvm-open-in-vm", "sd-decrypt", "./bad-key.sd-xfer"]
     receiver.test_name = "bad encryption key"
     receiver.test()
 

--- a/tests/integration/test_integration
+++ b/tests/integration/test_integration
@@ -62,6 +62,7 @@ def usage(err=None):
     print(tests)
     sys.exit(1)
 
+
 if arg == "all":
     prLightGray("Running all integration tests")
 elif arg in tests:
@@ -122,6 +123,7 @@ class StatefulListener():
         #     prYellow("  ...next expected state: {}".format(
         #         self.expected_states[self.on_state]))
 
+
 receiver = StatefulListener()
 reader = pipereader.PipeReader("/home/user/sdfifo", receiver.poller_cb)
 t = threading.Thread(target=reader.read)
@@ -136,6 +138,7 @@ def run_q(n):
     if arg == n:
         return True
     return False
+
 
 if run_q("full-success"):
     receiver.expected_states = [


### PR DESCRIPTION
Follow-up to #62, which falsely alleged it linted "all" Python files. It didn't: it only ran `flake8 .`, and trusted `flake8` to discover all Python files. Here, we add a `find` command to discover Python files, which catches scripts and other helpers that do not end in `*.py`. 

Changes are quite cosmetic, but it's still worth running the test suites locally to ensure no breakage. In particular, don't forget to run the integration tests in the `sd-journalist` VM, as described in the README.