### PR TITLE
Installs Fedora 26 template and tells VMs to use it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,7 @@ flake8: ## Lints all Python files with flake8
 
 update-fedora-templates: assert-dom0 ## Upgrade Fedora 25 to Fedora 26 templates
 	sudo qubes-dom0-update qubes-template-fedora-26
+	sudo qubes-prefs default_template fedora-26
 	sudo qubesctl state.sls qvm.default-dispvm
 	qubes-prefs default_dispvm fedora-26-dvm
 

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ flake8: ## Lints all Python files with flake8
 	@flake8 .
 
 update-fedora-templates: assert-dom0 ## Upgrade Fedora 25 to Fedora 26 templates
-	sudo qubes-dom0-update
+	sudo qubes-dom0-update qubes-template-fedora-26
 	sudo qubesctl state.sls qvm.default-dispvm
 	qubes-prefs default_dispvm fedora-26-dvm
 

--- a/dom0/sd-decrypt.sls
+++ b/dom0/sd-decrypt.sls
@@ -15,6 +15,7 @@
 {% load_yaml as defaults -%}
 name:         sd-decrypt
 present:
+  - template: fedora-26
   - label:    green
 prefs:
   - netvm:    ""

--- a/dom0/sd-gpg.sls
+++ b/dom0/sd-gpg.sls
@@ -14,6 +14,7 @@
 {% load_yaml as defaults -%}
 name:         sd-gpg
 present:
+  - template: fedora-26
   - label:    purple
 prefs:
   - netvm:    ""

--- a/dom0/sd-svs-disp.sls
+++ b/dom0/sd-svs-disp.sls
@@ -16,6 +16,7 @@
 {% load_yaml as defaults -%}
 name:         sd-svs-disp
 present:
+  - template: fedora-26
   - label:    green
 prefs:
   - netvm:    ""

--- a/dom0/sd-svs.sls
+++ b/dom0/sd-svs.sls
@@ -14,6 +14,7 @@
 {% load_yaml as defaults -%}
 name:         sd-svs
 present:
+  - template: fedora-26
   - label:    yellow
 prefs:
   - netvm:    ""


### PR DESCRIPTION
This should fix the issue on @conorsch 's #67 PR, by installing Fedora 26 and using it as the template VM for the various sd-workstation salt configurations.

Tests pass, following the process in #67!