### PR TITLE
Prefer plain yaml in salt configs

### DIFF
--- a/dom0/sd-decrypt.sls
+++ b/dom0/sd-decrypt.sls
@@ -10,18 +10,14 @@
 # non-disposable VM for the time being.
 ##
 
-{%- from "qvm/template.jinja" import load -%}
-
-{% load_yaml as defaults -%}
-name:         sd-decrypt
-present:
-  - template: fedora-28
-  - label:    green
-prefs:
-  - netvm:    ""
-{%- endload %}
-
-{{ load(defaults) }}
+sd-decrypt:
+  qvm.vm:
+    - name: sd-decrypt
+    - present:
+      - template: fedora-28
+      - label: green
+    - prefs:
+      - netvm: ""
 
 # tell qubes this VM can be used as a disp VM template
 qvm-prefs sd-decrypt template_for_dispvms True:

--- a/dom0/sd-gpg.sls
+++ b/dom0/sd-gpg.sls
@@ -9,15 +9,11 @@
 # This VM has no network configured.
 ##
 
-{%- from "qvm/template.jinja" import load -%}
-
-{% load_yaml as defaults -%}
-name:         sd-gpg
-present:
-  - template: fedora-28
-  - label:    purple
-prefs:
-  - netvm:    ""
-{%- endload %}
-
-{{ load(defaults) }}
+sd-gpg:
+  qvm.vm:
+    - name: sd-gpg
+    - present:
+      - template: fedora-28
+      - label: purple
+    - prefs:
+      - netvm: ""

--- a/dom0/sd-journalist.sls
+++ b/dom0/sd-journalist.sls
@@ -13,21 +13,17 @@ include:
   - qvm.template-whonix-ws
 #  - sd-whonix
 
-{%- from "qvm/template.jinja" import load -%}
-
-{% load_yaml as defaults -%}
-name:         sd-journalist
-present:
-  - template: whonix-ws-14
-  - label:    blue
-prefs:
-  - netvm:    sd-whonix
-require:
-  - pkg:      qubes-template-whonix-ws-14
-  - qvm:      sd-whonix
-{%- endload %}
-
-{{ load(defaults) }}
+sd-journalist:
+  qvm.vm:
+    - name: sd-journalist
+    - present:
+      - template: whonix-ws-14
+      - label: blue
+    - prefs:
+      - netvm: sd-whonix
+    - require:
+      - pkg: qubes-template-whonix-ws-14
+      - qvm: sd-whonix
 
 /etc/qubes-rpc/policy/sd-process.Feedback:
   file.managed:

--- a/dom0/sd-svs-disp.sls
+++ b/dom0/sd-svs-disp.sls
@@ -11,18 +11,14 @@
 # This VM has no network configured.
 ##
 
-{%- from "qvm/template.jinja" import load -%}
-
-{% load_yaml as defaults -%}
-name:         sd-svs-disp
-present:
-  - template: fedora-28
-  - label:    green
-prefs:
-  - netvm:    ""
-{%- endload %}
-
-{{ load(defaults) }}
+sd-svs-disp:
+  qvm.vm:
+    - name: sd-svs-disp
+    - present:
+      - template: fedora-28
+      - label: green
+    - prefs:
+        - netvm: ""
 
 # tell qubes this VM can be used as a disp VM template
 qvm-prefs sd-svs-disp template_for_dispvms True:

--- a/dom0/sd-svs-disp.sls
+++ b/dom0/sd-svs-disp.sls
@@ -18,7 +18,7 @@ sd-svs-disp:
       - template: fedora-28
       - label: green
     - prefs:
-        - netvm: ""
+      - netvm: ""
 
 # tell qubes this VM can be used as a disp VM template
 qvm-prefs sd-svs-disp template_for_dispvms True:

--- a/dom0/sd-svs.sls
+++ b/dom0/sd-svs.sls
@@ -9,18 +9,14 @@
 # This VM has no network configured.
 ##
 
-{%- from "qvm/template.jinja" import load -%}
-
-{% load_yaml as defaults -%}
-name:         sd-svs
-present:
-  - template: fedora-28
-  - label:    yellow
-prefs:
-  - netvm:    ""
-{%- endload %}
-
-{{ load(defaults) }}
+sd-svs:
+  qvm.vm:
+    - name: sd-svs
+    - present:
+      - template: fedora-28
+      - label: yellow
+    - prefs:
+      - netvm: ""
 
 sd-svs-dom0-qubes.OpenInVM:
   file.prepend:

--- a/dom0/sd-whonix.sls
+++ b/dom0/sd-whonix.sls
@@ -13,25 +13,21 @@ include:
   - qvm.template-whonix-gw
   - qvm.sys-firewall
 
-{%- from "qvm/template.jinja" import load -%}
-
-{% load_yaml as defaults -%}
-name: sd-whonix
-present:
-  - template: whonix-gw-14
-  - label: purple
-  - mem: 500
-prefs:
-  - provides-network: true
-  - netvm: sys-firewall
-  - autostart: true
-require:
-  - pkg: qubes-template-whonix-gw-14
-  - qvm: sys-firewall
-{%- endload %}
-
-{{ load(defaults) }}
-
 # Temporary workaround to bootstrap Salt support on target.
 qvm-run -a whonix-gw-14 "sudo apt-get install -qq python-futures":
   cmd.run
+
+sd-whonix:
+  qvm.vm:
+    - name: sd-whonix
+    - present:
+      - template: whonix-gw-14
+      - label: purple
+      - mem: 500
+    - prefs:
+      - provides-network: true
+      - netvm: ""
+      - autostart: true
+    - require:
+      - pkg: qubes-template-whonix-gw-14
+      - qvm: sys-firewall

--- a/dom0/sd-whonix.sls
+++ b/dom0/sd-whonix.sls
@@ -26,7 +26,7 @@ sd-whonix:
       - mem: 500
     - prefs:
       - provides-network: true
-      - netvm: ""
+      - netvm: "sys-firewall"
       - autostart: true
     - require:
       - pkg: qubes-template-whonix-gw-14


### PR DESCRIPTION
This builds on @charles-boyd 's #141 , catching it up to changes in `master` and fixing a small issue.

From #141:

> These changes address #130 by removing most of the Jinja2 template syntax from the Salt configs by using qvm.vm instead.

Closes #130 