### PR TITLE
Enable apparmor for whonix gateway and workstation vms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,12 +129,15 @@ flake8: ## Lints all Python files with flake8
 update-fedora-templates: assert-dom0 ## Upgrade to Fedora 28 templates
 	@./scripts/update-fedora-templates
 
+update-whonix-templates: assert-dom0 ## Upgrade to Whonix 14 templates
+	@./scripts/update-whonix-templates
+
 template: ## Builds securedrop-workstation Qube template RPM
 	./builder/build-workstation-template
 
-prep-whonix: ## enables apparmor on whonix-ws and whonix-gw
-	qvm-prefs -s whonix-gw kernelopts "nopat apparmor=1 security=apparmor"
-	qvm-prefs -s whonix-ws kernelopts "nopat apparmor=1 security=apparmor"
+prep-whonix: ## enables apparmor on whonix-ws-14 and whonix-gw-14
+	qvm-prefs -s whonix-gw-14 kernelopts "nopat apparmor=1 security=apparmor"
+	qvm-prefs -s whonix-ws-14 kernelopts "nopat apparmor=1 security=apparmor"
 
 # Explanation of the below shell command should it ever break.
 # 1. Set the field separator to ": ##" to parse lines for make targets.

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,9 @@ ifneq ($(HOST),dom0)
 	exit 1
 endif
 
-all: assert-dom0 validate clean sd-whonix sd-svs sd-gpg sd-journalist sd-decrypt \
-     sd-svs-disp ## Builds and provisions all VMs required for testing workstation
+all: assert-dom0 validate clean prep-whonix sd-whonix sd-svs sd-gpg \
+	sd-journalist sd-decrypt sd-svs-disp
+	## Builds and provisions all VMs required for testing workstation
 
 proj-tar: assert-dom0 ## Create tarball from "work" VM for export to dom0
 	qvm-run --pass-io $(DEVVM) 'tar -c -C $(dir $(DEVDIR)) $(notdir $(DEVDIR))' > ./sd-proj.tar
@@ -130,6 +131,10 @@ update-fedora-templates: assert-dom0 ## Upgrade to Fedora 28 templates
 
 template: ## Builds securedrop-workstation Qube template RPM
 	./builder/build-workstation-template
+
+prep-whonix: ## enables apparmor on whonix-ws and whonix-gw
+	qvm-prefs -s whonix-gw kernelopts "nopat apparmor=1 security=apparmor"
+	qvm-prefs -s whonix-ws kernelopts "nopat apparmor=1 security=apparmor"
 
 # Explanation of the below shell command should it ever break.
 # 1. Set the field separator to ": ##" to parse lines for make targets.

--- a/README.md
+++ b/README.md
@@ -58,8 +58,10 @@ After that initial manual step, the code in your development VM may be copied in
 
 #### Building
 
-Once the configuration is done and this directory is copied to `dom0`, `make` can be used to handle all provisioning and configuration by your unpriviledged user:
+Once the configuration is done and this directory is copied to `dom0`, you must update existing Qubes templates and use `make` to handle all provisioning and configuration by your unprivileged user:
 
+    $ make update-fedora-templates
+    $ make update-whonix-templates
     $ cd securedrop-workstation
     $ make all
 

--- a/dom0/sd-journalist.sls
+++ b/dom0/sd-journalist.sls
@@ -18,19 +18,19 @@ include:
 {% load_yaml as defaults -%}
 name:         sd-journalist
 present:
-  - template: whonix-ws
+  - template: whonix-ws-14
   - label:    blue
 prefs:
   - netvm:    sd-whonix
 require:
-  - pkg:      template-whonix-ws
+  - pkg:      qubes-template-whonix-ws-14
   - qvm:      sd-whonix
 {%- endload %}
 
 {{ load(defaults) }}
 
 /etc/qubes-rpc/policy/sd-process.Feedback:
-  file.managed:    
+  file.managed:
     - source: salt://sd/sd-journalist/sd-process.Feedback-dom0
     - user: root
     - group: root
@@ -47,4 +47,3 @@ sed -i '1isd-journalist sd-decrypt allow' /etc/qubes-rpc/policy/qubes.OpenInVM:
 sed -i '1isd-journalist $dispvm:sd-decrypt allow' /etc/qubes-rpc/policy/qubes.OpenInVM:
   cmd.run:
   - unless: grep -qF 'sd-journalist $dispvm:sd-decrypt allow' /etc/qubes-rpc/policy/qubes.OpenInVM
-

--- a/dom0/sd-whonix-hidserv-key.sls
+++ b/dom0/sd-whonix-hidserv-key.sls
@@ -9,5 +9,5 @@ sd-whonix-hidserv-key:
   require:
     - sls: sd-whonix
   file.append:
-    - name: /etc/tor/torrc
+    - name: /usr/local/etc/torrc.d/50_user.conf
     - text: HidServAuth {{ d.hidserv.hostname }} {{ d.hidserv.key }}

--- a/dom0/sd-whonix.sls
+++ b/dom0/sd-whonix.sls
@@ -18,7 +18,7 @@ include:
 {% load_yaml as defaults -%}
 name: sd-whonix
 present:
-  - template: whonix-gw
+  - template: whonix-gw-14
   - label: purple
   - mem: 500
 prefs:
@@ -26,7 +26,7 @@ prefs:
   - netvm: sys-firewall
   - autostart: true
 require:
-  - pkg: template-whonix-gw
+  - pkg: qubes-template-whonix-gw-14
   - qvm: sys-firewall
 {%- endload %}
 

--- a/scripts/update-whonix-templates
+++ b/scripts/update-whonix-templates
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Utility to update the default Whonix templates used by Qubes
+# when creating other VMs.
+set -e
+set -u
+set -o pipefail
+
+
+# Install the Community-maintained Whonix 14 templates (gw and ws) if absent.
+# We must use conditional logic, since the update command
+# will fail if the package is already installed.
+if ! rpm -qa | grep -q ^qubes-template-whonix-ws-14 ; then
+    sudo qubes-dom0-update --enablerepo=qubes-templates-community qubes-template-whonix-ws-14
+fi
+
+if ! rpm -qa | grep -q ^qubes-template-whonix-gw-14 ; then
+    sudo qubes-dom0-update --enablerepo=qubes-templates-community qubes-template-whonix-gw-14
+fi

--- a/tests/test_sd_whonix.py
+++ b/tests/test_sd_whonix.py
@@ -17,7 +17,7 @@ class SD_Whonix_Tests(SD_VM_Local_Test):
                          " {{ d.hidserv.key }}")
             line = t.render(d=config)
 
-            self.assertFileHasLine("/etc/tor/torrc", line)
+            self.assertFileHasLine("/usr/local/etc/torrc.d/50_user.conf", line)
 
 
 def load_tests(loader, tests, pattern):

--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -6,7 +6,7 @@ from qubesadmin import Qubes
 
 SUPPORTED_PLATFORMS = [
     "Fedora 28 (Twenty Eight)",
-    "Debian GNU/Linux 8 (jessie)",
+    "Debian GNU/Linux 9 (stretch)",
 ]
 
 WANTED_VMS = [


### PR DESCRIPTION
Fixes #108 and #122 
Based on the instructions in https://www.whonix.org/wiki/Qubes/AppArmor, AppArmor is enabled on the whonix template prior to creating the sd-whonix and sd-journalist AppVMs