### PR TITLE
Friendlier output on make clean action

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,11 +90,11 @@ remove-sd-export: assert-dom0 detach-sd-export-usb ## Destroys SD EXPORT VMs
 	@./scripts/destroy-vm sd-export-usb-dvm
 
 detach-sd-export-usb: assert-dom0 ## Detach USB device from SD EXPORT USB VM
-	@qvm-kill sd-export-usb || true
-	@qvm-usb detach sd-export-usb || true
+	@qvm-kill sd-export-usb 2>/dev/null || true
+	@qvm-usb detach sd-export-usb 2>/dev/null || true
 
 clean: assert-dom0 detach-sd-export-usb destroy-all clean-salt ## Destroys all SD VMs
-	sudo dnf -y -q remove securedrop-workstation-dom0-config || true
+	sudo dnf -y -q remove securedrop-workstation-dom0-config 2>/dev/null || true
 	sudo rm -f /usr/bin/securedrop-update \
 		/etc/cron.daily/securedrop-update-cron
 


### PR DESCRIPTION
The force-removal commands for VMs and dom0 RPMs were emitting stderr
messages that could be construed by developers as genuine errors in the
clean process, rather than expected output while ensuring absent state.
Updated the makefile targets for removing the sd-export-usb VM and the
dom0 salt config RPM to silence stderr.

Closes #286. 

### Before
```
usage: qvm-kill [--verbose] [--quiet] [--help] [--all] [--exclude EXCLUDE]
                [VMNAME [VMNAME ...]]
qvm-kill: error: no such domain: 'sd-export-usb'
usage: qvm-usb [--verbose] [--quiet] [--help]
               {list,ls,l,attach,at,a,detach,d,dt} ...
qvm-usb: error: no such domain: 'sd-export-usb'
Destroying VM 'sd-gpg'... (absent)
Destroying VM 'sd-proxy'... (absent)
Destroying VM 'sd-proxy-template'... (absent)
Destroying VM 'sd-svs'... (absent)
Destroying VM 'sd-svs-template'... (absent)
Destroying VM 'securedrop-workstation'... OK
Destroying VM 'sd-whonix'... (absent)
Destroying VM 'sd-svs-disp'... (absent)
Destroying VM 'sd-svs-disp-template'... (absent)
Destroying VM 'sd-export-usb'... (absent)
Destroying VM 'sd-export-usb-dvm'... (absent)
Destroying VM 'sd-export-template'... (absent)
Purging Salt config...
sudo dnf -y -q remove securedrop-workstation-dom0-config || true
Error: No packages marked for removal.
sudo rm -f /usr/bin/securedrop-update \
	/etc/cron.daily/securedrop-update-cron
```


### After
```
Destroying VM 'sd-gpg'... (absent)
Destroying VM 'sd-proxy'... (absent)
Destroying VM 'sd-proxy-template'... (absent)
Destroying VM 'sd-svs'... (absent)
Destroying VM 'sd-svs-template'... (absent)
Destroying VM 'securedrop-workstation'... OK
Destroying VM 'sd-whonix'... (absent)
Destroying VM 'sd-svs-disp'... (absent)
Destroying VM 'sd-svs-disp-template'... (absent)
Destroying VM 'sd-export-usb'... (absent)
Destroying VM 'sd-export-usb-dvm'... (absent)
Destroying VM 'sd-export-template'... (absent)
Purging Salt config...
sudo dnf -y -q remove securedrop-workstation-dom0-config 2>/dev/null || true
sudo rm -f /usr/bin/securedrop-update \
	/etc/cron.daily/securedrop-update-cron
```