### PR TITLE
Yet even more replacing sed commands

### DIFF
--- a/dom0/sd-decrypt.sls
+++ b/dom0/sd-decrypt.sls
@@ -38,7 +38,7 @@ qvm-tags sd-decrypt add sd-decrypt-vm:
 # Allow dispvms based on this vm to use sd-gpg
 /etc/qubes-rpc/policy/qubes.Gpg:
   file.line:
-    - content: sd-decrypt-vm sd-gpg allow
+    - content: $tag:sd-decrypt-vm sd-gpg allow
     - mode: insert
     - location: start
 

--- a/dom0/sd-decrypt.sls
+++ b/dom0/sd-decrypt.sls
@@ -36,15 +36,13 @@ qvm-tags sd-decrypt add sd-decrypt-vm:
   cmd.run
 
 # Allow dispvms based on this vm to use sd-gpg
-/etc/qubes-rpc/policy/qubes.Gpg:
-  file.line:
-    - content: $tag:sd-decrypt-vm sd-gpg allow
-    - mode: insert
-    - location: start
+sd-decrypt-dom0-qubes.qubesGpg:
+  file.prepend:
+    - name: /etc/qubes-rpc/policy/qubes.Gpg
+    - text: "$tag:sd-decrypt-vm sd-gpg allow\n"
 
 # Allow sd-decrypt to open files in sd-svs
-/etc/qubes-rpc/policy/qubes.OpenInVM:
-  file.line:
-    - content: sd-decrypt sd-svs allow
-    - mode: insert
-    - location: start
+sd-decrypt-dom0-qubes.OpenInVM:
+  file.prepend:
+    - name: /etc/qubes-rpc/policy/qubes.OpenInVM
+    - text: "sd-decrypt sd-svs allow\n"

--- a/dom0/sd-decrypt.sls
+++ b/dom0/sd-decrypt.sls
@@ -36,11 +36,15 @@ qvm-tags sd-decrypt add sd-decrypt-vm:
   cmd.run
 
 # Allow dispvms based on this vm to use sd-gpg
-sed -i '1i$tag:sd-decrypt-vm sd-gpg allow' /etc/qubes-rpc/policy/qubes.Gpg:
-  cmd.run:
-  - unless: grep -qF '$tag:sd-decrypt-vm sd-gpg allow' /etc/qubes-rpc/policy/qubes.Gpg
+/etc/qubes-rpc/policy/qubes.Gpg:
+  file.line:
+    - content: sd-decrypt-vm sd-gpg allow
+    - mode: insert
+    - location: start
 
 # Allow sd-decrypt to open files in sd-svs
-sed -i '1isd-decrypt sd-svs allow' /etc/qubes-rpc/policy/qubes.OpenInVM:
-  cmd.run:
-  - unless: grep -qF 'sd-decrypt sd-svs allow' /etc/qubes-rpc/policy/qubes.OpenInVM
+/etc/qubes-rpc/policy/qubes.OpenInVM:
+  file.line:
+    -content: sd-decrypt sd-svs allow
+    - mode: insert
+    - location: start

--- a/dom0/sd-decrypt.sls
+++ b/dom0/sd-decrypt.sls
@@ -45,6 +45,6 @@ qvm-tags sd-decrypt add sd-decrypt-vm:
 # Allow sd-decrypt to open files in sd-svs
 /etc/qubes-rpc/policy/qubes.OpenInVM:
   file.line:
-    -content: sd-decrypt sd-svs allow
+    - content: sd-decrypt sd-svs allow
     - mode: insert
     - location: start

--- a/dom0/sd-journalist.sls
+++ b/dom0/sd-journalist.sls
@@ -42,12 +42,16 @@ qvm-run -a whonix-ws-14 "sudo apt-get install -qq python-futures":
 
 # Allow sd-journslist to open files in sd-decrypt
 # When our Qubes bug is fixed, this will *not* be used
-sed -i '1isd-journalist sd-decrypt allow' /etc/qubes-rpc/policy/qubes.OpenInVM:
-  cmd.run:
-    - unless: grep -qF 'sd-journalist sd-decrypt allow' /etc/qubes-rpc/policy/qubes.OpenInVM
+/etc/qubes-rpc/policy/qubes.OpenInVM:
+  file.line:
+    - content: sd-journalist sd-decrypt allow
+    - mode: insert
+    - location: start
 
 # Allow sd-journalist to open files in sd-decrypt-bsed dispVM's
 # When our Qubes bug is fixed, this will be used.
-sed -i '1isd-journalist $dispvm:sd-decrypt allow' /etc/qubes-rpc/policy/qubes.OpenInVM:
-  cmd.run:
-  - unless: grep -qF 'sd-journalist $dispvm:sd-decrypt allow' /etc/qubes-rpc/policy/qubes.OpenInVM
+/etc/qubes-rpc/policy/qubes.OpenInVM:
+  file.line:
+    - content: sd-journalist $dispvm:sd-decrypt allow
+    - mode: insert
+    - location: start

--- a/dom0/sd-journalist.sls
+++ b/dom0/sd-journalist.sls
@@ -40,18 +40,15 @@ require:
 qvm-run -a whonix-ws-14 "sudo apt-get install -qq python-futures":
   cmd.run
 
-# Allow sd-journslist to open files in sd-decrypt
 # When our Qubes bug is fixed, this will *not* be used
-/etc/qubes-rpc/policy/qubes.OpenInVM:
-  file.line:
-    - content: sd-journalist sd-decrypt allow
-    - mode: insert
-    - location: start
+sd-journalist-dom0-qubes.OpenInVM:
+  file.prepend:
+    - name: /etc/qubes-rpc/policy/qubes.OpenInVM
+    - text: "sd-journalist sd-decrypt allow\n"
 
 # Allow sd-journalist to open files in sd-decrypt-bsed dispVM's
 # When our Qubes bug is fixed, this will be used.
-/etc/qubes-rpc/policy/qubes.OpenInVM:
-  file.line:
-    - content: sd-journalist $dispvm:sd-decrypt allow
-    - mode: insert
-    - location: start
+sd-journalist-dom0-qubes.OpenInVM-disp:
+  file.prepend:
+    - name: /etc/qubes-rpc/policy/qubes.OpenInVM
+    - text: "sd-journalist $dispvm:sd-decrypt allow\n"

--- a/dom0/sd-svs-disp.sls
+++ b/dom0/sd-svs-disp.sls
@@ -33,6 +33,8 @@ qvm-prefs sd-svs-disp template_for_dispvms True:
 qvm-tags sd-svs-disp add sd-svs-disp-vm:
   cmd.run
 
-sed -i '1i$tag:sd-svs-disp-vm sd-svs allow' /etc/qubes-rpc/policy/qubes.OpenInVM:
-  cmd.run:
-  - unless: grep -qF '1i$tag:sd-svs-disp-vm sd-svs allow' /etc/qubes-rpc/policy/qubes.OpenInVM
+/etc/qubes-rpc/policy/qubes.OpenInVM:
+  file.line:
+    - content: $tag:sd-svs-disp-vm sd-svs allow
+    - mode: insert
+    - location: start

--- a/dom0/sd-svs-disp.sls
+++ b/dom0/sd-svs-disp.sls
@@ -33,8 +33,7 @@ qvm-prefs sd-svs-disp template_for_dispvms True:
 qvm-tags sd-svs-disp add sd-svs-disp-vm:
   cmd.run
 
-/etc/qubes-rpc/policy/qubes.OpenInVM:
-  file.line:
-    - content: $tag:sd-svs-disp-vm sd-svs allow
-    - mode: insert
-    - location: start
+sd-svs-disp-dom0-qubes.OpenInVM:
+  file.prepend:
+    - name: /etc/qubes-rpc/policy/qubes.OpenInVM
+    - text: "$tag:sd-svs-disp-vm sd-svs allow\n"

--- a/dom0/sd-svs.sls
+++ b/dom0/sd-svs.sls
@@ -22,7 +22,8 @@ prefs:
 
 {{ load(defaults) }}
 
-# Allow sd-svs to open files in dispvms based on sd-svs-disp
-sed -i '1isd-svs $dispvm:sd-svs-disp allow' /etc/qubes-rpc/policy/qubes.OpenInVM:
-  cmd.run:
-    - unless: grep -qF 'sd-svs $dispvm:sd-svs-disp allow' /etc/qubes-rpc/policy/qubes.OpenInVM
+/etc/qubes-rpc/policy/qubes.OpenInVM:
+  file.line:
+    - content: sd-svs $dispvm:sd-svs-disp allow
+    - mode: insert
+    - location: start

--- a/dom0/sd-svs.sls
+++ b/dom0/sd-svs.sls
@@ -22,8 +22,7 @@ prefs:
 
 {{ load(defaults) }}
 
-/etc/qubes-rpc/policy/qubes.OpenInVM:
-  file.line:
-    - content: sd-svs $dispvm:sd-svs-disp allow
-    - mode: insert
-    - location: start
+sd-svs-dom0-qubes.OpenInVM:
+  file.prepend:
+    - name: /etc/qubes-rpc/policy/qubes.OpenInVM
+    - text: "sd-svs $dispvm:sd-svs-disp allow\n"


### PR DESCRIPTION
This builds on @charles-boyd 's recent work (https://github.com/freedomofpress/securedrop-workstation/pull/140/files) to replace the ugly `sed` commands in some of our Salt states. I included @conorsch 's state naming suggestions, and used Salt's `file.prepend` operation (rather than `file.line`),  which I found to be more successful for avoiding the same line repeatedly.