### PR TITLE
Uses Fedora 28 templates for all Fedora VMs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,10 +126,7 @@ flake8: ## Lints all Python files with flake8
 		| xargs flake8
 
 update-fedora-templates: assert-dom0 ## Upgrade to Fedora 28 templates
-	sudo qubes-dom0-update qubes-template-fedora-28
-	sudo qubes-prefs default_template fedora-28
-	sudo qubesctl state.sls qvm.default-dispvm
-	qubes-prefs default_dispvm fedora-28-dvm
+	@./scripts/update-fedora-templates
 
 template: ## Builds securedrop-workstation Qube template RPM
 	./builder/build-workstation-template

--- a/Makefile
+++ b/Makefile
@@ -125,11 +125,11 @@ flake8: ## Lints all Python files with flake8
 		| perl -F':\s+' -nE '$$F[1] =~ m/text\/x-python/ and say $$F[0]' \
 		| xargs flake8
 
-update-fedora-templates: assert-dom0 ## Upgrade Fedora 25 to Fedora 26 templates
-	sudo qubes-dom0-update qubes-template-fedora-26
-	sudo qubes-prefs default_template fedora-26
+update-fedora-templates: assert-dom0 ## Upgrade to Fedora 28 templates
+	sudo qubes-dom0-update qubes-template-fedora-28
+	sudo qubes-prefs default_template fedora-28
 	sudo qubesctl state.sls qvm.default-dispvm
-	qubes-prefs default_dispvm fedora-26-dvm
+	qubes-prefs default_dispvm fedora-28-dvm
 
 template: ## Builds securedrop-workstation Qube template RPM
 	./builder/build-workstation-template

--- a/dom0/sd-decrypt.sls
+++ b/dom0/sd-decrypt.sls
@@ -15,7 +15,7 @@
 {% load_yaml as defaults -%}
 name:         sd-decrypt
 present:
-  - template: fedora-26
+  - template: fedora-28
   - label:    green
 prefs:
   - netvm:    ""

--- a/dom0/sd-gpg.sls
+++ b/dom0/sd-gpg.sls
@@ -14,7 +14,7 @@
 {% load_yaml as defaults -%}
 name:         sd-gpg
 present:
-  - template: fedora-26
+  - template: fedora-28
   - label:    purple
 prefs:
   - netvm:    ""

--- a/dom0/sd-svs-disp.sls
+++ b/dom0/sd-svs-disp.sls
@@ -16,7 +16,7 @@
 {% load_yaml as defaults -%}
 name:         sd-svs-disp
 present:
-  - template: fedora-26
+  - template: fedora-28
   - label:    green
 prefs:
   - netvm:    ""

--- a/dom0/sd-svs.sls
+++ b/dom0/sd-svs.sls
@@ -14,7 +14,7 @@
 {% load_yaml as defaults -%}
 name:         sd-svs
 present:
-  - template: fedora-26
+  - template: fedora-28
   - label:    yellow
 prefs:
   - netvm:    ""

--- a/scripts/update-fedora-templates
+++ b/scripts/update-fedora-templates
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Utility to update the default Fedora templates used by Qubes
+# when creating other VMs.
+set -e
+set -u
+set -o pipefail
+
+
+# Install the Qubes-maintained Fedora template if absent.
+# We must use conditional logic, since the update command
+# will fail if the package is already installed.
+if ! rpm -qa | grep -q ^qubes-template-fedora-28 ; then
+    sudo qubes-dom0-update qubes-template-fedora-28
+fi
+
+# Check whether a suitable DispVM exists.
+if ! qvm-ls --quiet fedora-28-dvm 2>&1 > /dev/null ; then
+    qvm-create --template fedora-28 --label red fedora-28-dvm
+    qvm-features fedora-28-dvm appmenus-dispvm 1
+fi
+
+# Set latest Fedora as the default DispVM throughout.
+qubes-prefs default_template fedora-28
+qubes-prefs default_dispvm fedora-28-dvm
+
+# The Qubes Salt config must override the fedora-26-dvm setting.
+# We aren't managing that explicitly yet.
+# sudo qubesctl state.sls qvm.default-dispvm

--- a/scripts/update-fedora-templates
+++ b/scripts/update-fedora-templates
@@ -19,6 +19,9 @@ if ! qvm-ls --quiet fedora-28-dvm 2>&1 > /dev/null ; then
     qvm-features fedora-28-dvm appmenus-dispvm 1
 fi
 
+# The DispVM template must explicitly allow creation of DispVMs
+qvm-prefs fedora-28-dvm template_for_dispvms True
+
 # Set latest Fedora as the default DispVM throughout.
 qubes-prefs default_template fedora-28
 qubes-prefs default_dispvm fedora-28-dvm

--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -5,7 +5,7 @@ from qubesadmin import Qubes
 
 
 SUPPORTED_PLATFORMS = [
-    "Fedora 26 (Twenty Six)",
+    "Fedora 28 (Twenty Eight)",
     "Debian GNU/Linux 8 (jessie)",
 ]
 
@@ -79,7 +79,7 @@ class SD_VM_Platform_Tests(unittest.TestCase):
         """
         cmd = ["qubes-prefs", "default_dispvm"]
         result = subprocess.check_output(cmd).rstrip("\n")
-        self.assertEqual(result, "fedora-26-dvm")
+        self.assertEqual(result, "fedora-28-dvm")
 
 
 def load_tests(loader, tests, pattern):


### PR DESCRIPTION
Fedora 26 is now EOL. Rather than switch to 27, let's jump to 28 and buy ourselves a bit more breathing room on the lifecycle.

Closes #114.

### Testing

1. Pull the latest changes from this branch into dom0 via the `qvm-run` tar command (see README).
2. Run `make update-fedora-templates`.
3. Run `make all`.
4. Run `make test`.
5. Confirm all tests pass.

I'll note that the tests still permit Debian Jessie VMs, so we should definitely update that to force Stretch for any Debian hosts used in the config. Deferring that to a separate changeset, though.