### PR TITLE
Install evince in sd-svs-disp-template

### DIFF
--- a/dom0/sd-svs-disp-files.sls
+++ b/dom0/sd-svs-disp-files.sls
@@ -17,6 +17,7 @@ sd-svs-disp-install-mimetype-handler-package:
   pkg.installed:
     - pkgs:
       - securedrop-workstation-svs-disp
+      - evince
     - require:
       - sls: fpf-apt-test-repo
 

--- a/tests/test_svs_disp.py
+++ b/tests/test_svs_disp.py
@@ -12,6 +12,10 @@ class SD_SVS_Disp_Tests(SD_VM_Local_Test):
         pkg = "securedrop-workstation-svs-disp"
         self.assertTrue(self._package_is_installed(pkg))
 
+    def test_sd_svs_disp_evince_installed(self):
+        pkg = "evince"
+        self.assertTrue(self._package_is_installed(pkg))
+
     def test_sd_svs_disp_libreoffice_installed(self):
         self.assertTrue(self._package_is_installed("libreoffice"))
 


### PR DESCRIPTION
Fixes #282 

#### Test plan:

- `make clean`
-  `make all`
- [x] `make test` all tests pass
- [x] PDF file successfully opens in disposable VM from securedrop-client in sd-svs