### PR TITLE
Disables Whonix 14 repos

### DIFF
--- a/dom0/fpf-apt-test-repo.sls
+++ b/dom0/fpf-apt-test-repo.sls
@@ -41,3 +41,26 @@ update-all-apt-packages:
     - dist_upgrade: True
     - require:
       - pkg: install-python-apt-for-repo-config
+
+# The Whonix 14 repos are no longer maintained, so disable them to allow
+# apt to pull in updates from Debian upstream (and FPF apt repo).
+# Temporary measure until we migrate to Whonix 15, and Buster across the board.
+disable-whonix-14-repositories-onion:
+  file.line:
+    - name: /etc/apt/sources.list.d/whonix.list
+    - mode: replace
+    - match: "dds6qkxpwdeubwucdiaord2xgbbeyds25rbsgr73tbfpqpt4a6vjwsyd.onion stretch"
+    - content: "#deb tor+http://deb.dds6qkxpwdeubwucdiaord2xgbbeyds25rbsgr73tbfpqpt4a6vjwsyd.onion stretch main contrib non-free"
+    - backup: yes
+    - onlyif:
+      - test -f /etc/apt/sources.list.d/whonix.list
+
+disable-whonix-14-repositories-clearnet:
+  file.line:
+    - name: /etc/apt/sources.list.d/whonix.list
+    - mode: replace
+    - match: "deb.whonix.org stretch"
+    - content: "#deb https://deb.whonix.org stretch main contrib non-free"
+    - backup: yes
+    - onlyif:
+      - test -f /etc/apt/sources.list.d/whonix.list

--- a/tests/test_whonix_gw_14.py
+++ b/tests/test_whonix_gw_14.py
@@ -1,0 +1,23 @@
+import unittest
+
+from base import SD_VM_Local_Test
+
+
+class Whonix_Gateway_14_Tests(SD_VM_Local_Test):
+    def setUp(self):
+        self.vm_name = "whonix-gw-14"
+        self.whonix_apt_list = "/etc/apt/sources.list.d/whonix.list"
+        super(Whonix_Gateway_14_Tests, self).setUp()
+
+    def test_whonix_gw_14_onion_repo_disabled(self):
+        whonix_apt_repo_disabled = "#deb tor+http://deb.dds6qkxpwdeubwucdiaord2xgbbeyds25rbsgr73tbfpqpt4a6vjwsyd.onion stretch main contrib non-free"  # noqa
+        self.assertFileHasLine(self.whonix_apt_list, whonix_apt_repo_disabled)
+
+    def test_whonix_gw_14_clearnet_repo_disabled(self):
+        whonix_apt_repo_disabled = "#deb https://deb.whonix.org stretch main contrib non-free"  # noqa
+        self.assertFileHasLine(self.whonix_apt_list, whonix_apt_repo_disabled)
+
+
+def load_tests(loader, tests, pattern):
+    suite = unittest.TestLoader().loadTestsFromTestCase(Whonix_Gateway_14_Tests)
+    return suite

--- a/tests/test_whonix_ws_14.py
+++ b/tests/test_whonix_ws_14.py
@@ -1,0 +1,23 @@
+import unittest
+
+from base import SD_VM_Local_Test
+
+
+class Whonix_Workstation_14_Tests(SD_VM_Local_Test):
+    def setUp(self):
+        self.vm_name = "whonix-ws-14"
+        self.whonix_apt_list = "/etc/apt/sources.list.d/whonix.list"
+        super(Whonix_Workstation_14_Tests, self).setUp()
+
+    def test_whonix_ws_14_repo_disabled(self):
+        whonix_apt_repo_disabled = "#deb tor+http://deb.dds6qkxpwdeubwucdiaord2xgbbeyds25rbsgr73tbfpqpt4a6vjwsyd.onion stretch main contrib non-free"  # noqa
+        self.assertFileHasLine(self.whonix_apt_list, whonix_apt_repo_disabled)
+
+    def test_whonix_ws_14_clearnet_repo_disabled(self):
+        whonix_apt_repo_disabled = "#deb https://deb.whonix.org stretch main contrib non-free"  # noqa
+        self.assertFileHasLine(self.whonix_apt_list, whonix_apt_repo_disabled)
+
+
+def load_tests(loader, tests, pattern):
+    suite = unittest.TestLoader().loadTestsFromTestCase(Whonix_Workstation_14_Tests)
+    return suite


### PR DESCRIPTION
### Overview

Status: Ready for review.

Refs #300, but does not resolve.

### Description
We haven't migrated to Whonix 15 yet, because we're waiting for Debian
10 to become stable in the upstream Qubes repos, so we can build and
serve all SDW-related packages via the buster channel.

Whonix has already EOL'd 14, though, so trying to run an apt update with
the old Whonix channels in place will cause apt to fail, breaking all
provisioning of the sd-whonix and sd-proxy VMs.

Let's disable those repos for now, to allow devs to continue to work,
but the priority remains landing full Buster support across the board.
We disable two possible repo configurations here, both clearnet and
onion repo URLs.

### Testing

The quick-and-dirty test is the usual:

- [ ] `make clone`
- [ ] `make clean`
- [ ] `make all`
- [ ] `make test`

and confirm no errors. Depending on the state of your local environment, though, you may have already customized the `whonix-{gw,ws}-14` VMs to unbreak apt, by commenting out the Whonix repos, as done in the changes presented here. In that case, a full test would ensure that a _clean_ Whonix 14 setup still works. The test plan then becomes:

- [ ] `make clone`
- [ ] `make clean`
- [ ] `sudo dnf remove qubes-template-whonix-gw-14`
- [ ] `sudo dnf remove qubes-tempate-whonix-ws-14`
- [ ] `make all`
- [ ] `make test`

For myself, I used the longer test plan, and I'm able to log into the latest Client nightly and open submissions.