### PR TITLE
Automate Securedrop Workstation Qubes template building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,9 @@ update-fedora-templates: assert-dom0 ## Upgrade Fedora 25 to Fedora 26 templates
 	sudo qubesctl state.sls qvm.default-dispvm
 	qubes-prefs default_dispvm fedora-26-dvm
 
+template: ## Builds securedrop-workstation Qube template RPM
+	./builder/build-workstation-template
+
 # Explanation of the below shell command should it ever break.
 # 1. Set the field separator to ": ##" to parse lines for make targets.
 # 2. Check for second field matching, skip otherwise.

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ For more information on the integration tests, run `test_integration --help`.
 1. Create a fedora-28 AppVM for building
 2. Increase the disk size to at least 15GB (as the build uses over 10GB)
 3. Import the QubesOS master key and the GPG key used to sign tags (see https://www.qubes-os.org/security/verifying-signatures/)
-4. Run `build-workstation-template` in the `builder` directory
+4. Run `make template` in the top-level of this repository.
 5. Copy the rpm generated in `/home/user/src/securedrop-workstation/builder/qubes-builder/qubes-src/linux-template-builder/rpm/` to `dom0`
 6. Install the template in `dom0` : `sudo rpm -i <file>.rpm` (this takes a few minutes)
 7. Create a new VM based on this template:

--- a/README.md
+++ b/README.md
@@ -167,6 +167,19 @@ and run tests with
 
 For more information on the integration tests, run `test_integration --help`.
 
+## Building the templates
+
+1. Create a fedora-28 AppVM for building
+2. Increase the disk size to at least 15GB (as the build uses over 10GB)
+3. Import the QubesOS master key and the GPG key used to sign tags (see https://www.qubes-os.org/security/verifying-signatures/)
+4. Run `build-workstation-template` in the `builder` directory
+5. Copy the rpm generated in `/home/user/src/securedrop-workstation/builder/qubes-builder/qubes-src/linux-template-builder/rpm/` to `dom0`
+6. Install the template in `dom0` : `sudo rpm -i <file>.rpm` (this takes a few minutes)
+7. Create a new VM based on this template:
+```
+qvm-create --template grsec-workstation test-grsec-kernels --class AppVM --property virt_mode=hvm --property kernel='' --label green
+```
+
 ## Threat model
 
 This section outlines the threat model for the SecureDrop workstation, and should complement [SecureDrop's threat model](https://docs.securedrop.org/en/stable/threat_model/threat_model.html). This document is always a work in progress, if you have any questions or comments, please open an issue on [GitHub](https://github.com/freedomofpress/securedrop-workstation) or send an email to [securedrop@freedom.press](mailto:securedrop@freedom.press).

--- a/builder/build-workstation-template
+++ b/builder/build-workstation-template
@@ -10,6 +10,7 @@ repo_root="$(git rev-parse --show-toplevel)"
 build_dir="${repo_root}/builder"
 qubes_builder_dir="${build_dir}/qubes-builder"
 sd_template_dir="${build_dir}/qubes-template-securedrop-workstation"
+gpg_homedir="${repo_root}/builder/qubes-builder/keyrings/git"
 
 # Chroot may exist due to previous failed build; let's clean up responsibly.
 if [[ -d "${qubes_builder_dir}" ]]
@@ -32,6 +33,15 @@ cp ${sd_template_dir}/securedrop-workstation.conf builder.conf
 
 # Install dependencies from Qubes builder logic.
 make install-deps
+
+# Get sources for only the builder component, which will get Qubes dev keys and initialize the keyring
+make COMPONENTS="builder" get-sources
+
+# Add signing key to the keyring
+gpg --homedir ${gpg_homedir} --keyserver pool.sks-keyservers.net --recv-key AF775782949D263DAABB3387AAFB3575FAC82745 || exit 1;
+echo 'AF775782949D263DAABB3387AAFB3575FAC82745:6:' | gpg --homedir ${gpg_homedir} --import-ownertrust;
+
+# Get all sources
 make get-sources
 
 # Build it!

--- a/builder/build-workstation-template
+++ b/builder/build-workstation-template
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Wrapper script to manage the TemplateVM build process.
+# Clones the qubes-builder repo, as well as the securedrop-workstation repo,
+# and generates an RPM that can be installed in dom0 to support new TemplateVMs.
+set -e
+set -u
+set -o pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+build_dir="${repo_root}/builder"
+qubes_builder_dir="${build_dir}/qubes-builder"
+sd_template_dir="${build_dir}/qubes-template-securedrop-workstation"
+
+# Chroot may exist due to previous failed build; let's clean up responsibly.
+if [[ -d "${qubes_builder_dir}" ]]
+then
+    # Command exits 0 even if no chroot exists.
+    make -C "${qubes_builder_dir}" clean-chroot
+fi
+
+# Heavy-handed, but ensures build is clean, and also sidesteps idempotence
+# issues with the git clone/checkout commands.
+rm -rf "${qubes_builder_dir}" "${sd_template_dir}"
+
+git clone https://github.com/qubesos/qubes-builder "${build_dir}/qubes-builder"
+git clone https://github.com/freedomofpress/qubes-template-securedrop-workstation "${sd_template_dir}"
+
+cd "${qubes_builder_dir}"
+
+# Provision securedrop-workstation config so that we get the correct sources via `make get-sources`.
+cp ${sd_template_dir}/securedrop-workstation.conf builder.conf
+
+# Install dependencies from Qubes builder logic.
+make install-deps
+make get-sources
+
+# Build it!
+make qubes-vm
+make template


### PR DESCRIPTION
`build-workstation-template` in builder automatically builds a Qubes SecureDrop workstation template .rpm to be installed in dom0.

Installing this template will provide a usable grsecurity-hardened template. 

Fixes #109 

### Test plan:
1. create a fedora-28 vm for building purposes
2. increase the disk size to at least 15GB (as the build uses over 10GB)
3. run `build-workstation-template`
4. copy the rpm generated in `/home/user/src/securedrop-workstation/builder/qubes-builder/qubes-src/linux-template-builder/rpm/` to dom0
5. `sudo rpm -i <file>.rpm` (this takes a few minutes)
6. `qvm-create --template grsec-workstation test-grsec-kernels --class AppVM --property virt_mode=hvm --property kernel='' --label green`
7. open a terminal window in `test-grsec-kernels` and ensure the grsec kernel is running