### PR TITLE
Add sd-export-config.json in sd-export VMs

### DIFF
--- a/dom0/sd-export-files.sls
+++ b/dom0/sd-export-files.sls
@@ -77,3 +77,22 @@ sd-export-securedrop-icon:
     - group: root
     - mode: 644
     - makedirs: True
+
+# populate sd-export-config.json in sd-export-template. This contains the usb
+# device information used for the export
+
+{% import_json "sd/config.json" as d %}
+
+install-securedrop-export-json-config:
+  file.managed:
+    - name: /etc/sd-export-config.json
+    - source: salt://sd/sd-export/config.json.j2
+    - template: jinja
+    - context:
+        # get pci ID and usb ID from config.json
+        pci_bus_id_value: {{ (d.usb.device | regex_search('sys-usb:(.)-.'))[0] | int }}
+        usb_device_value: {{ (d.usb.device | regex_search('sys-usb:.-(.)'))[0] | int }}
+    - user: user
+    - group: user
+    - mode: 0644
+    - makedirs: True

--- a/sd-export/config.json.j2
+++ b/sd-export/config.json.j2
@@ -1,0 +1,4 @@
+{
+  "pci_bus_id": "{{ pci_bus_id_value }}",
+  "usb_device": "{{ usb_device_value }}"
+}

--- a/tests/test_sd_export.py
+++ b/tests/test_sd_export.py
@@ -1,3 +1,5 @@
+import json
+import re
 import unittest
 
 from base import SD_VM_Local_Test
@@ -20,6 +22,24 @@ class SD_Export_Tests(SD_VM_Local_Test):
     def test_sd_export_package_installed(self):
         self.assertTrue(self._package_is_installed("cryptsetup"))
         self.assertTrue(self._package_is_installed("printer-driver-brlaser"))
+
+    def test_sd_export_config_present(self):
+        with open("config.json") as c:
+            config = json.load(c)
+
+            # Extract values from config.json
+            match = re.match(r'sys-usb:(\d)-(\d)', config['usb']['device'])
+            pci_bus_id_value = match.group(1)
+            usb_device_value = match.group(2)
+
+        wanted_lines = [
+            "{",
+            "  \"pci_bus_id\": \"{}\",".format(pci_bus_id_value),
+            "  \"usb_device\": \"{}\"".format(usb_device_value),
+            "}",
+        ]
+        for line in wanted_lines:
+            self.assertFileHasLine("/etc/sd-export-config.json", line)
 
 
 def load_tests(loader, tests, pattern):


### PR DESCRIPTION
Towards #281 

This will allow sd-export to know what the dedicated USB device is for the export VM to facilitate preflight checks. This is required for the securedrop-export script to be able to know what the usb device configuration is. This is required for the USB preflight check, to check if a device is connected or not.

### Test plan
- [ ] make sd-export completes without error
- [ ] make test completes without error
- [ ] observe the configuration is populated in sd-export-usb (example below)

```
user@sd-export-usb:~$ cat /etc/sd-export-config.json 
{
  "pci_bus_id": "2",
  "usb_device": "4"
}
```