### PR TITLE
Installs SD workstation TemplateVM from RPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,11 +163,11 @@ Replies and Source Deletion will be added in the next major release of the *Secu
 
 Exporting documents directly from within the *SecureDrop Client* is not currently supported, but you can export documents manually via USB by following these steps:
 
-1. Create an export VM based on `sd-workstation-template`.
+1. Create an export VM based on the `securedrop-workstation` template.
    1. Click the Qubes menu in the upper left of the screen.
    2. Click **Create Qubes VM**
    3. Name the VM `sd-export`
-   4. Set the template as `sd-workstation-template`
+   4. Set the template as `securedrop-workstation`
    5. Set networking to (none).
    6. Click **OK** to create the VM.
 2. Start the VM. Again from the Qubes menu:

--- a/dom0/fpf-apt-test-repo.sls
+++ b/dom0/fpf-apt-test-repo.sls
@@ -31,3 +31,11 @@ configure apt-test apt repo:
     - key_url: "salt://sd/sd-workstation/apt-test-pubkey.asc"
     - require:
       - pkg: install-python-apt-for-repo-config
+
+# Ensure all apt updates are applied, since the VMs
+# will be cloned, duplicating package version drift.
+update-all-apt-packages:
+  pkg.uptodate:
+    - cache_valid_time: "3600"
+    - require:
+      - pkg: install-python-apt-for-repo-config

--- a/dom0/sd-dom0-files.sls
+++ b/dom0/sd-dom0-files.sls
@@ -60,14 +60,13 @@ dom0-workstation-rpm-repo:
     - require:
       - file: dom0-rpm-test-key
 
-# Not installing automatically, since we have more testing to do
-# dom0-install-securedrop-workstation-template:
-#   pkg.installed:
-#     - pkgs:
-#       - qubes-template-securedrop-workstation
-#     - require:
-#       - file: dom0-workstation-rpm-repo
-#       - cmd: dom0-rpm-test-key-sys-firewall
+dom0-install-securedrop-workstation-template:
+  pkg.installed:
+    - pkgs:
+      - qubes-template-securedrop-workstation
+    - require:
+      - file: dom0-workstation-rpm-repo
+      - cmd: dom0-rpm-test-key-sys-firewall
 
 # Copy script to system location so admins can run ad-hoc
 dom0-update-securedrop-script:

--- a/dom0/sd-gpg.sls
+++ b/dom0/sd-gpg.sls
@@ -16,7 +16,7 @@ sd-gpg:
   qvm.vm:
     - name: sd-gpg
     - present:
-      - template: sd-workstation-template
+      - template: securedrop-workstation
       - label: purple
     - prefs:
       - netvm: ""

--- a/dom0/sd-svs-disp.sls
+++ b/dom0/sd-svs-disp.sls
@@ -18,7 +18,7 @@ sd-svs-disp-template:
   qvm.vm:
     - name: sd-svs-disp-template
     - clone:
-      - source: sd-workstation-template
+      - source: securedrop-workstation
       - label: green
     - require:
       - sls: sd-workstation-template

--- a/dom0/sd-svs.sls
+++ b/dom0/sd-svs.sls
@@ -15,7 +15,7 @@ sd-svs-template:
   qvm.vm:
     - name: sd-svs-template
     - clone:
-      - source: sd-workstation-template
+      - source: securedrop-workstation
       - label: yellow
     - tags:
       - add:

--- a/dom0/sd-workstation-template-files.top
+++ b/dom0/sd-workstation-template-files.top
@@ -2,6 +2,6 @@
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 
 base:
-  sd-workstation-template:
+  securedrop-workstation:
     - fpf-apt-test-repo
     - sd-workstation-template-files

--- a/dom0/sd-workstation-template.sls
+++ b/dom0/sd-workstation-template.sls
@@ -1,21 +1,13 @@
 # -*- coding: utf-8 -*-
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 
-##
-# qvm.work
-# ========
-#
-# Installs 'sd-journlist' AppVM, for hosting the securedrop workstation app
-#
-##
+include:
+  - sd-dom0-files
 
-
+# Sets virt_mode and kernel to use custom hardened kernel.
 sd-workstation-template:
   qvm.vm:
-    - name: sd-workstation-template
-    - clone:
-      - source: debian-9
-      - label: yellow
+    - name: securedrop-workstation
     - prefs:
       - virt-mode: hvm
       - kernel: ''

--- a/dom0/sd-workstation-template.sls
+++ b/dom0/sd-workstation-template.sls
@@ -22,3 +22,5 @@ sd-workstation-template:
     - tags:
       - add:
         - sd-workstation
+    - require:
+      - pkg: dom0-install-securedrop-workstation-template

--- a/scripts/list-vms
+++ b/scripts/list-vms
@@ -12,7 +12,7 @@ declare -a sd_workstation_vm_names=(
   sd-proxy-template
   sd-svs
   sd-svs-template
-  sd-workstation-template
+  securedrop-workstation
   sd-whonix
   sd-svs-disp
   sd-svs-disp-template

--- a/scripts/provision-all
+++ b/scripts/provision-all
@@ -13,7 +13,7 @@ echo "Create base Template to be used by others"
 sudo qubesctl --show-output --targets dom0 state.sls sd-workstation-template
 
 echo "Configure packages inside base Template"
-sudo qubesctl --show-output --skip-dom0 --targets sd-workstation-template state.sls sd-workstation-template-files
+sudo qubesctl --show-output --skip-dom0 --targets securedrop-workstation state.sls sd-workstation-template-files
 
 echo "Set up dom0 config files, including RPC policies, and create VMs"
 # The dom0 config runs implicitly via qubesctl (unless `--skip-dom0` is passed), so the VM

--- a/tests/test_dom0_rpm_repo.py
+++ b/tests/test_dom0_rpm_repo.py
@@ -1,0 +1,40 @@
+import unittest
+
+
+class SD_Dom0_Rpm_Repo_Tests(unittest.TestCase):
+
+    def setUp(self):
+        # Enable full diff output in test report, to aid in debugging
+        self.maxDiff = None
+
+    def test_rpm_repo_public_key(self):
+        pubkey_actual = "/etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation-test"  # noqa
+        pubkey_wanted = "sd-workstation/apt-test-pubkey.asc"
+
+        with open(pubkey_actual, "r") as f:
+            pubkey_actual_contents = f.readlines()
+
+        with open(pubkey_wanted, "r") as f:
+            pubkey_wanted_contents = f.readlines()
+
+        self.assertEqual(pubkey_actual_contents, pubkey_wanted_contents)
+
+    def test_rpm_repo_config(self):
+        repo_file = "/etc/yum.repos.d/securedrop-workstation-dom0.repo"
+        wanted_lines = [
+            "[securedrop-workstation-dom0]",
+            "gpgcheck=1",
+            "gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation-test",  # noqa
+            "enabled=1",
+            "baseurl=https://dev-bin.ops.securedrop.org/dom0-rpm-repo/",
+            "name=SecureDrop Workstation Qubes dom0 repo",
+        ]
+        with open(repo_file, "r") as f:
+            found_lines = [x.strip() for x in f.readlines()]
+
+        self.assertEqual(found_lines, wanted_lines)
+
+
+def load_tests(loader, tests, pattern):
+    suite = unittest.TestLoader().loadTestsFromTestCase(SD_Dom0_Rpm_Repo_Tests)
+    return suite

--- a/tests/test_sys_firewall.py
+++ b/tests/test_sys_firewall.py
@@ -1,0 +1,19 @@
+import unittest
+
+from base import SD_VM_Local_Test
+
+
+class SD_Sys_Firewall_Tests(SD_VM_Local_Test):
+
+    def setUp(self):
+        self.vm_name = "sys-firewall"
+        super(SD_Sys_Firewall_Tests, self).setUp()
+
+    def test_rpm_repo_public_key(self):
+        self.assertFilesMatch("/etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation-test",  # noqa
+                              "sd-workstation/apt-test-pubkey.asc")
+
+
+def load_tests(loader, tests, pattern):
+    suite = unittest.TestLoader().loadTestsFromTestCase(SD_Sys_Firewall_Tests)
+    return suite

--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -82,7 +82,7 @@ class SD_VM_Tests(unittest.TestCase):
         nvm = vm.netvm
         self.assertTrue(nvm is None)
         # No sd-gpg-template, since keyring is managed in $HOME
-        self.assertTrue(vm.template == "sd-workstation-template")
+        self.assertTrue(vm.template == "securedrop-workstation")
         self.assertTrue(vm.autostart is True)
         self.assertFalse(vm.provides_network)
         self.assertFalse(vm.template_for_dispvms)
@@ -90,10 +90,11 @@ class SD_VM_Tests(unittest.TestCase):
         self.assertTrue('sd-workstation' in vm.tags)
 
     def test_sd_workstation_template(self):
-        vm = self.app.domains["sd-workstation-template"]
+        vm = self.app.domains["securedrop-workstation"]
         nvm = vm.netvm
         self.assertTrue(nvm is None)
-        self._check_kernel(vm)
+        self.assertTrue(vm.virt_mode == "hvm")
+        self.assertTrue(vm.kernel == "")
         self.assertTrue('sd-workstation' in vm.tags)
         self._check_kernel(vm)
 


### PR DESCRIPTION
Installs the newly hosted (#251) RPM package `qubes-template-securedrop-workstation` in dom0. The TemplateVM is used for all the SDW components. Here we update the clone logic from `debian-9` to `securedrop-workstation`, which is the VM as named by the RPM package.

The changes are straightforward in terms of the diff:

  1. Install the RPM in dom0 (was previously commented out in #251).
  2. Update the qvm.clone calls to omit debian-9.
  3. Updates all apt packages inside the TemplateVM.
  4. Adds a few config tests (that should have been included in #251).

Step 3 above is important because as soon as we start preferring the RPM to the debian-9 for clone operations, we'll see apt package drift that would be replicated across all cloned VMs. Therefore we run apt upgrade against _just_ the `securedrop-workstation` TemplateVM, prior to cloning, to ensure the packages are only fetched once.

Closes #157.

### Testing
Before starting, make sure updates are applied to your current Qubes TemplateVMs. Otherwise, the apt upgrade checks may show errors that are not related to the changes presented in this PR.

1. `make all` in dom0
2. `make test` in dom0 shows no errors
3. Run `securedrop-client` in `sd-svs` to confirm packages are installed



