### PR TITLE
Restrict and test and qubes-rpc policies for dom0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,14 @@ endif
 all: assert-dom0 validate clean update-fedora-templates			\
 	update-whonix-templates prep-whonix prep-dom0 sd-workstation-template \
 	sd-whonix sd-svs sd-gpg	\
-	sd-journalist sd-svs-disp
+	sd-journalist sd-svs-disp qubes-rpc
 
 clone: assert-dom0 ## Pulls the latest repo from work VM to dom0
 	@./scripts/clone-to-dom0
+
+qubes-rpc: prep-salt ## Places default deny qubes-rpc policies for sd-svs and sd-gpg
+	sudo qubesctl top.enable sd-dom0-qvm-rpc
+	sudo qubesctl --show-output --targets sd-dom0-qvm-rpc state.highstate
 
 sd-workstation-template: prep-salt ## Provisions base template for SDW AppVMs
 	sudo qubesctl top.enable sd-workstation-template

--- a/dom0/sd-dom0-qvm-rpc.sls
+++ b/dom0/sd-dom0-qvm-rpc.sls
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+##
+# Explicitly deny as a catch-all for SecureDrop workstation provisioned VMs.
+# All SecureDrop-workstation provisioned VMS should have the sd-workstation tag.
+# To be both be mindful of developers using the workstation and ensure
+# RPC policies are not too permissive, this should be the first action
+# performed by the install. All other provisioning steps will prepend to this
+# list grants.
+# using blockreplace will ensure that we will be able to more reliably update
+# these policies during updates.
+##
+dom0-rpc-qubes.ClipboardPaste:
+  file.blockreplace:
+    - name: /etc/qubes-rpc/policy/qubes.ClipboardPaste
+    - prepend_if_not_found: True
+    - marker_start: "### BEGIN securedrop-workstation ###"
+    - marker_end: "### END securedrop-workstation ###"
+    - content: |
+        $anyvm sd-journalist ask
+        $anyvm $tag:sd-workstation deny
+dom0-rpc-qubes.FeaturesRequest:
+  file.blockreplace:
+    - name: /etc/qubes-rpc/policy/qubes.FeaturesRequest
+    - prepend_if_not_found: True
+    - marker_start: "### BEGIN securedrop-workstation ###"
+    - marker_end: "### END securedrop-workstation ###"
+    - content: |
+        $anyvm $tag:sd-workstation deny
+dom0-rpc-qubes.Filecopy:
+  file.blockreplace:
+    - name: /etc/qubes-rpc/policy/qubes.Filecopy
+    - prepend_if_not_found: True
+    - marker_start: "### BEGIN securedrop-workstation ###"
+    - marker_end: "### END securedrop-workstation ###"
+    - content: |
+        sd-journalist sd-svs allow
+        $anyvm $tag:sd-workstation deny
+dom0-rpc-qubes.OpenInVM:
+  file.blockreplace:
+    - name: /etc/qubes-rpc/policy/qubes.OpenInVM
+    - prepend_if_not_found: True
+    - marker_start: "### BEGIN securedrop-workstation ###"
+    - marker_end: "### END securedrop-workstation ###"
+    - content: |
+        sd-journalist sd-svs allow
+        $tag:sd-svs-disp-vm sd-svs allow
+        sd-svs $dispvm:sd-svs-disp allow
+        $anyvm $tag:sd-workstation deny
+dom0-rpc-qubes.OpenURL:
+  file.blockreplace:
+    - name: /etc/qubes-rpc/policy/qubes.OpenURL
+    - prepend_if_not_found: True
+    - marker_start: "### BEGIN securedrop-workstation ###"
+    - marker_end: "### END securedrop-workstation ###"
+    - content: |
+        $anyvm $tag:sd-workstation deny
+dom0-rpc-qubes.PdfConvert:
+  file.blockreplace:
+    - name: /etc/qubes-rpc/policy/qubes.PdfConvert
+    - prepend_if_not_found: True
+    - marker_start: "### BEGIN securedrop-workstation ###"
+    - marker_end: "### END securedrop-workstation ###"
+    - content: |
+        $anyvm $tag:sd-workstation deny
+dom0-rpc-qubes.StartApp:
+  file.blockreplace:
+    - name: /etc/qubes-rpc/policy/qubes.StartApp
+    - prepend_if_not_found: True
+    - marker_start: "### BEGIN securedrop-workstation ###"
+    - marker_end: "### END securedrop-workstation ###"
+    - content: |
+        $anyvm $tag:sd-workstation deny
+dom0-rpc-qubes.USB:
+  file.blockreplace:
+    - name: /etc/qubes-rpc/policy/qubes.USB
+    - prepend_if_not_found: True
+    - marker_start: "### BEGIN securedrop-workstation ###"
+    - marker_end: "### END securedrop-workstation ###"
+    - content: |
+        $anyvm $tag:sd-workstation deny
+dom0-rpc-qubes.VMRootShell:
+  file.blockreplace:
+    - name: /etc/qubes-rpc/policy/qubes.VMRootShell
+    - prepend_if_not_found: True
+    - marker_start: "### BEGIN securedrop-workstation ###"
+    - marker_end: "### END securedrop-workstation ###"
+    - content: |
+        $anyvm $tag:sd-workstation deny
+dom0-rpc-qubes.VMshell:
+  file.blockreplace:
+    - name: /etc/qubes-rpc/policy/qubes.VMShell
+    - prepend_if_not_found: True
+    - marker_start: "### BEGIN securedrop-workstation ###"
+    - marker_end: "### END securedrop-workstation ###"
+    - content: |
+        $anyvm $tag:sd-workstation deny
+dom0-rpc-qubes.Gpg:
+  file.blockreplace:
+    - name: /etc/qubes-rpc/policy/qubes.Gpg
+    - prepend_if_not_found: True
+    - marker_start: "### BEGIN securedrop-workstation ###"
+    - marker_end: "### END securedrop-workstation ###"
+    - content: |
+        sd-svs sd-gpg allow
+        $anyvm $tag:sd-workstation deny
+dom0-rpc-qubes.GpgImportKey:
+  file.blockreplace:
+    - name: /etc/qubes-rpc/policy/qubes.GpgImportKey
+    - prepend_if_not_found: True
+    - marker_start: "### BEGIN securedrop-workstation ###"
+    - marker_end: "### END securedrop-workstation ###"
+    - content: |
+        $anyvm $tag:sd-workstation deny

--- a/dom0/sd-dom0-qvm-rpc.top
+++ b/dom0/sd-dom0-qvm-rpc.top
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+base:
+  dom0:
+    - sd-dom0-qvm-rpc

--- a/dom0/sd-gpg.sls
+++ b/dom0/sd-gpg.sls
@@ -17,3 +17,6 @@ sd-gpg:
       - label: purple
     - prefs:
       - netvm: ""
+    - tags:
+      - add:
+        - sd-workstation

--- a/dom0/sd-journalist-template.sls
+++ b/dom0/sd-journalist-template.sls
@@ -20,6 +20,9 @@ sd-journalist-template:
     - clone:
       - source: whonix-ws-14
       - label: blue
+    - tags:
+      - add:
+        - sd-workstation
   require:
     - pkg: qubes-template-whonix-ws-14
     - qvm: sd-whonix

--- a/dom0/sd-journalist.sls
+++ b/dom0/sd-journalist.sls
@@ -21,6 +21,9 @@ sd-journalist:
       - label: blue
     - prefs:
       - netvm: sd-whonix
+    - tags:
+      - add:
+        - sd-workstation
     - require:
       - pkg: qubes-template-whonix-ws-14
       - qvm: sd-whonix

--- a/dom0/sd-journalist.sls
+++ b/dom0/sd-journalist.sls
@@ -50,19 +50,6 @@ sd-journalist-install-python-futures:
         { sudo apt-get update && sudo apt-get install -qq python-futures ; }" &&
         qvm-shutdown --wait whonix-ws-14
 
-# When our Qubes bug is fixed, this will *not* be used
-sd-journalist-dom0-qubes.OpenInVM:
-  file.prepend:
-    - name: /etc/qubes-rpc/policy/qubes.OpenInVM
-    - text: "sd-journalist sd-decrypt allow\n"
-
-# Allow sd-journalist to open files in sd-decrypt-bsed dispVM's
-# When our Qubes bug is fixed, this will be used.
-sd-journalist-dom0-qubes.OpenInVM-disp:
-  file.prepend:
-    - name: /etc/qubes-rpc/policy/qubes.OpenInVM
-    - text: "sd-journalist sd-svs allow\n"
-
 # Permit the SecureDrop Proxy to manage Client connections
 sd-journalist-dom0-securedrop.Proxy:
   file.prepend:
@@ -70,9 +57,3 @@ sd-journalist-dom0-securedrop.Proxy:
     - text: |
         sd-svs sd-journalist allow
         $anyvm $anyvm deny
-
-# Permit the SecureDrop Proxy to copy files to Client.
-sd-journalist-dom0-qubes.Filecopy:
-  file.prepend:
-    - name: /etc/qubes-rpc/policy/qubes.Filecopy
-    - text: "sd-journalist sd-svs allow\n"

--- a/dom0/sd-svs-disp.sls
+++ b/dom0/sd-svs-disp.sls
@@ -41,8 +41,3 @@ qvm-prefs sd-svs-disp template_for_dispvms True:
 # This feels like a Qubes bug.
 qvm-tags sd-svs-disp add sd-svs-disp-vm:
   cmd.run
-
-sd-svs-disp-dom0-qubes.OpenInVM:
-  file.prepend:
-    - name: /etc/qubes-rpc/policy/qubes.OpenInVM
-    - text: "$tag:sd-svs-disp-vm sd-svs allow\n"

--- a/dom0/sd-svs-disp.sls
+++ b/dom0/sd-svs-disp.sls
@@ -26,6 +26,9 @@ sd-svs-disp:
       - label: green
     - prefs:
       - netvm: ""
+    - tags:
+      - add:
+        - sd-workstation
 
 # tell qubes this VM can be used as a disp VM template
 qvm-prefs sd-svs-disp template_for_dispvms True:

--- a/dom0/sd-svs-files.sls
+++ b/dom0/sd-svs-files.sls
@@ -60,10 +60,3 @@ sudo update-mime-database /usr/share/mime:
 
 sudo update-desktop-database /usr/share/applications:
   cmd.run
-
-install nautilus in sd-svs:
-  pkg.installed:
-    - pkgs:
-      # Nautilus necessary for manual file browsing, remove when
-      # the securedrop-client code package is installed
-      - nautilus

--- a/dom0/sd-svs.sls
+++ b/dom0/sd-svs.sls
@@ -33,17 +33,6 @@ sd-svs:
   require:
     - qvm: sd-svs-template
 
-sd-svs-dom0-qubes.OpenInVM:
-  file.prepend:
-    - name: /etc/qubes-rpc/policy/qubes.OpenInVM
-    - text: "sd-svs $dispvm:sd-svs-disp allow\n"
-
-# Allow sd-svs to access gpg keys on sd-gpg
-sd-svs-dom0-qubes.qubesGpg:
-  file.prepend:
-    - name: /etc/qubes-rpc/policy/qubes.Gpg
-    - text: "sd-svs sd-gpg allow\n"
-
 # Ensure the Qubes menu is populated with relevant app entries,
 # so that Nautilus/Files can be started via GUI interactions.
 sd-svs-template-sync-appmenus:

--- a/dom0/sd-svs.sls
+++ b/dom0/sd-svs.sls
@@ -15,6 +15,9 @@ sd-svs-template:
     - clone:
       - source: sd-workstation-template
       - label: yellow
+    - tags:
+      - add:
+        - sd-workstation
 
 sd-svs:
   qvm.vm:
@@ -24,6 +27,9 @@ sd-svs:
       - label: yellow
     - prefs:
       - netvm: ""
+    - tags:
+      - add:
+        - sd-workstation
   require:
     - qvm: sd-svs-template
 

--- a/dom0/sd-whonix.sls
+++ b/dom0/sd-whonix.sls
@@ -28,6 +28,9 @@ sd-whonix-template:
     - clone:
       - source: whonix-gw-14
       - label: purple
+    - tags:
+      - add:
+        - sd-workstation
     - require:
       - pkg: qubes-template-whonix-gw-14
       - qvm: sys-firewall
@@ -43,6 +46,9 @@ sd-whonix:
       - provides-network: true
       - netvm: "sys-firewall"
       - autostart: true
+    - tags:
+      - add:
+        - sd-workstation
     - require:
       - pkg: qubes-template-whonix-gw-14
       - qvm: sys-firewall

--- a/dom0/sd-workstation-template.sls
+++ b/dom0/sd-workstation-template.sls
@@ -19,3 +19,6 @@ sd-workstation-template:
     - prefs:
       - virt-mode: hvm
       - kernel: ''
+    - tags:
+      - add:
+        - sd-workstation

--- a/tests/test_qubes_rpc.py
+++ b/tests/test_qubes_rpc.py
@@ -1,0 +1,52 @@
+import io
+import os
+import unittest
+import yaml
+
+QUBES_POLICY_PREFIX = "/etc/qubes-rpc/policy/qubes."
+
+
+class SD_Qubes_Rpc_Tests(unittest.TestCase):
+
+    def setUp(self):
+        self.expected = self._loadVars()
+
+    def tearDown(self):
+        pass
+
+    def test_Policies(self):
+        # Using a for loop instead of pytest.parametrize due to
+        # the absence of pytest in dom0.
+        fail = False
+        for policy in self.expected:
+            if not self._startsWith(policy['policy'],
+                                    policy['starts_with']):
+                fail = True
+        self.assertFalse(fail)
+
+    def _startsWith(self, filename, expectedPolicy):
+        filePath = os.path.join(QUBES_POLICY_PREFIX + filename)
+        with io.open(filePath, 'r') as f:
+            actualPolicy = f.read()
+            if actualPolicy.startswith(expectedPolicy):
+                return True
+            else:
+                print("\n\n#### BEGIN RPC policy error report ####\n\n")
+                print("Policy for {} is:\n{}".format(filename,
+                                                     actualPolicy))
+                print("Policy for {} should be:\n{}".format(filename,
+                                                            expectedPolicy))
+                print("\n\n#### END RPC policy error report ####\n\n")
+                return False
+
+    def _loadVars(self):
+        filepath = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                "vars", "qubes-rpc.yml")
+        with io.open(filepath, 'r') as f:
+            data = yaml.safe_load(f)
+        return data
+
+
+def load_tests(loader, tests, pattern):
+    suite = unittest.TestLoader().loadTestsFromTestCase(SD_Qubes_Rpc_Tests)
+    return suite

--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -41,6 +41,7 @@ class SD_VM_Tests(unittest.TestCase):
         self.assertTrue(vm.template == "sd-whonix-template")
         self.assertTrue(vm.provides_network)
         self.assertFalse(vm.template_for_dispvms)
+        self.assertTrue('sd-workstation' in vm.tags)
 
     def test_sd_journalist_config(self):
         vm = self.app.domains["sd-journalist"]
@@ -49,6 +50,7 @@ class SD_VM_Tests(unittest.TestCase):
         self.assertTrue(vm.template == "sd-journalist-template")
         self.assertFalse(vm.provides_network)
         self.assertFalse(vm.template_for_dispvms)
+        self.assertTrue('sd-workstation' in vm.tags)
 
     def test_sd_svs_config(self):
         vm = self.app.domains["sd-svs"]
@@ -58,6 +60,7 @@ class SD_VM_Tests(unittest.TestCase):
         self.assertFalse(vm.provides_network)
         self.assertFalse(vm.template_for_dispvms)
         self._check_kernel(vm)
+        self.assertTrue('sd-workstation' in vm.tags)
 
     def test_sd_svs_disp_config(self):
         vm = self.app.domains["sd-svs-disp"]
@@ -67,6 +70,7 @@ class SD_VM_Tests(unittest.TestCase):
         self.assertFalse(vm.provides_network)
         self.assertTrue(vm.template_for_dispvms)
         self._check_kernel(vm)
+        self.assertTrue('sd-workstation' in vm.tags)
 
     def test_sd_gpg_config(self):
         vm = self.app.domains["sd-gpg"]
@@ -77,12 +81,35 @@ class SD_VM_Tests(unittest.TestCase):
         self.assertFalse(vm.provides_network)
         self.assertFalse(vm.template_for_dispvms)
         self._check_kernel(vm)
+        self.assertTrue('sd-workstation' in vm.tags)
 
     def test_sd_workstation_template(self):
         vm = self.app.domains["sd-workstation-template"]
         nvm = vm.netvm
         self.assertTrue(nvm is None)
         self._check_kernel(vm)
+        self.assertTrue('sd-workstation' in vm.tags)
+        self._check_kernel(vm)
+
+    def test_sd_journalist_template(self):
+        vm = self.app.domains["sd-journalist-template"]
+        nvm = vm.netvm
+        self.assertTrue(nvm is None)
+        self.assertTrue('sd-workstation' in vm.tags)
+
+    def sd_svs_template(self):
+        vm = self.app.domains["sd-svs-template"]
+        nvm = vm.netvm
+        self.assertTrue(nvm is None)
+        self.assertTrue('sd-workstation' in vm.tags)
+        self._check_kernel(vm)
+
+    def sd_svs_disp_template(self):
+        vm = self.app.domains["sd-svs-disp-template"]
+        nvm = vm.netvm
+        self.assertTrue(nvm is None)
+        self.assertTrue('sd-workstation' in vm.tags)
+        self.assertTrue(vm.template_for_dispvms)
 
 
 def load_tests(loader, tests, pattern):

--- a/tests/vars/qubes-rpc.yml
+++ b/tests/vars/qubes-rpc.yml
@@ -1,0 +1,169 @@
+- policy: ClipboardPaste
+  starts_with: |-
+    ### BEGIN securedrop-workstation ###
+    $anyvm sd-journalist ask
+    $anyvm $tag:sd-workstation deny
+    ### END securedrop-workstation ###
+
+- policy: FeaturesRequest
+  starts_with: |-
+    ### BEGIN securedrop-workstation ###
+    $anyvm $tag:sd-workstation deny
+    ### END securedrop-workstation ###
+
+- policy: Filecopy
+  starts_with: |-
+    ### BEGIN securedrop-workstation ###
+    sd-journalist sd-svs allow
+    $anyvm $tag:sd-workstation deny
+    ### END securedrop-workstation ###
+
+- policy: GetDate
+  starts_with: |-
+    $tag:anon-vm $anyvm deny
+    ## Note that policy parsing stops at the first match,
+    ## so adding anything below "$anyvm $anyvm action" line will have no effect
+
+    ## Please use a single # to start your custom comments
+
+    $anyvm	$anyvm	allow,target=dom0
+
+- policy: GetRandomizedTime
+  starts_with: |-
+    ## Note that policy parsing stops at the first match,
+    ## so adding anything below "$anyvm $anyvm action" line will have no effect
+
+    ## Please use a single # to start your custom comments
+
+    $anyvm	dom0	allow
+
+- policy: GetImageRGBA
+  starts_with: |-
+    ## Note that policy parsing stops at the first match,
+    ## so adding anything below "$anyvm $anyvm action" line will have no effect
+
+    ## Please use a single # to start your custom comments
+
+    $anyvm $dispvm allow
+    $anyvm $anyvm ask
+
+- policy: Gpg
+  starts_with: |-
+    ### BEGIN securedrop-workstation ###
+    sd-svs sd-gpg allow
+    $anyvm $tag:sd-workstation deny
+    ### END securedrop-workstation ###
+
+- policy: GpgImportKey
+  starts_with: |-
+    ### BEGIN securedrop-workstation ###
+    $anyvm $tag:sd-workstation deny
+    ### END securedrop-workstation ###
+
+- policy: InputKeyboard
+  starts_with: |-
+    $anyvm $anyvm deny
+
+- policy: InputMouse
+  starts_with: |-
+    sys-usb dom0 allow,user=root
+    $anyvm $anyvm deny
+
+- policy: NotifyTools
+  starts_with: |-
+    ## Note that policy parsing stops at the first match,
+    ## so adding anything below "$anyvm $anyvm action" line will have no effect
+
+    ## Please use a single # to start your custom comments
+
+    $anyvm	dom0	allow
+
+- policy: NotifyUpdates
+  starts_with: |-
+    ## Note that policy parsing stops at the first match,
+    ## so adding anything below "$anyvm $anyvm action" line will have no effect
+
+    ## Please use a single # to start your custom comments
+
+    $anyvm	dom0	allow
+
+- policy: OpenInVM
+  starts_with: |-
+    ### BEGIN securedrop-workstation ###
+    sd-journalist sd-svs allow
+    $tag:sd-svs-disp-vm sd-svs allow
+    sd-svs $dispvm:sd-svs-disp allow
+    $anyvm $tag:sd-workstation deny
+    ### END securedrop-workstation ###
+
+- policy: OpenURL
+  starts_with: |-
+    ### BEGIN securedrop-workstation ###
+    $anyvm $tag:sd-workstation deny
+    ### END securedrop-workstation ###
+
+- policy: PdfConvert
+  starts_with: |-
+    ### BEGIN securedrop-workstation ###
+    $anyvm $tag:sd-workstation deny
+    ### END securedrop-workstation ###
+
+- policy: ReceiveUpdates
+  starts_with: |-
+    ## Note that policy parsing stops at the first match,
+    ## so adding anything below "$anyvm $anyvm action" line will have no effect
+
+    ## Please use a single # to start your custom comments
+
+    $anyvm	dom0	allow
+
+- policy: StartApp
+  starts_with: |-
+    ### BEGIN securedrop-workstation ###
+    $anyvm $tag:sd-workstation deny
+    ### END securedrop-workstation ###
+
+- policy: SyncAppMenus
+  starts_with: |-
+    ## Note that policy parsing stops at the first match,
+    ## so adding anything below "$anyvm $anyvm action" line will have no effect
+
+    ## Please use a single # to start your custom comments
+
+    $anyvm	dom0	allow
+
+- policy: UpdatesProxy
+  starts_with: |-
+    $tag:whonix-updatevm $default allow,target=sys-whonix
+    $tag:whonix-updatevm $anyvm deny
+    ## Note that policy parsing stops at the first match,
+    ## so adding anything below "$anyvm $anyvm action" line will have no effect
+
+    ## Please use a single # to start your custom comments
+
+    # Default rule for all TemplateVMs - direct the connection to sys-net
+    $type:TemplateVM $default allow,target=sys-net
+
+    $anyvm $anyvm deny
+
+- policy: USB
+  starts_with: |-
+    ### BEGIN securedrop-workstation ###
+    $anyvm $tag:sd-workstation deny
+    ### END securedrop-workstation ###
+
+- policy: VMRootShell
+  starts_with: |-
+    ### BEGIN securedrop-workstation ###
+    $anyvm $tag:sd-workstation deny
+    ### END securedrop-workstation ###
+
+- policy: VMShell
+  starts_with: |-
+    ### BEGIN securedrop-workstation ###
+    $anyvm $tag:sd-workstation deny
+    ### END securedrop-workstation ###
+
+- policy: WindowIconUpdater
+  starts_with: |-
+    $anyvm dom0 allow


### PR DESCRIPTION
## Status

Ready for review. 

Fixes #175, #147 
- Add tag for workstation provisioned templates and AppVM (`sd-workstation`)
- Create tests to ensure workstation-provisioned templates and AppVMs have label properly applied
- Consolidated qubes-rpc policies in `dom0/sd-dom0-qvm-rpc.sls`, to make it easier to manage and slightly more idempotent.
- Create tests to ensure workstation provisioned templates and AppVMs have deny-by-default and least privilege qubes-rpc policies, by way of `sd-workstation` label.


## Test plan
- [ ] `clean && make all` should succeed with no error
- [ ] `make test` should pass
- [ ] Editing the top of the rpc policies should cause tests to fail
- [ ] Ensure qubes-rpc policies in dom0-sdkfjdsf are sane
And, as always:
- [ ] Download, decrypt and view a plaintext submission in disposable VM
- [ ] Download, decrypt and view a submission (e.g., image) in disposable VM