### PR TITLE
Switches to upstream python container for linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ flake8: ## Lints all Python files with flake8
 # available only in the developer environment, i.e. Work VM.
 	@docker run -v $(PWD):/code -w /code --name sdw_flake8 --rm \
 		--entrypoint /code/scripts/flake8-linting \
-		quay.io/freedomofpress/ci-python \
+		python:3.5.7-slim-stretch
 
 template: ## Builds securedrop-workstation Qube template RPM
 	./builder/build-workstation-template


### PR DESCRIPTION
The ci-python container was throwing errors related to jessie apt repos.
Rather than patch that container, let's switch to an upstream Python 3
container. The 3.5.7 version is not a perfect match for Debian Stretch,
which currently uses Pyhton 3.5.3, but it's close enough that it should
suffice for linting.

Closes #246.

## Testing
* [ ] Run `make flake8` on master and confirm failure, similar to errors documented in #246
* [ ] Run `make flake8` on this branch and confirm passing
* [ ] Confirm CI is passing on this branch