### PR TITLE
Do not explicitly install qubes-template-whonix-ws/gw-14

### DIFF
--- a/dom0/sd-dom0-files.sls
+++ b/dom0/sd-dom0-files.sls
@@ -116,16 +116,12 @@ dom0-enabled-apparmor-on-whonix-gw-14-template:
     - name: whonix-gw-14
     - prefs:
       - kernelopts: "nopat apparmor=1 security=apparmor"
-    - require:
-      - pkg: dom0-install-whonix-14-templates
 
 dom0-enabled-apparmor-on-whonix-ws-14-template:
   qvm.vm:
     - name: whonix-ws-14
     - prefs:
       - kernelopts: "nopat apparmor=1 security=apparmor"
-    - require:
-      - pkg: dom0-install-whonix-14-templates
 
 dom0-create-opt-securedrop-directory:
   file.directory:

--- a/dom0/sd-dom0-files.sls
+++ b/dom0/sd-dom0-files.sls
@@ -111,13 +111,6 @@ dom0-install-fedora-29-template:
     - pkgs:
       - qubes-template-fedora-29
 
-dom0-install-whonix-14-templates:
-  pkg.installed:
-    - fromrepo: qubes-templates-community
-    - pkgs:
-      - qubes-template-whonix-gw-14
-      - qubes-template-whonix-ws-14
-
 dom0-enabled-apparmor-on-whonix-gw-14-template:
   qvm.vm:
     - name: whonix-gw-14

--- a/dom0/sd-proxy.sls
+++ b/dom0/sd-proxy.sls
@@ -37,7 +37,6 @@ sd-proxy:
       - add:
         - sd-workstation
     - require:
-      - pkg: qubes-template-whonix-ws-14
       - qvm: sd-whonix
       - qvm: sd-proxy-template
 

--- a/dom0/sd-whonix.sls
+++ b/dom0/sd-whonix.sls
@@ -29,5 +29,4 @@ sd-whonix:
       - add:
         - sd-workstation
     - require:
-      - pkg: qubes-template-whonix-gw-14
       - qvm: sys-firewall


### PR DESCRIPTION
Fixes #287 

Since Qubes 4.0.1 isos include these templates. The templates cannot be downloaded via qubes-dom0-upgrade so fail on clean install.