### PR TITLE
updates sd-gpg autoaccept timeout to 8 hours

### DIFF
--- a/dom0/sd-gpg-files.sls
+++ b/dom0/sd-gpg-files.sls
@@ -9,6 +9,10 @@
 #
 ##
 
+/home/user/.profile:
+  file.append:
+    - text: "export QUBES_GPG_AUTOACCEPT=28800"
+
 /tmp/sd-journalist.sec:
   file.managed:
     - source: salt://sd/sd-journalist.sec

--- a/dom0/sd-gpg-files.sls
+++ b/dom0/sd-gpg-files.sls
@@ -9,16 +9,25 @@
 #
 ##
 
-/home/user/.profile:
-  file.append:
-    - text: "export QUBES_GPG_AUTOACCEPT=28800"
+sd-gpg-increase-keyring-access-timeout:
+  file.blockreplace:
+    - name: /home/user/.profile
+    - append_if_not_found: True
+    - marker_start: "### BEGIN securedrop-workstation ###"
+    - marker_end: "### END securedrop-workstation ###"
+    - content: |
+        export QUBES_GPG_AUTOACCEPT=28800
 
-/tmp/sd-journalist.sec:
+sd-gpg-import-submission-key:
   file.managed:
+    - name: /tmp/sd-journalist.sec
     - source: salt://sd/sd-journalist.sec
     - user: user
     - group: user
     - mode: 644
-
-sudo -u user gpg --import /tmp/sd-journalist.sec:
-  cmd.run
+    # Don't print private key to stdout
+    - show_changes: False
+  cmd.run:
+    - name: sudo -u user gpg --import /tmp/sd-journalist.sec
+    - require:
+      - file: sd-gpg-import-submission-key

--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -43,6 +43,10 @@ class SD_GPG_Tests(SD_VM_Local_Test):
         self.vm_name = "sd-gpg"
         super(SD_GPG_Tests, self).setUp()
 
+    def test_sd_gpg_timeout(self):
+        line = "export QUBES_GPG_AUTOACCEPT=28800"
+        self.assertFileHasLine("/home/user/.profile", line)
+
     def test_we_have_the_key(self):
         self.assertEqual(get_local_fp(), get_remote_fp())
 


### PR DESCRIPTION
This addresses #154 by increasing the split GPG autaccept interval to 1 hour for the sd-gpg vault VM

In UX terms, this will mean that the user will be prompted with the gpg accept dialog once at the beginning of their session and then again every hour. General consensus seems to be that the dialog offers no security benefits, so the interval could even be bumped up higher. It doesn't look like it can be suppressed without changes in split-gpg. 