### PR TITLE
Fix fedora update check test

### DIFF
--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -52,7 +52,7 @@ class SD_VM_Platform_Tests(unittest.TestCase):
             # so expect only that string.
             self.assertEqual(results, "Listing...")
         else:
-            cmd = "dnf check-update"
+            cmd = "sudo dnf check-update"
             # Will raise CalledProcessError if updates available
             stdout, stderr = vm.run(cmd)
             # 'stdout' will contain timestamped progress info; ignore it


### PR DESCRIPTION
Fixes #217 

Test plan:

- [x] Enure all your VMs are up to date (you can run `sudo securedrop-update`)
- [x] `make test` does not error out on `test_all_fedora_vms_uptodate`