### PR TITLE
Workaround for Salt config against Whonix

### DIFF
--- a/dom0/sd-journalist.sls
+++ b/dom0/sd-journalist.sls
@@ -36,6 +36,10 @@ require:
     - group: root
     - mode: 644
 
+# Temporary workaround to bootstrap Salt support on target.
+qvm-run -a whonix-ws-14 "sudo apt-get install -qq python-futures":
+  cmd.run
+
 # Allow sd-journslist to open files in sd-decrypt
 # When our Qubes bug is fixed, this will *not* be used
 sed -i '1isd-journalist sd-decrypt allow' /etc/qubes-rpc/policy/qubes.OpenInVM:

--- a/dom0/sd-whonix.sls
+++ b/dom0/sd-whonix.sls
@@ -31,3 +31,7 @@ require:
 {%- endload %}
 
 {{ load(defaults) }}
+
+# Temporary workaround to bootstrap Salt support on target.
+qvm-run -a whonix-gw-14 "sudo apt-get install -qq python-futures":
+  cmd.run


### PR DESCRIPTION
Partial progress toward #139. Doesn't resolve, but at least gets the
tests passing on sd-journalist again. Still struggling to get all tests
passing against sd-whonix.