### PR TITLE
Fixes GUI feedback in sd-journalist

### DIFF
--- a/dom0/sd-journalist.sls
+++ b/dom0/sd-journalist.sls
@@ -36,8 +36,12 @@ require:
     - group: root
     - mode: 644
 
-# Temporary workaround to bootstrap Salt support on target.
-qvm-run -a whonix-ws-14 "sudo apt-get install -qq python-futures":
+# Temporary workarounds for sd-journalist:
+#
+#   * python-futures required bootstrap Salt support
+#   * python-qt4 required for sd-process-feedback GUI integration
+#
+qvm-run -a whonix-ws-14 "sudo apt-get install -qq python-futures python-qt4":
   cmd.run
 
 # When our Qubes bug is fixed, this will *not* be used

--- a/dom0/sd-journalist.sls
+++ b/dom0/sd-journalist.sls
@@ -41,8 +41,9 @@ require:
 #   * python-futures required bootstrap Salt support
 #   * python-qt4 required for sd-process-feedback GUI integration
 #
-qvm-run -a whonix-ws-14 "sudo apt-get install -qq python-futures python-qt4":
-  cmd.run
+install python-qt4 and python-futures:
+  cmd.run:
+    - name: qvm-run -a whonix-ws-14 'sudo apt-get update && sudo apt-get install -qq python-futures python-qt4'
 
 # When our Qubes bug is fixed, this will *not* be used
 sd-journalist-dom0-qubes.OpenInVM:

--- a/sd-decrypt/decrypt-sd-submission
+++ b/sd-decrypt/decrypt-sd-submission
@@ -17,7 +17,7 @@ def send_progress(msg):
                          "sd-process.Feedback"],
                          close_fds=True,
                          stdin=subprocess.PIPE)
-    p.communicate(msg)
+    p.communicate(bytes(msg.encode('utf-8')))
 
 
 input = sys.argv[1]

--- a/sd-journalist/sd-process-download
+++ b/sd-journalist/sd-process-download
@@ -68,7 +68,7 @@ wait_for_sigfile(sigfile)
 if os.path.isfile(fn) is False:
     c = subprocess.Popen(["/usr/local/bin/sd-process-feedback"],
                          stdin=subprocess.PIPE)
-    c.communicate('DOWNLOAD_FILE_MISSING\n')
+    c.communicate(bytes("DOWNLOAD_FILE_MISSING\n".encode('utf-8')))
     sys.exit()
 
 fh = tempfile.NamedTemporaryFile(suffix=".sd-xfer", delete=False)
@@ -81,7 +81,7 @@ fh.close()
 # from the same machine? This can only happen on sd-journalist.
 c = subprocess.Popen(["/usr/local/bin/sd-process-feedback"],
                      stdin=subprocess.PIPE)
-c.communicate(input="DOWNLOAD_BUNDLE_CREATED\n")
+c.communicate(bytes("DOWNLOAD_BUNDLE_CREATED\n".encode('utf-8')))
 
 # ship this to the next phase
 subprocess.call(["qvm-open-in-vm", "sd-decrypt", fh.name])

--- a/sd-journalist/sd-process-feedback
+++ b/sd-journalist/sd-process-feedback
@@ -5,7 +5,7 @@ import posix
 import sys
 import os
 
-arg = sys.stdin.readline()
+arg = sys.stdin.readline().encode('utf-8')
 
 try:
     fifo = os.open('/home/user/sdfifo', posix.O_WRONLY | posix.O_NONBLOCK)

--- a/sd-svs/accept-sd-xfer-extracted
+++ b/sd-svs/accept-sd-xfer-extracted
@@ -13,7 +13,7 @@ def send_progress(msg):
                          "sd-process.Feedback"],
                          close_fds=True,
                          stdin=subprocess.PIPE)
-    p.communicate(msg)
+    p.communicate(bytes(msg.encode('utf-8')))
 
 
 send_progress("DECRYPTED_BUNDLE_ON_SVS")


### PR DESCRIPTION
Installs python-qt4 in whonix-ws-14

The `python-qt4` package is required for the GUI feedback integration,
so status messages can be displayed to the user. The package isn't
present by default, and we need it in sd-journalist. Since we don't
have SD TemplateVMs yet, we're adding the package to the base template,
installing in `whonix-ws-14`, rather than `sd-journalist`, to get
persistence for the package.


Marking as WIP, because we still have another follow-up to fix the submission process pipeline. See https://github.com/freedomofpress/securedrop-workstation/issues/127#issuecomment-421124029 for details; I propose we append a resolving commit here, then use the following test plan.

### Testing
1. Run `make all` in `dom0`.
2. Run `qvm-shutdown --wait whonix-ws-14`, to ensure the modified TemplateVM will be used on subsequent creation.
3. Re-run `make all` in `dom0`.
4. Run `make test` and confirm no errors.
5. Browse to configured Journalist Interface in the `sd-journalist` VM.
6. Download submission.
7. Confirm submission is processed successfully, and you can view the decrypted content of the submission.