### PR TITLE
Get builder dependencies after retrieving sources

### DIFF
--- a/builder/build-workstation-template
+++ b/builder/build-workstation-template
@@ -31,9 +31,6 @@ cd "${qubes_builder_dir}"
 # Provision securedrop-workstation config so that we get the correct sources via `make get-sources`.
 cp ${sd_template_dir}/securedrop-workstation.conf builder.conf
 
-# Install dependencies from Qubes builder logic.
-make install-deps
-
 # Get sources for only the builder component, which will get Qubes dev keys and initialize the keyring
 make COMPONENTS="builder" get-sources
 
@@ -43,6 +40,9 @@ echo 'AF775782949D263DAABB3387AAFB3575FAC82745:6:' | gpg --homedir ${gpg_homedir
 
 # Get all sources
 make get-sources
+
+# Install dependencies from Qubes builder logic.
+make install-deps
 
 # Build it!
 make qubes-vm

--- a/builder/build-workstation-template
+++ b/builder/build-workstation-template
@@ -47,3 +47,8 @@ make install-deps
 # Build it!
 make qubes-vm
 make template
+
+# Report location of RPM package
+rpm_location="$(sudo find -type f -name 'qubes-template-securedrop-workstation*.rpm')"
+echo "Build finished. RPM package available at:"
+echo "$rpm_location"


### PR DESCRIPTION
Sources and builder plugins used in making the template require different dependencies, thus the
`make install-deps` should be moved after `make get-sources`.

Test:
* Create new fedora-28 based appvm
* Increase private storage size (20GB is good)
* git clone this repo and checkout this branch
* cd into `builder/` and run `build-workstation-template` script