### PR TITLE
Update qrexec policy keywords

### DIFF
--- a/dom0/sd-dom0-qvm-rpc.sls
+++ b/dom0/sd-dom0-qvm-rpc.sls
@@ -17,7 +17,7 @@ dom0-rpc-qubes.ClipboardPaste:
     - marker_start: "### BEGIN securedrop-workstation ###"
     - marker_end: "### END securedrop-workstation ###"
     - content: |
-        $anyvm $tag:sd-workstation deny
+        @anyvm @tag:sd-workstation deny
 dom0-rpc-qubes.FeaturesRequest:
   file.blockreplace:
     - name: /etc/qubes-rpc/policy/qubes.FeaturesRequest
@@ -25,7 +25,7 @@ dom0-rpc-qubes.FeaturesRequest:
     - marker_start: "### BEGIN securedrop-workstation ###"
     - marker_end: "### END securedrop-workstation ###"
     - content: |
-        $anyvm $tag:sd-workstation deny
+        @anyvm @tag:sd-workstation deny
 dom0-rpc-qubes.Filecopy:
   file.blockreplace:
     - name: /etc/qubes-rpc/policy/qubes.Filecopy
@@ -33,8 +33,8 @@ dom0-rpc-qubes.Filecopy:
     - marker_start: "### BEGIN securedrop-workstation ###"
     - marker_end: "### END securedrop-workstation ###"
     - content: |
-        sd-proxy $tag:sd-client allow
-        $anyvm $tag:sd-workstation deny
+        sd-proxy @tag:sd-client allow
+        @anyvm @tag:sd-workstation deny
 dom0-rpc-qubes.OpenInVM:
   file.blockreplace:
     - name: /etc/qubes-rpc/policy/qubes.OpenInVM
@@ -42,9 +42,9 @@ dom0-rpc-qubes.OpenInVM:
     - marker_start: "### BEGIN securedrop-workstation ###"
     - marker_end: "### END securedrop-workstation ###"
     - content: |
-        $tag:sd-client $dispvm:sd-svs-disp allow
-        $tag:sd-client sd-export-usb allow
-        $anyvm $tag:sd-workstation deny
+        @tag:sd-client @dispvm:sd-svs-disp allow
+        @tag:sd-client sd-export-usb allow
+        @anyvm @tag:sd-workstation deny
 dom0-rpc-qubes.OpenURL:
   file.blockreplace:
     - name: /etc/qubes-rpc/policy/qubes.OpenURL
@@ -52,7 +52,7 @@ dom0-rpc-qubes.OpenURL:
     - marker_start: "### BEGIN securedrop-workstation ###"
     - marker_end: "### END securedrop-workstation ###"
     - content: |
-        $anyvm $tag:sd-workstation deny
+        @anyvm @tag:sd-workstation deny
 dom0-rpc-qubes.PdfConvert:
   file.blockreplace:
     - name: /etc/qubes-rpc/policy/qubes.PdfConvert
@@ -60,7 +60,7 @@ dom0-rpc-qubes.PdfConvert:
     - marker_start: "### BEGIN securedrop-workstation ###"
     - marker_end: "### END securedrop-workstation ###"
     - content: |
-        $anyvm $tag:sd-workstation deny
+        @anyvm @tag:sd-workstation deny
 dom0-rpc-qubes.StartApp:
   file.blockreplace:
     - name: /etc/qubes-rpc/policy/qubes.StartApp
@@ -68,7 +68,7 @@ dom0-rpc-qubes.StartApp:
     - marker_start: "### BEGIN securedrop-workstation ###"
     - marker_end: "### END securedrop-workstation ###"
     - content: |
-        $anyvm $tag:sd-workstation deny
+        @anyvm @tag:sd-workstation deny
 dom0-rpc-qubes.USB:
   file.blockreplace:
     - name: /etc/qubes-rpc/policy/qubes.USB
@@ -76,7 +76,7 @@ dom0-rpc-qubes.USB:
     - marker_start: "### BEGIN securedrop-workstation ###"
     - marker_end: "### END securedrop-workstation ###"
     - content: |
-        $anyvm $tag:sd-workstation deny
+        @anyvm @tag:sd-workstation deny
 dom0-rpc-qubes.VMRootShell:
   file.blockreplace:
     - name: /etc/qubes-rpc/policy/qubes.VMRootShell
@@ -84,7 +84,7 @@ dom0-rpc-qubes.VMRootShell:
     - marker_start: "### BEGIN securedrop-workstation ###"
     - marker_end: "### END securedrop-workstation ###"
     - content: |
-        $anyvm $tag:sd-workstation deny
+        @anyvm @tag:sd-workstation deny
 dom0-rpc-qubes.VMshell:
   file.blockreplace:
     - name: /etc/qubes-rpc/policy/qubes.VMShell
@@ -92,7 +92,7 @@ dom0-rpc-qubes.VMshell:
     - marker_start: "### BEGIN securedrop-workstation ###"
     - marker_end: "### END securedrop-workstation ###"
     - content: |
-        $anyvm $tag:sd-workstation deny
+        @anyvm @tag:sd-workstation deny
 dom0-rpc-qubes.Gpg:
   file.blockreplace:
     - name: /etc/qubes-rpc/policy/qubes.Gpg
@@ -100,8 +100,8 @@ dom0-rpc-qubes.Gpg:
     - marker_start: "### BEGIN securedrop-workstation ###"
     - marker_end: "### END securedrop-workstation ###"
     - content: |
-        $tag:sd-client sd-gpg allow
-        $anyvm $tag:sd-workstation deny
+        @tag:sd-client sd-gpg allow
+        @anyvm @tag:sd-workstation deny
 dom0-rpc-qubes.GpgImportKey:
   file.blockreplace:
     - name: /etc/qubes-rpc/policy/qubes.GpgImportKey
@@ -109,5 +109,5 @@ dom0-rpc-qubes.GpgImportKey:
     - marker_start: "### BEGIN securedrop-workstation ###"
     - marker_end: "### END securedrop-workstation ###"
     - content: |
-        $tag:sd-client sd-gpg allow
-        $anyvm $tag:sd-workstation deny
+        @tag:sd-client sd-gpg allow
+        @anyvm @tag:sd-workstation deny

--- a/dom0/sd-proxy.sls
+++ b/dom0/sd-proxy.sls
@@ -49,4 +49,4 @@ sd-proxy-dom0-securedrop.Proxy:
     - name: /etc/qubes-rpc/policy/securedrop.Proxy
     - text: |
         sd-svs sd-proxy allow
-        $anyvm $anyvm deny
+        @anyvm @anyvm deny

--- a/tests/vars/qubes-rpc.yml
+++ b/tests/vars/qubes-rpc.yml
@@ -1,175 +1,175 @@
 - policy: ClipboardPaste
   starts_with: |-
     ### BEGIN securedrop-workstation ###
-    $anyvm $tag:sd-workstation deny
+    @anyvm @tag:sd-workstation deny
     ### END securedrop-workstation ###
 
 - policy: FeaturesRequest
   starts_with: |-
     ### BEGIN securedrop-workstation ###
-    $anyvm $tag:sd-workstation deny
+    @anyvm @tag:sd-workstation deny
     ### END securedrop-workstation ###
 
 - policy: Filecopy
   starts_with: |-
     ### BEGIN securedrop-workstation ###
-    sd-proxy $tag:sd-client allow
-    $anyvm $tag:sd-workstation deny
+    sd-proxy @tag:sd-client allow
+    @anyvm @tag:sd-workstation deny
     ### END securedrop-workstation ###
 
 - policy: GetDate
   starts_with: |-
     ## Note that policy parsing stops at the first match,
-    ## so adding anything below "$anyvm $anyvm action" line will have no effect
+    ## so adding anything below "@anyvm @anyvm action" line will have no effect
 
     ## Please use a single # to start your custom comments
 
-    $tag:anon-vm	$anyvm	deny
-    $anyvm	$anyvm	allow,target=dom0
+    @tag:anon-vm	@anyvm	deny
+    @anyvm	@anyvm	allow,target=dom0
 
 - policy: GetRandomizedTime
   starts_with: |-
     ## Note that policy parsing stops at the first match,
-    ## so adding anything below "$anyvm $anyvm action" line will have no effect
+    ## so adding anything below "@anyvm @anyvm action" line will have no effect
 
     ## Please use a single # to start your custom comments
 
-    $anyvm	dom0	allow
+    @anyvm	dom0	allow
 
 - policy: GetImageRGBA
   starts_with: |-
     ## Note that policy parsing stops at the first match,
-    ## so adding anything below "$anyvm $anyvm action" line will have no effect
+    ## so adding anything below "@anyvm @anyvm action" line will have no effect
 
     ## Please use a single # to start your custom comments
 
-    $anyvm $dispvm allow
-    $anyvm $anyvm ask
+    @anyvm @dispvm allow
+    @anyvm @anyvm ask
 
 - policy: Gpg
   starts_with: |-
     ### BEGIN securedrop-workstation ###
-    $tag:sd-client sd-gpg allow
-    $anyvm $tag:sd-workstation deny
+    @tag:sd-client sd-gpg allow
+    @anyvm @tag:sd-workstation deny
     ### END securedrop-workstation ###
 
 - policy: GpgImportKey
   starts_with: |-
     ### BEGIN securedrop-workstation ###
-    $tag:sd-client sd-gpg allow
-    $anyvm $tag:sd-workstation deny
+    @tag:sd-client sd-gpg allow
+    @anyvm @tag:sd-workstation deny
     ### END securedrop-workstation ###
 
 - policy: InputKeyboard
   starts_with: |-
-    $anyvm $anyvm deny
+    @anyvm @anyvm deny
 
 - policy: InputMouse
   starts_with: |-
     sys-usb dom0 allow,user=root
-    $anyvm $anyvm deny
+    @anyvm @anyvm deny
 
 - policy: NotifyTools
   starts_with: |-
     ## Note that policy parsing stops at the first match,
-    ## so adding anything below "$anyvm $anyvm action" line will have no effect
+    ## so adding anything below "@anyvm @anyvm action" line will have no effect
 
     ## Please use a single # to start your custom comments
 
-    $anyvm	dom0	allow
+    @anyvm	dom0	allow
 
 - policy: NotifyUpdates
   starts_with: |-
     ## Note that policy parsing stops at the first match,
-    ## so adding anything below "$anyvm $anyvm action" line will have no effect
+    ## so adding anything below "@anyvm @anyvm action" line will have no effect
 
     ## Please use a single # to start your custom comments
 
-    $anyvm	dom0	allow
+    @anyvm	dom0	allow
 
 - policy: OpenInVM
   starts_with: |-
     ### BEGIN securedrop-workstation ###
-    $tag:sd-client $dispvm:sd-svs-disp allow
-    $tag:sd-client sd-export-usb allow
-    $anyvm $tag:sd-workstation deny
+    @tag:sd-client @dispvm:sd-svs-disp allow
+    @tag:sd-client sd-export-usb allow
+    @anyvm @tag:sd-workstation deny
     ### END securedrop-workstation ###
 
 - policy: OpenURL
   starts_with: |-
     ### BEGIN securedrop-workstation ###
-    $anyvm $tag:sd-workstation deny
+    @anyvm @tag:sd-workstation deny
     ### END securedrop-workstation ###
 
 - policy: PdfConvert
   starts_with: |-
     ### BEGIN securedrop-workstation ###
-    $anyvm $tag:sd-workstation deny
+    @anyvm @tag:sd-workstation deny
     ### END securedrop-workstation ###
 
 - policy: ReceiveUpdates
   starts_with: |-
     ## Note that policy parsing stops at the first match,
-    ## so adding anything below "$anyvm $anyvm action" line will have no effect
+    ## so adding anything below "@anyvm @anyvm action" line will have no effect
 
     ## Please use a single # to start your custom comments
 
-    $anyvm	dom0	allow
+    @anyvm	dom0	allow
 
 - policy: StartApp
   starts_with: |-
     ### BEGIN securedrop-workstation ###
-    $anyvm $tag:sd-workstation deny
+    @anyvm @tag:sd-workstation deny
     ### END securedrop-workstation ###
 
 - policy: SyncAppMenus
   starts_with: |-
     ## Note that policy parsing stops at the first match,
-    ## so adding anything below "$anyvm $anyvm action" line will have no effect
+    ## so adding anything below "@anyvm @anyvm action" line will have no effect
 
     ## Please use a single # to start your custom comments
 
-    $anyvm	dom0	allow
+    @anyvm	dom0	allow
 
 - policy: UpdatesProxy
   starts_with: |-
     ## Note that policy parsing stops at the first match,
-    ## so adding anything below "$anyvm $anyvm action" line will have no effect
+    ## so adding anything below "@anyvm @anyvm action" line will have no effect
 
     ## Please use a single # to start your custom comments
 
     # Upgrade all TemplateVMs through sys-whonix.
-    #$type:TemplateVM $default allow,target=sys-whonix
+    #@type:TemplateVM @default allow,target=sys-whonix
 
     # Upgrade Whonix TemplateVMs through sys-whonix.
-    $tag:whonix-updatevm $default allow,target=sys-whonix
+    @tag:whonix-updatevm @default allow,target=sys-whonix
 
     # Deny Whonix TemplateVMs using UpdatesProxy of any other VM.
-    $tag:whonix-updatevm $anyvm deny
+    @tag:whonix-updatevm @anyvm deny
 
     # Default rule for all TemplateVMs - direct the connection to sys-net
-    $type:TemplateVM $default allow,target=sys-net
+    @type:TemplateVM @default allow,target=sys-net
 
-    $anyvm $anyvm deny
+    @anyvm @anyvm deny
 
 - policy: USB
   starts_with: |-
     ### BEGIN securedrop-workstation ###
-    $anyvm $tag:sd-workstation deny
+    @anyvm @tag:sd-workstation deny
     ### END securedrop-workstation ###
 
 - policy: VMRootShell
   starts_with: |-
     ### BEGIN securedrop-workstation ###
-    $anyvm $tag:sd-workstation deny
+    @anyvm @tag:sd-workstation deny
     ### END securedrop-workstation ###
 
 - policy: VMShell
   starts_with: |-
     ### BEGIN securedrop-workstation ###
-    $anyvm $tag:sd-workstation deny
+    @anyvm @tag:sd-workstation deny
     ### END securedrop-workstation ###
 
 - policy: WindowIconUpdater
   starts_with: |-
-    $anyvm dom0 allow
+    @anyvm dom0 allow

--- a/tests/vars/qubes-rpc.yml
+++ b/tests/vars/qubes-rpc.yml
@@ -20,31 +20,31 @@
 - policy: GetDate
   starts_with: |-
     ## Note that policy parsing stops at the first match,
-    ## so adding anything below "@anyvm @anyvm action" line will have no effect
+    ## so adding anything below "$anyvm $anyvm action" line will have no effect
 
     ## Please use a single # to start your custom comments
 
-    @tag:anon-vm	@anyvm	deny
-    @anyvm	@anyvm	allow,target=dom0
+    $tag:anon-vm	$anyvm	deny
+    $anyvm	$anyvm	allow,target=dom0
 
 - policy: GetRandomizedTime
   starts_with: |-
     ## Note that policy parsing stops at the first match,
-    ## so adding anything below "@anyvm @anyvm action" line will have no effect
+    ## so adding anything below "$anyvm $anyvm action" line will have no effect
 
     ## Please use a single # to start your custom comments
 
-    @anyvm	dom0	allow
+    $anyvm	dom0	allow
 
 - policy: GetImageRGBA
   starts_with: |-
     ## Note that policy parsing stops at the first match,
-    ## so adding anything below "@anyvm @anyvm action" line will have no effect
+    ## so adding anything below "$anyvm $anyvm action" line will have no effect
 
     ## Please use a single # to start your custom comments
 
-    @anyvm @dispvm allow
-    @anyvm @anyvm ask
+    $anyvm $dispvm allow
+    $anyvm $anyvm ask
 
 - policy: Gpg
   starts_with: |-
@@ -62,30 +62,30 @@
 
 - policy: InputKeyboard
   starts_with: |-
-    @anyvm @anyvm deny
+    $anyvm $anyvm deny
 
 - policy: InputMouse
   starts_with: |-
     sys-usb dom0 allow,user=root
-    @anyvm @anyvm deny
+    $anyvm $anyvm deny
 
 - policy: NotifyTools
   starts_with: |-
     ## Note that policy parsing stops at the first match,
-    ## so adding anything below "@anyvm @anyvm action" line will have no effect
+    ## so adding anything below "$anyvm $anyvm action" line will have no effect
 
     ## Please use a single # to start your custom comments
 
-    @anyvm	dom0	allow
+    $anyvm	dom0	allow
 
 - policy: NotifyUpdates
   starts_with: |-
     ## Note that policy parsing stops at the first match,
-    ## so adding anything below "@anyvm @anyvm action" line will have no effect
+    ## so adding anything below "$anyvm $anyvm action" line will have no effect
 
     ## Please use a single # to start your custom comments
 
-    @anyvm	dom0	allow
+    $anyvm	dom0	allow
 
 - policy: OpenInVM
   starts_with: |-
@@ -110,11 +110,11 @@
 - policy: ReceiveUpdates
   starts_with: |-
     ## Note that policy parsing stops at the first match,
-    ## so adding anything below "@anyvm @anyvm action" line will have no effect
+    ## so adding anything below "$anyvm $anyvm action" line will have no effect
 
     ## Please use a single # to start your custom comments
 
-    @anyvm	dom0	allow
+    $anyvm	dom0	allow
 
 - policy: StartApp
   starts_with: |-
@@ -125,32 +125,32 @@
 - policy: SyncAppMenus
   starts_with: |-
     ## Note that policy parsing stops at the first match,
-    ## so adding anything below "@anyvm @anyvm action" line will have no effect
+    ## so adding anything below "$anyvm $anyvm action" line will have no effect
 
     ## Please use a single # to start your custom comments
 
-    @anyvm	dom0	allow
+    $anyvm	dom0	allow
 
 - policy: UpdatesProxy
   starts_with: |-
     ## Note that policy parsing stops at the first match,
-    ## so adding anything below "@anyvm @anyvm action" line will have no effect
+    ## so adding anything below "$anyvm $anyvm action" line will have no effect
 
     ## Please use a single # to start your custom comments
 
     # Upgrade all TemplateVMs through sys-whonix.
-    #@type:TemplateVM @default allow,target=sys-whonix
+    #$type:TemplateVM $default allow,target=sys-whonix
 
     # Upgrade Whonix TemplateVMs through sys-whonix.
-    @tag:whonix-updatevm @default allow,target=sys-whonix
+    $tag:whonix-updatevm $default allow,target=sys-whonix
 
     # Deny Whonix TemplateVMs using UpdatesProxy of any other VM.
-    @tag:whonix-updatevm @anyvm deny
+    $tag:whonix-updatevm $anyvm deny
 
     # Default rule for all TemplateVMs - direct the connection to sys-net
-    @type:TemplateVM @default allow,target=sys-net
+    $type:TemplateVM $default allow,target=sys-net
 
-    @anyvm @anyvm deny
+    $anyvm $anyvm deny
 
 - policy: USB
   starts_with: |-
@@ -172,4 +172,4 @@
 
 - policy: WindowIconUpdater
   starts_with: |-
-    @anyvm dom0 allow
+    $anyvm dom0 allow


### PR DESCRIPTION
Qubes advises that all qrexec policy keywords should now begin with `@` (instead of `$`).

For context, see the security bulletin here: https://github.com/QubesOS/qubes-secpack/blob/master/QSBs/qsb-038-2018.txt

Fixes #309