### PR TITLE
rpc policies: allow sd-svs to get sd-gpg to import gpg keys

### DIFF
--- a/dom0/sd-dom0-qvm-rpc.sls
+++ b/dom0/sd-dom0-qvm-rpc.sls
@@ -108,4 +108,5 @@ dom0-rpc-qubes.GpgImportKey:
     - marker_start: "### BEGIN securedrop-workstation ###"
     - marker_end: "### END securedrop-workstation ###"
     - content: |
+        sd-svs sd-gpg allow
         $anyvm $tag:sd-workstation deny

--- a/tests/vars/qubes-rpc.yml
+++ b/tests/vars/qubes-rpc.yml
@@ -56,6 +56,7 @@
 - policy: GpgImportKey
   starts_with: |-
     ### BEGIN securedrop-workstation ###
+    sd-svs sd-gpg allow
     $anyvm $tag:sd-workstation deny
     ### END securedrop-workstation ###
 


### PR DESCRIPTION
part of the resolution for https://github.com/freedomofpress/securedrop-client/issues/363 (securedrop-client needs to have this rpc policy in place to resolve that issue)

## test

1. Apply change described in https://github.com/QubesOS/qubes-app-linux-split-gpg/pull/23

2. Then manually try to import a gpg key in sd-svs:

```
qubes-gpg-import-key test_key.asc
```