### PR TITLE
Converts all SDW AppVMs to Debian 9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ sd-whonix: prep-salt ## Provisions SD Whonix VM
 
 sd-svs-disp: prep-salt ## Provisions SD Submission Viewing VM
 	sudo qubesctl top.enable sd-svs-disp
+	sudo qubesctl top.enable sd-svs-disp-files
 	sudo qubesctl --targets sd-svs-disp state.highstate
 
 clean-salt: assert-dom0 ## Purges SD Salt configuration from dom0

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ sd-whonix: prep-salt ## Provisions SD Whonix VM
 sd-svs-disp: prep-salt ## Provisions SD Submission Viewing VM
 	sudo qubesctl top.enable sd-svs-disp
 	sudo qubesctl top.enable sd-svs-disp-files
+	sudo qubesctl --targets debian-9 state.highstate
 	sudo qubesctl --targets sd-svs-disp state.highstate
 
 clean-salt: assert-dom0 ## Purges SD Salt configuration from dom0

--- a/dom0/sd-gpg.sls
+++ b/dom0/sd-gpg.sls
@@ -13,7 +13,7 @@ sd-gpg:
   qvm.vm:
     - name: sd-gpg
     - present:
-      - template: fedora-28
+      - template: debian-9
       - label: purple
     - prefs:
       - netvm: ""

--- a/dom0/sd-journalist.sls
+++ b/dom0/sd-journalist.sls
@@ -39,7 +39,7 @@ sd-journalist:
 #
 install python-qt4 and python-futures:
   cmd.run:
-    - name: qvm-run -a whonix-ws-14 'sudo apt-get update && sudo apt-get install -qq python-futures python-qt4'
+    - name: qvm-run -a whonix-ws-14 'sudo apt-get update && sudo apt-get install -qq python-futures python3-pyqt4 gvfs-bin libgnomevfs2-bin'
 
 # When our Qubes bug is fixed, this will *not* be used
 sd-journalist-dom0-qubes.OpenInVM:

--- a/dom0/sd-svs-disp-files.sls
+++ b/dom0/sd-svs-disp-files.sls
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+##
+# sd-svs-disp-files
+# ========
+#
+# Moves files into place on sd-svs-disp
+#
+##
+
+# xdg-open falls back to run-mailcap on debian-9, so CLI invocations
+# will not use gedit as intended. Let's force use of gedit via mailcap.
+sd-svs-force-gedit-for-xdg-open:
+  file.prepend:
+    - name: /etc/mailcap
+    - text: "text/plain; gedit %s; test=test -x /usr/bin/gedit"
+
+sudo update-mime-database /usr/local/share/mime:
+  cmd.run
+
+sudo update-desktop-database /usr/local/share/applications:
+  cmd.run

--- a/dom0/sd-svs-disp-files.top
+++ b/dom0/sd-svs-disp-files.top
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+base:
+  sd-svs-disp:
+    - sd-svs-disp-files

--- a/dom0/sd-svs-disp-files.top
+++ b/dom0/sd-svs-disp-files.top
@@ -2,5 +2,6 @@
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 
 base:
-  sd-svs-disp:
+  # Target Debian-9, since changes to sd-svs-disp won't persist
+  debian-9:
     - sd-svs-disp-files

--- a/dom0/sd-svs-disp.sls
+++ b/dom0/sd-svs-disp.sls
@@ -15,7 +15,7 @@ sd-svs-disp:
   qvm.vm:
     - name: sd-svs-disp
     - present:
-      - template: fedora-28
+      - template: debian-9
       - label: green
     - prefs:
       - netvm: ""

--- a/dom0/sd-svs-files.sls
+++ b/dom0/sd-svs-files.sls
@@ -55,13 +55,6 @@
     - mode: 644
     - makedirs: True
 
-# xdg-open falls back to run-mailcap on debian-9, so CLI invocations
-# will not use gedit as intended. Let's force use of gedit via mailcap.
-sd-svs-force-gedit-for-xdg-open:
-  file.prepend:
-    - name: /etc/mailcap
-    - text: "text/plain; gedit %s; test=test -x /usr/bin/gedit"
-
 sudo update-mime-database /usr/local/share/mime:
   cmd.run
 

--- a/dom0/sd-svs-files.sls
+++ b/dom0/sd-svs-files.sls
@@ -55,6 +55,13 @@
     - mode: 644
     - makedirs: True
 
+# xdg-open falls back to run-mailcap on debian-9, so CLI invocations
+# will not use gedit as intended. Let's force use of gedit via mailcap.
+sd-svs-force-gedit-for-xdg-open:
+  file.prepend:
+    - name: /etc/mailcap
+    - text: "text/plain; gedit %s; test=test -x /usr/bin/gedit"
+
 sudo update-mime-database /usr/local/share/mime:
   cmd.run
 

--- a/dom0/sd-svs.sls
+++ b/dom0/sd-svs.sls
@@ -13,7 +13,7 @@ sd-svs:
   qvm.vm:
     - name: sd-svs
     - present:
-      - template: fedora-28
+      - template: debian-9
       - label: yellow
     - prefs:
       - netvm: ""

--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -10,9 +10,13 @@ def find_fp_from_gpg_output(gpg):
     lines = gpg.split("\n")
 
     for line in lines:
-        m = re.match('\s*Key fingerprint = (.*)$', line)
+        # dom0 uses Fedora25 with gpg 1.4.22, whereas AppVMs
+        # use Debian9 with gpg 2.1.18, so we'll match fingerprint
+        # by a loose regex rather than substring match.
+        regex = '\s*(Key fingerprint = )?([A-F0-9\s]{50})$'
+        m = re.match(regex, line)
         if m is not None:
-            fp = m.groups()[0]
+            fp = m.groups()[1]
             return fp
 
 

--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -5,7 +5,6 @@ from qubesadmin import Qubes
 
 
 SUPPORTED_PLATFORMS = [
-    "Fedora 28 (Twenty Eight)",
     "Debian GNU/Linux 9 (stretch)",
 ]
 


### PR DESCRIPTION
All of the `sd-*` VMs for the SecureDrop Workstation now use Debian 9 as
the base template. This will allow us to use deb packages across the
board for all AppVMs, as well as the hardened based image with a custom
kernel in the near future, as well.

Updates the test suites to accommodate for gpg v1/v2 output variance, as
well as removes Fedora 28 as a permitted base for the AppVMs in the
platform tests.

### Testing

1. Run `make all` in `dom0` and confirm no errors.
2. Run `make test` in `dom0` and confirm no errors.
3. Run **Qubes Manager** and visually confirm all the `sd-` VMs are running Debian 9 (or Whonix 14, which is itself based on Debian 9). 
4. Confirm you can download and view a test submission.

Regarding 4, there's a bit of manual work that may be required, in order to get a file browser for in the SVS.

1. Run `sudo apt install -y nautilus` inside the `debian-9` template.
2. Via Qubes menu, navigate to **Template: Debian-9 > Qubes Settings > Applications** and click ** Refresh Applications.
3. Via Qubes menu, navigate to **Domain: sd-svs > Qubes Settings > Applications** and click ** Refresh Applications.

I propose _not_ automating this step since it's a temporary workaround. We're planning to implement TemplateVMs in #131, as well as ditching file browsing in favor of the [SecureDrop Client](https://github.com/freedomofpress/securedrop-client) on the SVS.