### PR TITLE
Updates docs and config for Qubes 4.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ While we are strongly committed to piloting the use of Qubes OS for SecureDrop, 
 
 Installing this project is involved. It requires an up-to-date Qubes 4.0 installation running on a machine with at least 12GB of RAM. You'll need access to a SecureDrop staging server as well.
 
-#### Qubes 4.0
+#### Qubes 4.0.1
 
-Before trying to use this project, install [Qubes 4.0](https://www.qubes-os.org/downloads/) on your development machine. Accept the default VM configuration during the install process.
+Before trying to use this project, install [Qubes 4.0.1](https://www.qubes-os.org/downloads/) on your development machine. Accept the default VM configuration during the install process.
 
 After installing Qubes, you must update both dom0 and debian-9 template VM to include the latest version of the `qubes-kernel-vm-support` package.
 
@@ -105,62 +105,6 @@ qfile-agent : Fatal error: File copy: Disk quota exceeded; Last file: <...> (err
 ```
 
 When the installation process completes, a number of new VMs will be available on your machine, all prefixed with `sd-`.
-
-Proceed to the following steps to clean up templates on workstation, which are necessary due to the inclusion of end-of-life templates in Qubes 4.0.
-
-##### Upgrading `sys-net`, `sys-usb` and `sys-firewall` to `fedora-28`
-
-Qubes 4.0 ships with end-of-life `fedora-26` templates which are used by default for `sys-net`, `sys-firewall` and `sys-usb`. You need to manually upgrade `sys-net`, `sys-firewall` and `sys-usb` VMs to `fedora-28` by running the following commands in `dom0`:
-
-```
-qvm-kill sys-net
-qvm-prefs sys-net template fedora-28
-qvm-start sys-net
-
-qvm-kill sys-firewall
-qvm-prefs sys-firewall template fedora-28
-qvm-start sys-firewall
-
-qvm-kill sys-usb
-qvm-prefs sys-usb template fedora-28
-qvm-start sys-usb
-
-```
-
-Any other `fedora-26` VMs you may have created or that are installed by default (`work`, `personal`, `untrusted`, `vault`) should also be updated in the same manner.
-
-You will also need to update the default disposable VM template to `fedora-28`:
-
-```
-qvm-create --template fedora-28 --label red fedora-28-dvm
-qvm-prefs fedora-28-dvm template_for_dispvms True
-qubes-prefs default_dispvm fedora-28-dvm
-```
-
-You can then delete the end-of-life `fedora-26` template in `dom0` by running:
-
-```
-sudo dnf remove qubes-template-fedora-26
-```
-
-If this command produces an error, open the Qube Manager and ensure that there are no remaining VMs using the `fedora-26` template.
-
-#### Upgrading `sys-whonix` and `whonix-ws` AppVMs to Whonix 14
-
-Qubes 4.0 also ships with end-of-life Whonix templates (`whonix-gw` and `whonix-ws`).`sys-whonix` is used by `sd-whonix` to fetch updates, and should be upgraded. You should destroy `whonix-gw` from the Qube Manager and re-provision a new `sys-whonix` AppVM based on `whonix-gw-14` with the option **provides network**. You will need to delete the `whonix-ws-dvm` and `anon-whonix` VMs. You can then remove the end-of-life templates by running the following commands in `dom0`:
-
-```
-sudo dnf remove qubes-template-whonix-gw
-sudo dnf remove qubes-template-whonix-ws
-```
-
-Upon release, Qubes 4.0.1 will no longer ship `fedora-26` or older Whonix templates, and the above steps will no longer be necessary.
-
-Finally, update all the templates and reboot the machine. Your workstation will then be ready for use. In `dom0`, run:
-
-```
-sudo securedrop-update
-```
 
 #### Using the *SecureDrop Client*
 

--- a/README.md
+++ b/README.md
@@ -194,8 +194,8 @@ qvm-copy-to-vm sd-export ~/.securedrop_client/data/name-of-file
 The development plan is to provide functionality in the *SecureDrop Client* that automates step 3, and assists the user in taking these steps via GUI prompts. Eventually we plan to provide other methods for export, such as [OnionShare](https://onionshare.org/) (this will require the attachment of a NetVM), using a dedicated export VM template with tools such as OnionShare and Veracrypt. The next section includes instructions to approximate the OnionShare sharing flow.
 
 ##### Transferring files via OnionShare
-1. Create an `sd-onionshare-template` VM based on `fedora-28`:
-   1. Click on the Qubes menu in the upper left, select "Template: Fedora 28", click on "fedora-28: Qube Settings", and click on **Clone Qube**
+1. Create an `sd-onionshare-template` VM based on `fedora-29`:
+   1. Click on the Qubes menu in the upper left, select "Template: Fedora 29", click on "fedora-29: Qube Settings", and click on **Clone Qube**
    2. Name the cloned qube `sd-onionshare-template`
    3. In the Qubes menu on the top-left, select "Template: sd-onionshare-template" and click on "sd-onionshare-template: Terminal"
    4. Install OnionShare: `sudo dnf install onionshare`
@@ -310,7 +310,7 @@ Be aware that running tests *will* power down running SecureDrop VMs, and may re
 
 ## Building the Templates
 
-1. Create a `fedora-28` AppVM for building
+1. Create a `fedora-29` AppVM for building
 2. Increase the disk size to at least 15GB (as the build uses over 10GB)
 3. Import the QubesOS master key and the GPG key used to sign tags (see https://www.qubes-os.org/security/verifying-signatures/)
 4. Run `make template` in the top-level of this repository.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Installing this project is involved. It requires an up-to-date Qubes 4.0 install
 
 Before trying to use this project, install [Qubes 4.0.1](https://www.qubes-os.org/downloads/) on your development machine. Accept the default VM configuration during the install process.
 
-After installing Qubes, you must update both dom0 and debian-9 template VM to include the latest version of the `qubes-kernel-vm-support` package.
+After installing Qubes, you must update both dom0 and the base templates to include the latest versions of apt packages.
 
 ##### `dom0`
 
@@ -50,20 +50,14 @@ Open a terminal in `dom0` by clicking on the Qubes menu top-right of the screen 
 sudo qubes-dom0-update
 ```
 
-##### `debian-9`
-Open a terminal in the `debian-9` TemplateVM and run:
+Finally, update all existing TemplateVMs:
 
 ```
-sudo apt-get update
-sudo apt-get upgrade
-apt-cache policy qubes-kernel-vm-support
+qubes-update-gui
 ```
 
-After verifying that the latest version of `qubes-kernel-vm-support` is installed, shut down the template VM:
+Select all VMs marked as **updates available**, then click **Next**. Once all updates have been applied, you're ready to proceed.
 
-```
-sudo poweroff
-```
 
 #### Download, Configure, Copy to `dom0`
 

--- a/dom0/fpf-apt-test-repo.sls
+++ b/dom0/fpf-apt-test-repo.sls
@@ -1,6 +1,19 @@
 # -*- coding: utf-8 -*-
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 
+# Handle misconfigured jessie-backports repo in default debian-9 TemplateVM.
+# The Jessie repos aren't maintained anymore, and their inclusion causes
+# even apt update to fail.
+remove-jessie-backports-repo:
+  file.line:
+    - name: /etc/apt/sources.list
+    # Unclear why "Delete" *must* be capitalized, but that's the case!
+    - mode: delete
+    - match: jessie-backports
+    # quiet param seems to be ignored, so using "onlyif" to test existence
+    - quiet: True
+    - onlyif:
+      - test -f /etc/apt/sources.list
 
 # That's right, we need to install a package in order to
 # configure a repo to install another package
@@ -8,6 +21,8 @@ install-python-apt-for-repo-config:
   pkg.installed:
     - pkgs:
       - python-apt
+    - require:
+      - file: remove-jessie-backports-repo
 
 configure apt-test apt repo:
   pkgrepo.managed:

--- a/dom0/sd-dom0-files.sls
+++ b/dom0/sd-dom0-files.sls
@@ -45,10 +45,10 @@ dom0-securedrop-icon:
       - file: dom0-securedrop-icons-directory
 
 # Install latest templates required for SDW VMs.
-dom0-install-fedora-28-template:
+dom0-install-fedora-29-template:
   pkg.installed:
     - pkgs:
-      - qubes-template-fedora-28
+      - qubes-template-fedora-29
 
 dom0-install-whonix-14-templates:
   pkg.installed:

--- a/dom0/securedrop-update
+++ b/dom0/securedrop-update
@@ -42,7 +42,7 @@ securedrop-update-feedback "Updating application..."
 # update only fedora template: dist_upgrade is required for debian package
 # upgrades and causes fedora template upgrades to fail.
 
-qubesctl --target fedora-28 pkg.upgrade refresh=true
+qubesctl --target fedora-29 pkg.upgrade refresh=true
 
 # upgrade all (other) templates
 qubesctl --skip-dom0 --templates \

--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -99,8 +99,8 @@ class SD_VM_Platform_Tests(unittest.TestCase):
         """
         # Technically we want to know whether the sys-firewall, sys-net, and
         # sys-usb VMs have their updates installed. This test assumes those
-        # AppVMs are based on fedora-28.
-        vm_name = "fedora-28"
+        # AppVMs are based on fedora-29.
+        vm_name = "fedora-29"
         vm = self.app.domains[vm_name]
         self._ensure_packages_up_to_date(vm, fedora=True)
         vm.shutdown()
@@ -137,7 +137,7 @@ class SD_VM_Platform_Tests(unittest.TestCase):
         """
         cmd = ["qubes-prefs", "default_dispvm"]
         result = subprocess.check_output(cmd).decode("utf-8").rstrip("\n")
-        self.assertEqual(result, "fedora-28-dvm")
+        self.assertEqual(result, "fedora-29-dvm")
 
 
 def load_tests(loader, tests, pattern):

--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -44,20 +44,23 @@ class SD_VM_Platform_Tests(unittest.TestCase):
         updates. Assumes VM is Debian-based, so uses apt, but supports
         `fedora=True` to use dnf instead.
         """
+        # Create custom error message, so failing test cases display
+        # which VM caused the looped check to fail.
+        fail_msg = "Unapplied updates for VM '{}'".format(vm)
         if not fedora:
             cmd = "apt list --upgradable"
             stdout, stderr = vm.run(cmd)
             results = stdout.rstrip().decode("utf-8")
             # `apt list` will always print "Listing..." to stdout,
             # so expect only that string.
-            self.assertEqual(results, "Listing...")
+            self.assertEqual(results, "Listing...", fail_msg)
         else:
             cmd = "sudo dnf check-update"
             # Will raise CalledProcessError if updates available
             stdout, stderr = vm.run(cmd)
             # 'stdout' will contain timestamped progress info; ignore it
             results = stderr.rstrip().decode("utf-8")
-            self.assertEqual(results, "")
+            self.assertEqual(results, "", fail_msg)
 
     def _ensure_jessie_backports_disabled(self, vm):
         """

--- a/tests/vars/qubes-rpc.yml
+++ b/tests/vars/qubes-rpc.yml
@@ -24,7 +24,7 @@
 
     ## Please use a single # to start your custom comments
 
-    $tag:anon-vm  $anyvm  deny
+    $tag:anon-vm	$anyvm	deny
     $anyvm	$anyvm	allow,target=dom0
 
 - policy: GetRandomizedTime

--- a/tests/vars/qubes-rpc.yml
+++ b/tests/vars/qubes-rpc.yml
@@ -19,12 +19,12 @@
 
 - policy: GetDate
   starts_with: |-
-    $tag:anon-vm $anyvm deny
     ## Note that policy parsing stops at the first match,
     ## so adding anything below "$anyvm $anyvm action" line will have no effect
 
     ## Please use a single # to start your custom comments
 
+    $tag:anon-vm  $anyvm  deny
     $anyvm	$anyvm	allow,target=dom0
 
 - policy: GetRandomizedTime
@@ -131,12 +131,19 @@
 
 - policy: UpdatesProxy
   starts_with: |-
-    $tag:whonix-updatevm $default allow,target=sys-whonix
-    $tag:whonix-updatevm $anyvm deny
     ## Note that policy parsing stops at the first match,
     ## so adding anything below "$anyvm $anyvm action" line will have no effect
 
     ## Please use a single # to start your custom comments
+
+    # Upgrade all TemplateVMs through sys-whonix.
+    #$type:TemplateVM $default allow,target=sys-whonix
+
+    # Upgrade Whonix TemplateVMs through sys-whonix.
+    $tag:whonix-updatevm $default allow,target=sys-whonix
+
+    # Deny Whonix TemplateVMs using UpdatesProxy of any other VM.
+    $tag:whonix-updatevm $anyvm deny
 
     # Default rule for all TemplateVMs - direct the connection to sys-net
     $type:TemplateVM $default allow,target=sys-net


### PR DESCRIPTION
Ensures the docs are accurate as of Qubes 4.0.1. Ran through a clean install and fixed errors encountered during the provisioning process. Fortunately, much of the manual recommendations we'd made around EOL Fedora templates can now be removed from the README—although I expect we'll soon be forced to do the same for 29 -> 30 (Fedora-29 goes EOL ~ 2019-09). 

Closes #245.
Closes #189.
Closes #191.

### Testing
Ideally, perform a clean installation of Qubes 4.0.1 following these new docs! That's a large ask, though, so more practically, the following should work:

1. Check out this branch in `sd-dev` (or other AppVM you use for development)
2. Switch to dom0 for following commands
3. Run `make clean` to purge any old config.
4. Run `make all` to provision all VMs, and confirm no errors.
5. Run `make test` and confirm all passing.

Assuming those steps go smoothly, take a moment to run `qvm-ls | grep fedora` and make sure the _only_ references you see are to `fedora-29`. If you see other versions, you may want to clean up, e.g.

```
qvm-remove fedora-28-dvm
sudo dnf remove qubes-template-fedora-28
```

And similar for any other versions of Fedora VMs you may have.

