### PR TITLE
Installs securedrop-proxy package in sd-journalist

### DIFF
--- a/dom0/fpf-apt-test-repo.sls
+++ b/dom0/fpf-apt-test-repo.sls
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+
+# That's right, we need to install a package in order to
+# configure a repo to install another package
+install-python-apt-for-repo-config:
+  pkg.installed:
+    - pkgs:
+      - python-apt
+
+configure apt-test apt repo:
+  pkgrepo.managed:
+    - name: "deb [arch=amd64] https://apt-test-qubes.freedom.press stretch main"
+    - file: /etc/apt/sources.list.d/fpf-apt-test.list
+    - key_url: "salt://sd/sd-workstation/apt-test-pubkey.asc"
+  require:
+    - install-python-apt-for-repo-config

--- a/dom0/sd-journalist-files.top
+++ b/dom0/sd-journalist-files.top
@@ -5,4 +5,5 @@ base:
   sd-journalist:
     - sd-journalist-files
   sd-journalist-template:
+    - fpf-apt-test-repo
     - sd-journalist-template-files

--- a/dom0/sd-journalist-template-files.sls
+++ b/dom0/sd-journalist-template-files.sls
@@ -77,3 +77,12 @@
 
 sudo update-desktop-database /usr/share/applications:
   cmd.run
+
+# Depends on FPF-controlled apt repo, already present
+# in underlying "securedrop-workstation" base template.
+install-securedrop-proxy-package:
+  pkg.installed:
+    - pkgs:
+      - securedrop-proxy
+  require:
+    - sls: fpf-apt-test-repo

--- a/dom0/sd-journalist-template-files.sls
+++ b/dom0/sd-journalist-template-files.sls
@@ -86,3 +86,15 @@ install-securedrop-proxy-package:
       - securedrop-proxy
   require:
     - sls: fpf-apt-test-repo
+
+{% import_json "sd/config.json" as d %}
+
+install-securedrop-proxy-yaml-config:
+  file.append:
+    - name: /etc/sd-proxy.yaml
+    - text: |
+        host: {{ d.hidserv.hostname }}
+        scheme: http
+        port: 80
+        target_vm: sd-svs
+        dev: False

--- a/dom0/sd-journalist-template.sls
+++ b/dom0/sd-journalist-template.sls
@@ -29,6 +29,6 @@ sd-journalist-template:
 sd-journalist-template-sync-appmenus:
   cmd.run:
     - name: >
-        qvm-start sd-journalist-template &&
+        qvm-start --skip-if-running sd-journalist-template &&
         qvm-sync-appmenus sd-journalist-template &&
         qvm-shutdown sd-journalist-template

--- a/dom0/sd-journalist.sls
+++ b/dom0/sd-journalist.sls
@@ -54,3 +54,17 @@ sd-journalist-dom0-qubes.OpenInVM-disp:
   file.prepend:
     - name: /etc/qubes-rpc/policy/qubes.OpenInVM
     - text: "sd-journalist sd-svs allow\n"
+
+# Permit the SecureDrop Proxy to manage Client connections
+sd-journalist-dom0-securedrop.Proxy:
+  file.prepend:
+    - name: /etc/qubes-rpc/policy/securedrop.Proxy
+    - text: |
+        sd-svs sd-journalist allow
+        $anyvm $anyvm deny
+
+# Permit the SecureDrop Proxy to copy files to Client.
+sd-journalist-dom0-qubes.Filecopy:
+  file.prepend:
+    - name: /etc/qubes-rpc/policy/qubes.Filecopy
+    - text: "sd-journalist sd-svs allow\n"

--- a/dom0/sd-svs.sls
+++ b/dom0/sd-svs.sls
@@ -43,6 +43,6 @@ sd-svs-dom0-qubes.qubesGpg:
 sd-svs-template-sync-appmenus:
   cmd.run:
     - name: >
-        qvm-start sd-svs-template &&
+        qvm-start --skip-if-running sd-svs-template &&
         qvm-sync-appmenus sd-svs-template &&
         qvm-shutdown sd-svs-template

--- a/dom0/sd-workstation-template-files.sls
+++ b/dom0/sd-workstation-template-files.sls
@@ -1,12 +1,3 @@
-# -*- coding: utf-8 -*-
-# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
-
-configure apt-test apt repo:
-  pkgrepo.managed:
-    - name: "deb [arch=amd64] https://apt-test-qubes.freedom.press stretch main"
-    - file: /etc/apt/sources.list.d/fpf-apt-test.list
-    - key_url: "salt://sd/sd-workstation/apt-test-pubkey.asc"
-
 configure mimetype support for debian9:
   pkg.installed:
     - pkgs:

--- a/dom0/sd-workstation-template-files.top
+++ b/dom0/sd-workstation-template-files.top
@@ -3,4 +3,5 @@
 
 base:
   sd-workstation-template:
+    - fpf-apt-test-repo
     - sd-workstation-template-files

--- a/tests/base.py
+++ b/tests/base.py
@@ -62,6 +62,16 @@ class SD_VM_Local_Test(unittest.TestCase):
                                             "/bin/cat {}".format(path)])
         return contents
 
+    def _package_is_installed(self, pkg):
+        """
+        Confirms that a given package is installed inside the VM.
+        """
+        # dpkg --verify will exit non-zero for a non-installed pkg,
+        # and dom0 will percolate that error code
+        subprocess.check_call(["qvm-run", "-a", "-q", self.vm_name,
+                               "dpkg --verify {}".format(pkg)])
+        return True
+
     def assertFilesMatch(self, remote_path, local_path):
         remote_content = self._get_file_contents(remote_path)
 

--- a/tests/test_journalist_vm.py
+++ b/tests/test_journalist_vm.py
@@ -28,6 +28,9 @@ class SD_Journalist_Tests(SD_VM_Local_Test):
         self.assertFilesMatch("/usr/bin/sd-process-display",
                               "sd-journalist/sd-process-display")
 
+    def test_sd_proxy_package_installed(self):
+        self.assertTrue(self._package_is_installed("securedrop-proxy"))
+
 
 def load_tests(loader, tests, pattern):
     suite = unittest.TestLoader().loadTestsFromTestCase(SD_Journalist_Tests)

--- a/tests/test_journalist_vm.py
+++ b/tests/test_journalist_vm.py
@@ -1,4 +1,5 @@
 import unittest
+import json
 
 from base import SD_VM_Local_Test
 
@@ -30,6 +31,21 @@ class SD_Journalist_Tests(SD_VM_Local_Test):
 
     def test_sd_proxy_package_installed(self):
         self.assertTrue(self._package_is_installed("securedrop-proxy"))
+
+    def test_sd_proxy_yaml_config(self):
+        with open("config.json") as c:
+            config = json.load(c)
+            hostname = config['hidserv']['hostname']
+
+        wanted_lines = [
+            "host: {}".format(hostname),
+            "scheme: http",
+            "port: 80",
+            "target_vm: sd-svs",
+            "dev: False",
+        ]
+        for line in wanted_lines:
+            self.assertFileHasLine("/etc/sd-proxy.yaml", line)
 
 
 def load_tests(loader, tests, pattern):


### PR DESCRIPTION
**Review and merge #169 first.** 

Summary of changes:

* Installs the `securedrop-proxy` package via https://apt-test-qubes.freedom.press into the `sd-journalist` VM (which is still called `sd-journalist`; once the client code lands in `sd-svs`, we can rename). 
* Configures dom0 RPC policies as [described in the proxy docs](https://github.com/freedomofpress/securedrop-proxy#qubes-integration)
* Reads the Onion URL from local `config.json` and stores that in `/etc/sd-proxy.yaml` inside `sd-journalist`.
* Writes a few new tests so we can confirm the package is indeed present

Closes #161.

### Testing

1. Run `make all` in `dom0` and confirm no errors.
2. Run `make test` in `dom0` and confirm no errors.
3. Confirm you can download and view a test submission. A plaintext submission should be displayed in `gedit` _in a DisposableVM_. 

Have not verified proxy functionality; waiting on client integration to make the bits flow.
