### PR TITLE
Make single-file gpg and msg downloads work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ clean-salt: assert-dom0 ## Purges SD Salt configuration from dom0
 	sudo find /srv/salt/_tops -lname '/srv/salt/sd-*' -delete
 
 prep-salt: assert-dom0 ## Configures Salt layout for SD workstation VMs
-	sudo mkdir /srv/salt/sd
+	-sudo mkdir /srv/salt/sd
 	sudo cp config.json /srv/salt/sd
 	sudo cp sd-journalist.sec /srv/salt/sd
 	sudo cp -r sd-decrypt /srv/salt/sd

--- a/sd-decrypt/decrypt-sd-submission
+++ b/sd-decrypt/decrypt-sd-submission
@@ -8,7 +8,8 @@ import zipfile
 import glob
 import subprocess
 import shutil
-
+import re
+import gzip
 
 def send_progress(msg):
     p = subprocess.Popen(["qrexec-client-vm", "sd-journalist",
@@ -51,6 +52,17 @@ for z in zips:
         zf.extractall(tmpdir + "/extracted/")
     os.unlink(z)
 
+gpgs = glob.glob(tmpdir + "/*gpg")
+for g in gpgs:
+    match = re.search('\d-(.*)-(msg|doc).*$', g)
+    source = match.group(1)
+    target = "{}/extracted/{}".format(tmpdir, source)
+
+    if not os.path.exists(target):
+        os.makedirs(target)
+
+    os.rename(g, "{}/{}".format(target, os.path.basename(g)))
+
 send_progress("SUBMISSION_FILES_EXTRACTED")
 
 # great, we should be left with a directory tree filled with files
@@ -74,14 +86,40 @@ for root, dirnames, filenames in os.walk(tmpdir):
             send_progress("SUBMISSION_FILE_DECRYPTION_SUCCEEDED")
         err.close()
 
-# almost done. docs are gzipped. let's ungzip them.
+# almost done. some docs are gzipped, so let's ungzip them. also,
+# torbrowser (?) seems to add numeric suffixes to files if they've
+# been previously downloaded, even if those files are not in the
+# download directory? so we need to deal with stripping those numbers
+# off the end of filenames. This happens with single-file downloads,
+# not tar files (since those tar files have a different name every
+# time they're downloaded)
+
 any_files = False
 for root, dirnames, filenames in os.walk(tmpdir):
-    for fn in fnmatch.filter(filenames, '*.gz'):
+
+    # first let's find "msg" files
+    for fn in fnmatch.filter(filenames, '*-msg*'):
+        orig_path = os.path.join(root, fn)
         any_files = True
-        # maybe sorta lazy, could do this using python gzip module.
-        # XXX also catch errors here...
-        subprocess.call(["gunzip", os.path.join(root, fn)])
+
+        match = re.search('(.*-msg)(-\d)?$', orig_path)
+        path_removed_number = match.group(1)
+        os.rename(orig_path, path_removed_number)
+
+    # and now find gzipped file submissions
+    for fn in fnmatch.filter(filenames, '*.gz*'):
+        orig_path = os.path.join(root, fn)
+        any_files = True
+
+        with gzip.open(orig_path, 'rb') as f:
+            file_content = f.read()
+
+        [ungz_path, _ext] = os.path.splitext(orig_path)
+
+        with open(ungz_path, 'w') as f:
+            f.write(file_content)
+
+        os.unlink(orig_path)
 
 if not any_files:
     send_progress("SUBMISSION_FILE_NO_FILES_FOUND")

--- a/sd-decrypt/decrypt-sd-submission
+++ b/sd-decrypt/decrypt-sd-submission
@@ -52,7 +52,7 @@ for z in zips:
         zf.extractall(tmpdir + "/extracted/")
     os.unlink(z)
 
-gpgs = glob.glob(tmpdir + "/*gpg")
+gpgs = glob.glob(os.path.join(tmpdir, "*gpg"))
 for g in gpgs:
     match = re.search('\d-(.*)-(msg|doc).*$', g)
     source = match.group(1)
@@ -61,7 +61,7 @@ for g in gpgs:
     if not os.path.exists(target):
         os.makedirs(target)
 
-    os.rename(g, "{}/{}".format(target, os.path.basename(g)))
+    os.rename(g, os.path.join(target, os.path.basename(g)))
 
 send_progress("SUBMISSION_FILES_EXTRACTED")
 

--- a/sd-decrypt/decrypt-sd-submission
+++ b/sd-decrypt/decrypt-sd-submission
@@ -11,6 +11,7 @@ import shutil
 import re
 import gzip
 
+
 def send_progress(msg):
     p = subprocess.Popen(["qrexec-client-vm", "sd-journalist",
                          "sd-process.Feedback"],

--- a/sd-journalist/mimeapps.list
+++ b/sd-journalist/mimeapps.list
@@ -1,4 +1,5 @@
 [Default Applications]
+application/pgp-encrypted=process-download.desktop;
 application/zip=process-download.desktop;
 application/x-dia-diagram=do-not-open.desktop;
 text/x-vcard=do-not-open.desktop;

--- a/sd-journalist/sd-process-download.desktop
+++ b/sd-journalist/sd-process-download.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
 Type=Application
-MimeType=application/zip
+MimeType=application/zip;application/pgp-encrypted
 Name=Process SecureDrop Download
 Exec=/usr/local/bin/sd-process-download


### PR DESCRIPTION
Closes #8 

This extends the approach Jen took in #9. Extending the workstation to handle single file downloads only required updating the decryption phase (aside from updating the MIME registry in sd-journalist to make our own scripts handle `.gpg` files).

A confounding problem is that TorBrowser seems to want to add numeric suffixes to the names of "downloaded" files if they've already been downloaded in the past- even if the file was not saved to disk but was handled by a different application (as is the case here- our scripts handle downloaded submissions). So, our code needs to expect and handle numeric suffixes on .gpg files. We strip the number off the filename, so we don't end up with many copies of the same file, named slightly differently, on `sd-svs`. I handle that process in `sd-decrypt`, but a strong case could be made that it belongs in `sd-journalist`, I suppose.

The "numeric suffix" problem doesn't turn up when downloading multiple files from SD, since it generates a new filename for each bundle. 

Another oddity is that when downloading multiple files from securedrop, it puts each file in its own directory in the generated tarball. Our processing does not remove that directory level, so if (over time) a journalist downloads both single files and a bundle which contains those same files, they'll end up with a tree that might look like-

    Sources/monistic_convention/1-monistic_convention-doc
    Sources/monistic_convention/2-monistic_convention-msg
    Sources/monistic_convention/1_2017-09-22/1-monistic_convention-doc
    Sources/monistic_convention/2_2017-09-22/2-monistic_convention-msg
   
i.e., the same files are in two different places. I am not sure why SD adds that extra directory layer, but we should probably just remove that level in our processing.