### PR TITLE
Upgrade fedora-28 in separate qubesctl command

### DIFF
--- a/dom0/securedrop-update
+++ b/dom0/securedrop-update
@@ -38,6 +38,13 @@ securedrop-update-feedback "Updating dom0 configuration..."
 sudo qubes-dom0-update -y
 
 securedrop-update-feedback "Updating application..."
+
+# update only fedora template: dist_upgrade is required for debian package
+# upgrades and causes fedora template upgrades to fail.
+
+qubesctl --target fedora-28 pkg.upgrade refresh=true
+
+# upgrade all (other) templates
 qubesctl --skip-dom0 --templates \
     --max-concurrency "$SECUREDROP_MAX_CONCURRENCY" \
     pkg.upgrade refresh=true dist_upgrade=true


### PR DESCRIPTION
Fixes #181 

Adds another qubesctl command to run an update exclusively on the
fedora-28 template, in order to not have to manage update logic. We can revisit this later
if this proves unreliable or cumbersome (as the fedora template is updated twice in this case)

### Test plan:

- [ ] `make all` and `make test` complete without error
- [ ] run `securedrop-update` in dom0
- [ ] Open terminal in fedora-28, `sudo dnf update` and ensure no package updates are available
- [ ] Open terminal in debian-9 template (or any other debian-based template VM) and ensure no package updates are available by running `sudo apt update && sudo apt list --upgradable`