### PR TITLE
Provision submission key fingerprint in config.json to sd-svs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ sd-gpg: prep-salt ## Provisions SD GPG keystore VM
 sd-svs: prep-salt ## Provisions SD SVS VM
 	sudo qubesctl top.enable sd-svs
 	sudo qubesctl top.enable sd-svs-files
+	sudo qubesctl top.enable sd-svs-config
 	sudo qubesctl --show-output --targets sd-svs-template state.highstate
 	sudo qubesctl --show-output --targets sd-svs state.highstate
 

--- a/config.json.example
+++ b/config.json.example
@@ -1,4 +1,5 @@
 {
+  "submission_key_fpr": "65A1B5FF195B56353CC63DFFCC40EF1228271441",
   "hidserv": {
     "hostname": "avgfxawdn6c3coe3.onion",
     "key": "Il8Xas7uf6rjtc0LxYwhrx"

--- a/dom0/sd-svs-config.sls
+++ b/dom0/sd-svs-config.sls
@@ -1,0 +1,24 @@
+##
+# sd-svs-config
+# ========
+#
+# Moves files into place on sd-svs
+#
+#
+
+# populate config.json for sd-svs. This contains the journalist_key_fingerprint
+# used to encrypt replies
+
+{% import_json "sd/config.json" as d %}
+
+install-securedrop-proxy-yaml-config:
+  file.managed:
+    - name: /home/user/.securedrop_client/config.json
+    - source: salt://sd/sd-svs/config.json.j2
+    - template: jinja
+    - context:
+        submission_fpr: {{ d.submission_key_fpr}}
+    - user: user
+    - group: user
+    - mode: 0600
+    - makedirs: True

--- a/dom0/sd-svs-config.top
+++ b/dom0/sd-svs-config.top
@@ -1,0 +1,3 @@
+base:
+  sd-svs:
+    - sd-svs-config

--- a/dom0/sd-svs-files.sls
+++ b/dom0/sd-svs-files.sls
@@ -5,7 +5,7 @@
 # sd-svs-files
 # ========
 #
-# Moves files into place on sd-svs
+# Moves files into place on sd-svs-template
 #
 ##
 include:

--- a/sd-svs/config.json.j2
+++ b/sd-svs/config.json.j2
@@ -1,0 +1,1 @@
+{"journalist_key_fingerprint": "{{ submission_fpr }}"}

--- a/tests/test_svs.py
+++ b/tests/test_svs.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 
 from base import SD_VM_Local_Test
@@ -25,6 +26,14 @@ class SD_SVS_Tests(SD_VM_Local_Test):
 
     def test_sd_client_package_installed(self):
         self.assertTrue(self._package_is_installed("securedrop-client"))
+
+    def test_sd_client_config(self):
+        with open("config.json") as c:
+            config = json.load(c)
+            submission_fpr = config['submission_key_fpr']
+
+        line = '{{"journalist_key_fingerprint": "{}"}}'.format(submission_fpr)
+        self.assertFileHasLine("/home/user/.securedrop_client/config.json", line)
 
 
 def load_tests(loader, tests, pattern):


### PR DESCRIPTION
Towards https://github.com/freedomofpress/securedrop-client/issues/475

The SecureDrop client expects a file named config.json in /home/user/.securedrop_client/ containing the journalist key fingerprint. This key is used to encrypt replies to the submission (journalist key), so that replies can be decrypted by journalists in the client. This is because replies are encrypted in the client.

/home/user/.securedrop_client folder is populated on first run, and since it's the home directory, must be applied to `sd-svs` and not `sd-svs-template`

dom0 config.json file should now contain the GPG fingerprint of the submission key, which will populate config.json file in sd-svs.


### Test plan
- `make clean`
- checkout this branch and `make clone`
- add a `submission_key_fpr` containing the GPG fingerprint of the SecureDrop instance used 
- `make all`
- [ ] all tests pass with `make test`
- [ ] I can send a reply to a source from the client