### PR TITLE
Autostart sd-proxy and sd-gpg at login

### DIFF
--- a/dom0/sd-gpg.sls
+++ b/dom0/sd-gpg.sls
@@ -20,6 +20,7 @@ sd-gpg:
       - label: purple
     - prefs:
       - netvm: ""
+      - autostart: true
     - tags:
       - add:
         - sd-workstation

--- a/dom0/sd-proxy.sls
+++ b/dom0/sd-proxy.sls
@@ -32,6 +32,7 @@ sd-proxy:
     - prefs:
       - netvm: sd-whonix
       - kernelopts: "nopat apparmor=1 security=apparmor"
+      - autostart: true
     - tags:
       - add:
         - sd-workstation

--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -41,6 +41,7 @@ class SD_VM_Tests(unittest.TestCase):
         self.assertEqual(vm.kernelopts, wanted_kernelopts)
         self.assertTrue(vm.template == "whonix-gw-14")
         self.assertTrue(vm.provides_network)
+        self.assertTrue(vm.autostart is True)
         self.assertFalse(vm.template_for_dispvms)
         self.assertTrue('sd-workstation' in vm.tags)
 
@@ -51,6 +52,7 @@ class SD_VM_Tests(unittest.TestCase):
         wanted_kernelopts = "nopat apparmor=1 security=apparmor"
         self.assertEqual(vm.kernelopts, wanted_kernelopts)
         self.assertTrue(vm.template == "sd-proxy-template")
+        self.assertTrue(vm.autostart is True)
         self.assertFalse(vm.provides_network)
         self.assertFalse(vm.template_for_dispvms)
         self.assertTrue('sd-workstation' in vm.tags)
@@ -81,6 +83,7 @@ class SD_VM_Tests(unittest.TestCase):
         self.assertTrue(nvm is None)
         # No sd-gpg-template, since keyring is managed in $HOME
         self.assertTrue(vm.template == "sd-workstation-template")
+        self.assertTrue(vm.autostart is True)
         self.assertFalse(vm.provides_network)
         self.assertFalse(vm.template_for_dispvms)
         self._check_kernel(vm)


### PR DESCRIPTION
Fixes #200 

Test plan:

- `make all`  on this branch
- reboot
- [x] observe sd-gpg and sd-proxy have started without user intervention at boot