### PR TITLE
Declares dependencies on FPF apt repo for config pkgs

### DIFF
--- a/dom0/sd-workstation-template-files.sls
+++ b/dom0/sd-workstation-template-files.sls
@@ -1,5 +1,10 @@
-configure mimetype support for debian9:
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+sd-workstation-template-install-kernel-config-packages:
   pkg.installed:
     - pkgs:
       - securedrop-workstation-config
       - securedrop-workstation-grsec
+  require:
+    - sls: fpf-apt-test-repo


### PR DESCRIPTION
The config packages weren't requiring the presence of the apt repo, so
the pkgs occasionally failed to be installed. Let's declare the
dependency to ensure proper ordering.

Closes #195.