### PR TITLE
Make the feedback processes smarter in the face of a blocking socket

### DIFF
--- a/sd-journalist/sd-process-feedback
+++ b/sd-journalist/sd-process-feedback
@@ -1,7 +1,15 @@
-#!/bin/sh
+#!/usr/bin/python
 
-# `read` reads exactly one line from stdin as a literal string.
-read arg
+import errno
+import posix
+import sys
+import os
 
-# our process on the other end will read at most BUFSIZE bytes
-echo $arg > /home/user/sdfifo
+arg = sys.stdin.readline()
+
+try:
+    fifo = os.open('/home/user/sdfifo', posix.O_WRONLY | posix.O_NONBLOCK)
+    os.write(fifo, arg)
+except OSError as ex:
+    if ex.errno == errno.ENXIO:
+        pass


### PR DESCRIPTION
This closes #65. If the monitoring UI dies (user closes the window, perhaps), the feedback FIFO loses its reader. In a naive implementation, any processes trying to write to that pipe will block. This has the unhappy effect of stopping all SD submission processing. 

This changes how we write to that FIFO. Rather than using the shell's `echo` built-in, we use a Python script to open a nonblocking file handle to the FIFO. If the open fails, we silently move on, which allows submission processing to continue. If the open works, we write to the FIFO, which will update the user interface.