### PR TITLE
Updates tests to expect Fedora 26 (instead of Fedora 26)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,8 @@ flake8: ## Lints all Python files with flake8
 	@flake8 .
 
 update-fedora-templates: assert-dom0 ## Upgrade Fedora 25 to Fedora 26 templates
-	sudo qubes-dom0-update
+	sudo qubes-dom0-update qubes-template-fedora-26
+	sudo qubes-prefs default_template fedora-26
 	sudo qubesctl state.sls qvm.default-dispvm
 	qubes-prefs default_dispvm fedora-26-dvm
 

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,11 @@ flake8: ## Lints all Python files with flake8
 # available only in the developer environment, i.e. Work VM.
 	@flake8 .
 
+update-fedora-templates: assert-dom0 ## Upgrade Fedora 25 to Fedora 26 templates
+	sudo qubes-dom0-update
+	sudo qubesctl state.sls qvm.default-dispvm
+	qubes-prefs default_dispvm fedora-26-dvm
+
 # Explanation of the below shell command should it ever break.
 # 1. Set the field separator to ": ##" to parse lines for make targets.
 # 2. Check for second field matching, skip otherwise.

--- a/dom0/sd-decrypt.sls
+++ b/dom0/sd-decrypt.sls
@@ -15,6 +15,7 @@
 {% load_yaml as defaults -%}
 name:         sd-decrypt
 present:
+  - template: fedora-26
   - label:    green
 prefs:
   - netvm:    ""

--- a/dom0/sd-gpg.sls
+++ b/dom0/sd-gpg.sls
@@ -14,6 +14,7 @@
 {% load_yaml as defaults -%}
 name:         sd-gpg
 present:
+  - template: fedora-26
   - label:    purple
 prefs:
   - netvm:    ""

--- a/dom0/sd-svs-disp.sls
+++ b/dom0/sd-svs-disp.sls
@@ -16,6 +16,7 @@
 {% load_yaml as defaults -%}
 name:         sd-svs-disp
 present:
+  - template: fedora-26
   - label:    green
 prefs:
   - netvm:    ""

--- a/dom0/sd-svs.sls
+++ b/dom0/sd-svs.sls
@@ -14,6 +14,7 @@
 {% load_yaml as defaults -%}
 name:         sd-svs
 present:
+  - template: fedora-26
   - label:    yellow
 prefs:
   - netvm:    ""

--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -27,22 +27,43 @@ class SD_VM_Platform_Tests(unittest.TestCase):
         pass
 
     def _get_platform_info(self, vm):
+        """
+        Retrieve base OS for running AppVM. Executes command on AppVM
+        and returns the PRETTY_NAME field from /etc/os-release.
+        """
+        # Not using `lsb_release` for platform info, because it is not present
+        # on Qubes AppVMs. Rather than install it simply for testing purposes,
+        # let's maintain the default config and retrieve the value elsewise.
         cmd = "perl -nE '/^PRETTY_NAME=\"(.*)\"$/ and say $1' /etc/os-release"
         stdout, stderr = vm.run(cmd)
         platform = stdout.rstrip("\n")
         return platform
 
     def _validate_vm_platform(self, vm):
+        """
+        Asserts that the given AppVM is based on an OS listed in the
+        SUPPORTED_PLATFORMS list, as specified in tests.
+        """
         platform = self._get_platform_info(vm)
         self.assertIn(platform, SUPPORTED_PLATFORMS)
 
     def test_sd_journalist_template(self):
+        """
+        Asserts that the 'sd-journalist' VM is using a supported base OS.
+        """
+        # This test is a single example of the method for testing: it would
+        # be ideal to use a loop construct (such as pytest.mark.parametrize),
+        # but doing so would introduce additional dependencies to dom0.
         vm = self.app.domains["sd-journalist"]
         self._validate_vm_platform(vm)
 
     def test_all_sd_vm_platforms(self):
         """
         Test all VM platforms iteratively.
+
+        Due to for-loop implementation, the first failure will stop the test.
+        Therefore, even if multiple VMs are NOT running a supported platform,
+        only a single failure will be reported.
         """
         # Would prefer to use a feature like pytest.mark.parametrize
         # for better error output here, but not available in dom0.

--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -1,4 +1,5 @@
 import unittest
+import subprocess
 
 from qubesadmin import Qubes
 
@@ -48,6 +49,16 @@ class SD_VM_Platform_Tests(unittest.TestCase):
         for vm_name in WANTED_VMS:
             vm = self.app.domains[vm_name]
             self._validate_vm_platform(vm)
+
+    def test_dispvm_default_platform(self):
+        """
+        Query dom0 Qubes preferences and confirm that new DispVMs
+        will be created under a supported OS. Requires a separate
+        test because DispVMs may not be running at present.
+        """
+        cmd = ["qubes-prefs", "default_dispvm"]
+        result = subprocess.check_output(cmd).rstrip("\n")
+        self.assertEqual(result, "fedora-26-dvm")
 
 
 def load_tests(loader, tests, pattern):

--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -4,7 +4,7 @@ from qubesadmin import Qubes
 
 
 SUPPORTED_PLATFORMS = [
-    "Fedora 25 (Twenty Five)",
+    "Fedora 26 (Twenty Six)",
     "Debian GNU/Linux 8 (jessie)",
 ]
 


### PR DESCRIPTION
Closes #48.

Forces tests to fail if Fedora 25 is used anywhere. There are two places we need to check:

* inside the running SD VMs (by inspecting the contents of `/etc/os-release`)
* in the Qubes dom0 settings for new DispVMs (which may not be running and therefore won't be caught by the above check)

There's a long circuitous route for upgrading the templates in the Qubes docs, but when reviewing please use the Makefile target. I wrote the Makefile target _after_ I upgraded my VMs, but it should cover all your bases. If not, please comment.

### Testing
1. Checkout this feature branch in the work VM.
2. In dom0, run `make clone`
3. In dom0, run `make all`
4. In dom0, run `make test`
5. **Confirm tests fail due to Fedora 25 VMs.**
6. In dom0, run `make update-fedora-templates`
7. In dom0, re-run `make all`.
8. In dom0, re-run `make test`.
9. **Confirm tests pass.**

I also ran the integration tests and confirmed those were passing. Will update the documentation on the integration tests separately. 



 