### PR TITLE
130 prefer plain yaml in salt configs

### DIFF
--- a/dom0/sd-decrypt.sls
+++ b/dom0/sd-decrypt.sls
@@ -38,7 +38,7 @@ qvm-tags sd-decrypt add sd-decrypt-vm:
 # Allow dispvms based on this vm to use sd-gpg
 /etc/qubes-rpc/policy/qubes.Gpg:
   file.line:
-    - content: sd-decrypt-vm sd-gpg allow
+    - content: $tag:sd-decrypt-vm sd-gpg allow
     - mode: insert
     - location: start
 

--- a/dom0/sd-decrypt.sls
+++ b/dom0/sd-decrypt.sls
@@ -36,11 +36,15 @@ qvm-tags sd-decrypt add sd-decrypt-vm:
   cmd.run
 
 # Allow dispvms based on this vm to use sd-gpg
-sed -i '1i$tag:sd-decrypt-vm sd-gpg allow' /etc/qubes-rpc/policy/qubes.Gpg:
-  cmd.run:
-  - unless: grep -qF '$tag:sd-decrypt-vm sd-gpg allow' /etc/qubes-rpc/policy/qubes.Gpg
+/etc/qubes-rpc/policy/qubes.Gpg:
+  file.line:
+    - content: sd-decrypt-vm sd-gpg allow
+    - mode: insert
+    - location: start
 
 # Allow sd-decrypt to open files in sd-svs
-sed -i '1isd-decrypt sd-svs allow' /etc/qubes-rpc/policy/qubes.OpenInVM:
-  cmd.run:
-  - unless: grep -qF 'sd-decrypt sd-svs allow' /etc/qubes-rpc/policy/qubes.OpenInVM
+/etc/qubes-rpc/policy/qubes.OpenInVM:
+  file.line:
+    -content: sd-decrypt sd-svs allow
+    - mode: insert
+    - location: start

--- a/dom0/sd-decrypt.sls
+++ b/dom0/sd-decrypt.sls
@@ -10,18 +10,14 @@
 # non-disposable VM for the time being.
 ##
 
-{%- from "qvm/template.jinja" import load -%}
-
-{% load_yaml as defaults -%}
-name:         sd-decrypt
-present:
-  - template: fedora-28
-  - label:    green
-prefs:
-  - netvm:    ""
-{%- endload %}
-
-{{ load(defaults) }}
+sd-decrypt:
+  qvm.vm:
+    - name: sd-decrypt
+    - present:
+      - template: fedora-28
+      - label: green
+    - prefs:
+      - netvm: ""
 
 # tell qubes this VM can be used as a disp VM template
 qvm-prefs sd-decrypt template_for_dispvms True:
@@ -45,6 +41,6 @@ qvm-tags sd-decrypt add sd-decrypt-vm:
 # Allow sd-decrypt to open files in sd-svs
 /etc/qubes-rpc/policy/qubes.OpenInVM:
   file.line:
-    -content: sd-decrypt sd-svs allow
+    - content: sd-decrypt sd-svs allow
     - mode: insert
     - location: start

--- a/dom0/sd-gpg.sls
+++ b/dom0/sd-gpg.sls
@@ -9,15 +9,11 @@
 # This VM has no network configured.
 ##
 
-{%- from "qvm/template.jinja" import load -%}
-
-{% load_yaml as defaults -%}
-name:         sd-gpg
-present:
-  - template: fedora-28
-  - label:    purple
-prefs:
-  - netvm:    ""
-{%- endload %}
-
-{{ load(defaults) }}
+sd-gpg:
+  qvm.vm:
+    - name: sd-gpg
+    - present:
+      - template: fedora-28
+      - label: purple
+    - prefs:
+      - netvm: ""

--- a/dom0/sd-journalist.sls
+++ b/dom0/sd-journalist.sls
@@ -38,12 +38,16 @@ require:
 
 # Allow sd-journslist to open files in sd-decrypt
 # When our Qubes bug is fixed, this will *not* be used
-sed -i '1isd-journalist sd-decrypt allow' /etc/qubes-rpc/policy/qubes.OpenInVM:
-  cmd.run:
-    - unless: grep -qF 'sd-journalist sd-decrypt allow' /etc/qubes-rpc/policy/qubes.OpenInVM
+/etc/qubes-rpc/policy/qubes.OpenInVM:
+  file.line:
+    - content: sd-journalist sd-decrypt allow
+    - mode: insert
+    - location: start
 
 # Allow sd-journalist to open files in sd-decrypt-bsed dispVM's
 # When our Qubes bug is fixed, this will be used.
-sed -i '1isd-journalist $dispvm:sd-decrypt allow' /etc/qubes-rpc/policy/qubes.OpenInVM:
-  cmd.run:
-  - unless: grep -qF 'sd-journalist $dispvm:sd-decrypt allow' /etc/qubes-rpc/policy/qubes.OpenInVM
+/etc/qubes-rpc/policy/qubes.OpenInVM:
+  file.line:
+    - content: sd-journalist $dispvm:sd-decrypt allow
+    - mode: insert
+    - location: start

--- a/dom0/sd-journalist.sls
+++ b/dom0/sd-journalist.sls
@@ -13,21 +13,17 @@ include:
   - qvm.template-whonix-ws
 #  - sd-whonix
 
-{%- from "qvm/template.jinja" import load -%}
-
-{% load_yaml as defaults -%}
-name:         sd-journalist
-present:
-  - template: whonix-ws-14
-  - label:    blue
-prefs:
-  - netvm:    sd-whonix
-require:
-  - pkg:      qubes-template-whonix-ws-14
-  - qvm:      sd-whonix
-{%- endload %}
-
-{{ load(defaults) }}
+sd-journalist:
+  qvm.vm:
+    - name: sd-journalist
+    - present:
+      - template: whonix-ws-14
+      - label: blue
+    - prefs:
+      - netvm: sd-whonix
+    - require:
+      - pkg: qubes-template-whonix-ws-14
+      - qvm: sd-whonix
 
 /etc/qubes-rpc/policy/sd-process.Feedback:
   file.managed:

--- a/dom0/sd-svs-disp.sls
+++ b/dom0/sd-svs-disp.sls
@@ -11,18 +11,14 @@
 # This VM has no network configured.
 ##
 
-{%- from "qvm/template.jinja" import load -%}
-
-{% load_yaml as defaults -%}
-name:         sd-svs-disp
-present:
-  - template: fedora-28
-  - label:    green
-prefs:
-  - netvm:    ""
-{%- endload %}
-
-{{ load(defaults) }}
+sd-svs-disp:
+  qvm.vm:
+    - name: sd-svs-disp
+    - present:
+      - template: fedora-28
+      - label: green
+    - prefs:
+        - netvm: ""
 
 # tell qubes this VM can be used as a disp VM template
 qvm-prefs sd-svs-disp template_for_dispvms True:

--- a/dom0/sd-svs-disp.sls
+++ b/dom0/sd-svs-disp.sls
@@ -33,6 +33,8 @@ qvm-prefs sd-svs-disp template_for_dispvms True:
 qvm-tags sd-svs-disp add sd-svs-disp-vm:
   cmd.run
 
-sed -i '1i$tag:sd-svs-disp-vm sd-svs allow' /etc/qubes-rpc/policy/qubes.OpenInVM:
-  cmd.run:
-  - unless: grep -qF '1i$tag:sd-svs-disp-vm sd-svs allow' /etc/qubes-rpc/policy/qubes.OpenInVM
+/etc/qubes-rpc/policy/qubes.OpenInVM:
+  file.line:
+    - content: $tag:sd-svs-disp-vm sd-svs allow
+    - mode: insert
+    - location: start

--- a/dom0/sd-svs-disp.sls
+++ b/dom0/sd-svs-disp.sls
@@ -18,7 +18,7 @@ sd-svs-disp:
       - template: fedora-28
       - label: green
     - prefs:
-        - netvm: ""
+      - netvm: ""
 
 # tell qubes this VM can be used as a disp VM template
 qvm-prefs sd-svs-disp template_for_dispvms True:

--- a/dom0/sd-svs.sls
+++ b/dom0/sd-svs.sls
@@ -22,7 +22,8 @@ prefs:
 
 {{ load(defaults) }}
 
-# Allow sd-svs to open files in dispvms based on sd-svs-disp
-sed -i '1isd-svs $dispvm:sd-svs-disp allow' /etc/qubes-rpc/policy/qubes.OpenInVM:
-  cmd.run:
-    - unless: grep -qF 'sd-svs $dispvm:sd-svs-disp allow' /etc/qubes-rpc/policy/qubes.OpenInVM
+/etc/qubes-rpc/policy/qubes.OpenInVM:
+  file.line:
+    - content: sd-svs $dispvm:sd-svs-disp allow
+    - mode: insert
+    - location: start

--- a/dom0/sd-svs.sls
+++ b/dom0/sd-svs.sls
@@ -9,18 +9,14 @@
 # This VM has no network configured.
 ##
 
-{%- from "qvm/template.jinja" import load -%}
-
-{% load_yaml as defaults -%}
-name:         sd-svs
-present:
-  - template: fedora-28
-  - label:    yellow
-prefs:
-  - netvm:    ""
-{%- endload %}
-
-{{ load(defaults) }}
+sd-svs:
+  qvm.vm:
+    - name: sd-svs
+    - present:
+      - template: fedora-28
+      - label: yellow
+    - prefs:
+      - netvm: ""
 
 /etc/qubes-rpc/policy/qubes.OpenInVM:
   file.line:

--- a/dom0/sd-whonix.sls
+++ b/dom0/sd-whonix.sls
@@ -13,21 +13,17 @@ include:
   - qvm.template-whonix-gw
   - qvm.sys-firewall
 
-{%- from "qvm/template.jinja" import load -%}
-
-{% load_yaml as defaults -%}
-name: sd-whonix
-present:
-  - template: whonix-gw-14
-  - label: purple
-  - mem: 500
-prefs:
-  - provides-network: true
-  - netvm: sys-firewall
-  - autostart: true
-require:
-  - pkg: qubes-template-whonix-gw-14
-  - qvm: sys-firewall
-{%- endload %}
-
-{{ load(defaults) }}
+sd-whonix:
+  qvm.vm:
+    - name: sd-whonix
+    - present:
+      - template: whonix-gw-14
+      - label: purple
+      - mem: 500
+    - prefs:
+      - provides-network: true
+      - netvm: ""
+      - autostart: true
+    - require:
+      - pkg: qubes-template-whonix-gw-14
+      - qvm: sys-firewall


### PR DESCRIPTION
These changes address #130 by removing most of the Jinja2 template syntax from the Salt configs by using `qvm.vm` instead.

Note that this merge request is a continuation off PR #140, which is also related to improving the overall readability and maintainability of the Salt configs.