### PR TITLE
Installs mimetype handlers for SVS DispVM via package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,22 +88,22 @@ remove-sd-gpg: assert-dom0 ## Destroys SD GPG keystore VM
 clean: assert-dom0 destroy-all clean-salt ## Destroys all SD VMs
 
 test: assert-dom0 ## Runs all application tests (no integration tests yet)
-	python -m unittest discover tests
+	python3 -m unittest discover -v tests
 
 test-base: assert-dom0 ## Runs tests for VMs layout
-	python -m unittest -v tests.test_vms_exist.SD_VM_Tests
+	python3 -m unittest -v tests.test_vms_exist.SD_VM_Tests
 
 test-svs: assert-dom0 ## Runs tests for SD SVS VM config
-	python -m unittest -v tests.test_svs.SD_SVS_Tests
+	python3 -m unittest -v tests.test_svs.SD_SVS_Tests
 
 test-journalist: assert-dom0 ## Runs tests for SD Journalist VM
-	python -m unittest -v tests.test_journalist_vm
+	python3 -m unittest -v tests.test_journalist_vm
 
 test-whonix: assert-dom0 ## Runs tests for SD Whonix VM
-	python -m unittest -v tests.test_sd_whonix
+	python3 -m unittest -v tests.test_sd_whonix
 
 test-gpg: assert-dom0 ## Runs tests for SD GPG functionality
-	python -m unittest -v tests.test_gpg
+	python3 -m unittest -v tests.test_gpg
 
 validate: assert-dom0 ## Checks for local requirements in dev env
 	@bash -c "test -e config.json" || \

--- a/dom0/sd-svs-disp-files.sls
+++ b/dom0/sd-svs-disp-files.sls
@@ -5,17 +5,17 @@
 # sd-svs-disp-files
 # ========
 #
-# Moves files into place on sd-svs-disp
+# Installs configuration packages specific to the SVS DispVM,
+# used for opening submissions.
 #
 ##
 
-sd-svs-disp-write-mimetyeps:
-  file.managed:
-    - name: /usr/share/applications/mimeapps.list
-    - source: salt://sd/sd-svs/mimeapps-sd-svs-disp.list
-    - user: root
-    - group: root
-    - mode: 644
+include:
+  - fpf-apt-test-repo
 
-sudo update-mime-database /usr/share/mime:
-  cmd.run
+sd-svs-disp-install-mimetype-handler-package:
+  pkg.installed:
+    - pkgs:
+      - securedrop-workstation-svs-disp
+  require:
+    - sls: fpf-apt-test-repo

--- a/dom0/sd-svs-disp-files.top
+++ b/dom0/sd-svs-disp-files.top
@@ -3,4 +3,5 @@
 
 base:
   sd-svs-disp-template:
+    - fpf-apt-test-repo
     - sd-svs-disp-files

--- a/sd-svs/mimeapps-sd-svs-disp.list
+++ b/sd-svs/mimeapps-sd-svs-disp.list
@@ -1,2 +1,0 @@
-[Default Applications]
-text/plain=org.gnome.gedit.desktop

--- a/tests/base.py
+++ b/tests/base.py
@@ -58,8 +58,9 @@ class SD_VM_Local_Test(unittest.TestCase):
         self.vm.start()
 
     def _get_file_contents(self, path):
-        contents = subprocess.check_output(["qvm-run", "-p", self.vm_name,
-                                            "/bin/cat {}".format(path)])
+        cmd = ["qvm-run", "-p", self.vm_name,
+               "/bin/cat {}".format(path)]
+        contents = subprocess.check_output(cmd).decode("utf-8")
         return contents
 
     def _package_is_installed(self, pkg):
@@ -79,7 +80,7 @@ class SD_VM_Local_Test(unittest.TestCase):
         with open(local_path) as f:
             content = f.read()
         import difflib
-        print("".join(difflib.unified_diff(remote_content, content)))
+        print("".join(difflib.unified_diff(remote_content, content)), end="")
         self.assertTrue(remote_content == content)
 
     def assertFileHasLine(self, remote_path, wanted_line):

--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -7,7 +7,7 @@ from base import SD_VM_Local_Test
 
 def find_fp_from_gpg_output(gpg):
 
-    lines = gpg.split("\n")
+    lines = gpg.decode("utf-8").split("\n")
 
     for line in lines:
         # dom0 uses Fedora25 with gpg 1.4.22, whereas AppVMs

--- a/tests/test_svs.py
+++ b/tests/test_svs.py
@@ -27,6 +27,16 @@ class SD_SVS_Tests(SD_VM_Local_Test):
         self.assertTrue(self._package_is_installed("securedrop-client"))
 
 
+class SD_SVS_Disp_Tests(SD_VM_Local_Test):
+    def setUp(self):
+        self.vm_name = "sd-svs-disp"
+        super(SD_SVS_Disp_Tests, self).setUp()
+
+    def test_sd_client_package_installed(self):
+        pkg = "securedrop-workstation-svs-disp"
+        self.assertTrue(self._package_is_installed(pkg))
+
+
 def load_tests(loader, tests, pattern):
     suite = unittest.TestLoader().loadTestsFromTestCase(SD_SVS_Tests)
     return suite

--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -28,9 +28,8 @@ class SD_VM_Tests(unittest.TestCase):
         self.assertTrue(vm.kernel == "")
 
         # Check exact kernel version in VM
-        raw_output = vm.run("uname -r")
-        # Response is a tuple of e.g. ('4.14.74-grsec\n', '')
-        kernel_version = raw_output[0].rstrip()
+        stdout, stderr = vm.run("uname -r")
+        kernel_version = stdout.decode("utf-8").rstrip()
         assert kernel_version.endswith("-grsec")
         assert kernel_version == EXPECTED_KERNEL_VERSION
 

--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -27,7 +27,7 @@ class SD_VM_Platform_Tests(unittest.TestCase):
         # let's maintain the default config and retrieve the value elsewise.
         cmd = "perl -nE '/^PRETTY_NAME=\"(.*)\"$/ and say $1' /etc/os-release"
         stdout, stderr = vm.run(cmd)
-        platform = stdout.rstrip("\n")
+        platform = stdout.decode("utf-8").rstrip("\n")
         return platform
 
     def _validate_vm_platform(self, vm):
@@ -47,7 +47,7 @@ class SD_VM_Platform_Tests(unittest.TestCase):
         if not fedora:
             cmd = "apt list --upgradable"
             stdout, stderr = vm.run(cmd)
-            results = stdout.rstrip()
+            results = stdout.rstrip().decode("utf-8")
             # `apt list` will always print "Listing..." to stdout,
             # so expect only that string.
             self.assertEqual(results, "Listing...")
@@ -56,7 +56,7 @@ class SD_VM_Platform_Tests(unittest.TestCase):
             # Will raise CalledProcessError if updates available
             stdout, stderr = vm.run(cmd)
             # 'stdout' will contain timestamped progress info; ignore it
-            results = stderr.rstrip()
+            results = stderr.rstrip().decode("utf-8")
             self.assertEqual(results, "")
 
     def test_all_sd_vms_uptodate(self):
@@ -112,7 +112,7 @@ class SD_VM_Platform_Tests(unittest.TestCase):
         test because DispVMs may not be running at present.
         """
         cmd = ["qubes-prefs", "default_dispvm"]
-        result = subprocess.check_output(cmd).rstrip("\n")
+        result = subprocess.check_output(cmd).decode("utf-8").rstrip("\n")
         self.assertEqual(result, "fedora-28-dvm")
 
 


### PR DESCRIPTION
Converts the mimetype handler logic for `sd-svs-disp` (used to open submissions) to Debian package, based on logic presented in https://github.com/freedomofpress/securedrop-debian-packaging/pull/10.

Also updated the config tests to Python 3 because it was easy and closes another issue.

Closes #182. Closes #188.

I'm able to open a test submission (tried a JPG) just fine using the new logic.