### PR TITLE
Installs python-fixtures in Whonix VMs only when necessary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,36 +18,36 @@ clone: assert-dom0 ## Pulls the latest repo from work VM to dom0
 sd-workstation-template: prep-salt ## Provisions base template for SDW AppVMs
 	sudo qubesctl top.enable sd-workstation-template
 	sudo qubesctl top.enable sd-workstation-template-files
-	sudo qubesctl --targets sd-workstation-template state.highstate
+	sudo qubesctl --show-output --targets sd-workstation-template state.highstate
 
 sd-journalist: prep-salt ## Provisions SD Journalist VM
 	sudo qubesctl top.enable sd-journalist
 	sudo qubesctl top.enable sd-journalist-files
-	sudo qubesctl --targets sd-journalist-template state.highstate
-	sudo qubesctl --targets sd-journalist state.highstate
+	sudo qubesctl --show-output --targets sd-journalist-template state.highstate
+	sudo qubesctl --show-output --targets sd-journalist state.highstate
 
 sd-gpg: prep-salt ## Provisions SD GPG keystore VM
 	sudo qubesctl top.enable sd-gpg
 	sudo qubesctl top.enable sd-gpg-files
-	sudo qubesctl --targets sd-gpg state.highstate
+	sudo qubesctl --show-output --targets sd-gpg state.highstate
 
 sd-svs: prep-salt ## Provisions SD SVS VM
 	sudo qubesctl top.enable sd-svs
 	sudo qubesctl top.enable sd-svs-files
-	sudo qubesctl --targets sd-svs-template state.highstate
-	sudo qubesctl --targets sd-svs state.highstate
+	sudo qubesctl --show-output --targets sd-svs-template state.highstate
+	sudo qubesctl --show-output --targets sd-svs state.highstate
 
 sd-whonix: prep-salt ## Provisions SD Whonix VM
 	sudo qubesctl top.enable sd-whonix
 	sudo qubesctl top.enable sd-whonix-hidserv-key
-	sudo qubesctl --targets sd-whonix-template state.highstate
-	sudo qubesctl --targets sd-whonix state.highstate
+	sudo qubesctl --show-output --targets sd-whonix-template state.highstate
+	sudo qubesctl --show-output --targets sd-whonix state.highstate
 
 sd-svs-disp: prep-salt ## Provisions SD Submission Viewing VM
 	sudo qubesctl top.enable sd-svs-disp
 	sudo qubesctl top.enable sd-svs-disp-files
-	sudo qubesctl --targets sd-svs-disp-template state.highstate
-	sudo qubesctl --targets sd-svs-disp state.highstate
+	sudo qubesctl --show-output --targets sd-svs-disp-template state.highstate
+	sudo qubesctl --show-output --targets sd-svs-disp state.highstate
 
 clean-salt: assert-dom0 ## Purges SD Salt configuration from dom0
 	@echo "Purging Salt config..."
@@ -130,7 +130,7 @@ prep-whonix: ## enables apparmor on whonix-ws-14 and whonix-gw-14
 prep-dom0: prep-salt # Copies dom0 config files for VM updates
 	sudo qubesctl top.enable sd-vm-updates
 	sudo qubesctl top.enable sd-dom0-files
-	sudo qubesctl --targets dom0 state.highstate
+	sudo qubesctl --show-output --targets dom0 state.highstate
 
 list-vms: ## Prints all Qubes VMs managed by Workstation salt config
 	@./scripts/list-vms

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Once the configuration is done and this directory is copied to `dom0`, you must 
 make all
 ```
 
-The build process takes quite a while. You will be presented with a dialogue asking how to connect to Tor: you should be able to select the default option and continue.
+The build process takes quite a while. You will be presented with a dialogue asking how to connect to Tor: you should be able to select the default option and continue. You may wish to increase the scrollback in the dom0 terminal from 1000 (the default) to 100000, to ensure you can review any errors in the verbose output.
 
 When the installation process completes, a number of new VMs will be available on your machine, all prefixed with `sd-`.
 

--- a/dom0/fpf-apt-test-repo.sls
+++ b/dom0/fpf-apt-test-repo.sls
@@ -15,4 +15,4 @@ configure apt-test apt repo:
     - file: /etc/apt/sources.list.d/fpf-apt-test.list
     - key_url: "salt://sd/sd-workstation/apt-test-pubkey.asc"
   require:
-    - install-python-apt-for-repo-config
+    - pkg: install-python-apt-for-repo-config

--- a/dom0/sd-dom0-files.sls
+++ b/dom0/sd-dom0-files.sls
@@ -41,8 +41,5 @@ dom0-securedrop-icon:
     - user: root
     - group: root
     - mode: 644
-  # Dependency on parent dir should be explicitly declared,
-  # but the require syntax below was throwing an error that the
-  # referenced task was "not available".
-  # require:
-  #   - dom0-securedrop-icons-directory
+  require:
+    - file: dom0-securedrop-icons-directory

--- a/dom0/sd-journalist-files.sls
+++ b/dom0/sd-journalist-files.sls
@@ -9,11 +9,15 @@
 #
 ##
 
-mkfifo /home/user/sdfifo:
-  cmd.run
-
-chmod 666 /home/user/sdfifo:
-  cmd.run
+sd-journalist-create-feedback-pipe:
+  file.mknod:
+    - name: /home/user/sdfifo
+    - ntype: p
+    - user: user
+    - group: user
+    - mode: 666
+  require:
+    - cmd: sd-journalist-install-python-futures
 
 /home/user/.config/mimeapps.list:
   file.managed:
@@ -22,3 +26,12 @@ chmod 666 /home/user/sdfifo:
     - group: user
     - mode: 644
     - makedirs: True
+  require:
+    - cmd: sd-journalist-install-python-futures
+
+sd-journalist-install-python-qt4:
+  pkg.installed:
+    - pkgs:
+        - python-qt4
+  require:
+    - cmd: sd-journalist-install-python-futures

--- a/dom0/sd-journalist.sls
+++ b/dom0/sd-journalist.sls
@@ -25,6 +25,7 @@ sd-journalist:
       - pkg: qubes-template-whonix-ws-14
       - qvm: sd-whonix
       - qvm: sd-journalist-template
+      - cmd: sd-journalist-install-python-futures
 
 /etc/qubes-rpc/policy/sd-process.Feedback:
   file.managed:
@@ -38,9 +39,13 @@ sd-journalist:
 #   * python-futures required bootstrap Salt support
 #   * python-qt4 required for sd-process-feedback GUI integration
 #
-install python-qt4 and python-futures:
+sd-journalist-install-python-futures:
   cmd.run:
-    - name: qvm-run -a whonix-ws-14 'sudo apt-get update && sudo apt-get install -qq python-futures python-qt4'
+    - name: >
+        qvm-run -a whonix-ws-14
+        "python -c 'import concurrent.futures' ||
+        { sudo apt-get update && sudo apt-get install -qq python-futures ; }" &&
+        qvm-shutdown --wait whonix-ws-14
 
 # When our Qubes bug is fixed, this will *not* be used
 sd-journalist-dom0-qubes.OpenInVM:

--- a/dom0/sd-whonix.sls
+++ b/dom0/sd-whonix.sls
@@ -14,8 +14,13 @@ include:
   - qvm.sys-firewall
 
 # Temporary workaround to bootstrap Salt support on target.
-qvm-run -a whonix-gw-14 "sudo apt-get install -qq python-futures":
-  cmd.run
+sd-whonix-install-python-futures:
+  cmd.run:
+    - name: >
+        qvm-run -a whonix-gw-14
+        "python -c 'import concurrent.futures' ||
+        { sudo apt-get update && sudo apt-get install -qq python-futures ; }" &&
+        qvm-shutdown --wait whonix-gw-14
 
 sd-whonix-template:
   qvm.vm:
@@ -41,3 +46,4 @@ sd-whonix:
     - require:
       - pkg: qubes-template-whonix-gw-14
       - qvm: sys-firewall
+      - cmd: sd-whonix-install-python-futures


### PR DESCRIPTION
The `qvm-run` command ensuring that `python-fixtures` was present in the Whonix templates was flakey, causing several developers (myself included) to omit it when testing locally to avoid problems. Made it more stable by checking whether the library is available before running the apt commands. 

Also finetuned the dependency declaration in the related Salt commands, so that python-fixtures is _always_ present before Salt commands are run against the associated VMs. Increased verbosity of the Salt output, as well, since the default behavior was masking highly informative error output.

Closes #184.

## Testing

1. Run `make all` in dom0, confirm no errors
2. Run `make test` in dom0, confirm no errors.

If you see failing tests in step 2 regarding uninstalled updates, run `sudo securedrop-update`, then re-run `make test`.