### PR TITLE
Removes auto-updater from workstation

### DIFF
--- a/dom0/sd-dom0-files.sls
+++ b/dom0/sd-dom0-files.sls
@@ -68,20 +68,16 @@ dom0-install-securedrop-workstation-template:
       - file: dom0-workstation-rpm-repo
       - cmd: dom0-rpm-test-key-sys-firewall
 
-# Copy script to system location so admins can run ad-hoc
+# Remove the auto updater script
 dom0-update-securedrop-script:
-  file.managed:
+  file.absent:
     - name: /usr/bin/securedrop-update
-    - source: salt://securedrop-update
-    - user: root
-    - group: root
-    - mode: 755
 
-# Symlink update script into cron, for single point of update
+
+# Remove Symlink update script
 dom0-update-securedrop-script-cron:
   file.symlink:
     - name: /etc/cron.daily/securedrop-update-cron
-    - target: /usr/bin/securedrop-update
 
 # Create directory for storing SecureDrop-specific icons
 dom0-securedrop-icons-directory:


### PR DESCRIPTION
This PR removes the securedrop autoupdater. 

We can get it back in future, for now use the Qubes
updater UI.


## How to test?

In `dom0` after getting this branch.

```
make prep-dom0
```