### PR TITLE
Upgrades all sys-* VMs to Fedora 30

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,10 +218,10 @@ In the future, we plan on shipping a *SecureDrop Workstation* installer package 
 
 ### Building the Templates
 
-1. Create a `fedora-29` AppVM for building the templates. It's going
+1. Create a `fedora-30` AppVM for building the templates. It's going
    to need Docker and several other packages every time you use it, so
    it might be worth creating another template derived from
-   `fedora-29`, into which you can install those extras, and basing
+   `fedora-30`, into which you can install those extras, and basing
    the builder VM on that, or just using a StandaloneVM to save time
    and repetition.
 2. Increase the disk size to at least 15GB (as the build uses over
@@ -454,8 +454,8 @@ make sd-export
 
 ### Transferring files via OnionShare
 
-1. Create an `sd-onionshare-template` VM based on `fedora-29`:
-   1. Click on the Qubes menu in the upper left, select "Template: Fedora 29", click on "fedora-29: Qube Settings", and click on **Clone Qube**
+1. Create an `sd-onionshare-template` VM based on `fedora-30`:
+   1. Click on the Qubes menu in the upper left, select "Template: Fedora 30", click on "fedora-30: Qube Settings", and click on **Clone Qube**
    2. Name the cloned qube `sd-onionshare-template`
    3. In the Qubes menu on the top-left, select "Template: sd-onionshare-template" and click on "sd-onionshare-template: Terminal"
    4. Install OnionShare: `sudo dnf install onionshare`

--- a/dom0/sd-dom0-files.sls
+++ b/dom0/sd-dom0-files.sls
@@ -24,23 +24,6 @@ dom0-rpm-test-key-import:
     - require:
       - file: dom0-rpm-test-key
 
-dom0-rpm-test-key-sys-firewall:
-  cmd.run:
-    # Pass in the pubkey directly to sys-firewall, so it's available on the
-    # UpdateVM for dom0 while we're configuring dom0 repos.
-    - name: >
-        qvm-run -p sys-firewall '
-        sudo tee /etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation-test'
-        < /srv/salt/sd/sd-workstation/apt-test-pubkey.asc
-
-dom0-rpm-test-key-sys-firewall-import:
-  cmd.run:
-    - name: >
-        qvm-run --no-gui sys-firewall '
-        sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation-test'
-    - require:
-      - cmd: dom0-rpm-test-key-sys-firewall
-
 dom0-workstation-rpm-repo:
   # We use file.managed rather than pkgrepo.managed, because Qubes dom0
   # settings write new repos to /etc/yum.real.repos.d/, but only /etc/yum.repos.d/
@@ -66,7 +49,6 @@ dom0-install-securedrop-workstation-template:
       - qubes-template-securedrop-workstation
     - require:
       - file: dom0-workstation-rpm-repo
-      - cmd: dom0-rpm-test-key-sys-firewall
 
 # Copy script to system location so admins can run ad-hoc
 dom0-update-securedrop-script:

--- a/dom0/sd-dom0-files.sls
+++ b/dom0/sd-dom0-files.sls
@@ -10,7 +10,7 @@ dom0-rpm-test-key:
   file.managed:
     # We write the pubkey to the repos config location, because the repos
     # config location is automatically sent to dom0's UpdateVM. Otherwise,
-    # we must place the GPG key inside the fedora-29 TemplateVM, then
+    # we must place the GPG key inside the fedora-30 TemplateVM, then
     # restart sys-firewall.
     - name: /etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation-test
     - source: "salt://sd/sd-workstation/apt-test-pubkey.asc"
@@ -106,10 +106,10 @@ dom0-securedrop-icon:
       - file: dom0-securedrop-icons-directory
 
 # Install latest templates required for SDW VMs.
-dom0-install-fedora-29-template:
+dom0-install-fedora-template:
   pkg.installed:
     - pkgs:
-      - qubes-template-fedora-29
+      - qubes-template-fedora-30
 
 dom0-enabled-apparmor-on-whonix-gw-14-template:
   qvm.vm:

--- a/dom0/sd-dom0-files.sls
+++ b/dom0/sd-dom0-files.sls
@@ -105,12 +105,6 @@ dom0-securedrop-icon:
     - require:
       - file: dom0-securedrop-icons-directory
 
-# Install latest templates required for SDW VMs.
-dom0-install-fedora-template:
-  pkg.installed:
-    - pkgs:
-      - qubes-template-fedora-30
-
 dom0-enabled-apparmor-on-whonix-gw-14-template:
   qvm.vm:
     - name: whonix-gw-14

--- a/dom0/sd-svs-disp.sls
+++ b/dom0/sd-svs-disp.sls
@@ -41,3 +41,9 @@ sd-svs-disp:
         - service.paxctld
     - require:
       - qvm: sd-svs-disp-template
+
+sd-svs-disp-default-dispvm:
+  cmd.run:
+    - name: qubes-prefs default_dispvm sd-svs-disp
+    - require:
+      - qvm: sd-svs-disp

--- a/dom0/sd-sys-firewall-files.sls
+++ b/dom0/sd-sys-firewall-files.sls
@@ -1,0 +1,30 @@
+sys-firewall-rpm-test-key:
+  file.managed:
+    - name: /rw/config/RPM-GPG-KEY-securedrop-workstation-test
+    - source: "salt://sd/sd-workstation/apt-test-pubkey.asc"
+    - user: root
+    - group: root
+    - mode: 644
+
+sys-firewall-rpm-test-key-script:
+  file.managed:
+    - name: /rw/config/sd-copy-rpm-repo-pubkey.sh
+    - source: "salt://sd/sys-firewall/sd-copy-rpm-repo-pubkey.sh"
+    - user: root
+    - group: root
+    - mode: 755
+
+sys-firewall-rpm-test-key-rclocal:
+  file.line:
+    - name: /rw/config/rc.local
+    - mode: insert
+    - location: end
+    - match: "/rw/config/sd-copy-rpm-repo-pubkey.sh"
+    - content: "/rw/config/sd-copy-rpm-repo-pubkey.sh"
+
+sys-firewall-rpm-test-key-import:
+  cmd.run:
+    - name: /rw/config/sd-copy-rpm-repo-pubkey.sh
+    - require:
+      - file: sys-firewall-rpm-test-key
+      - file: sys-firewall-rpm-test-key-script

--- a/dom0/sd-sys-firewall-files.top
+++ b/dom0/sd-sys-firewall-files.top
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+base:
+  sys-firewall:
+    - sd-sys-firewall-files

--- a/dom0/sd-sys-vms.sls
+++ b/dom0/sd-sys-vms.sls
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+#
+# Ensures that sys-* VMs (viz. sys-net, sys-firewall, sys-usb) use
+# an up-to-date version of Fedora, in order to receive security updates.
+
+{% set sd_supported_fedora_version = 'fedora-30' %}
+
+# Install latest templates required for SDW VMs.
+dom0-install-fedora-template:
+  pkg.installed:
+    - pkgs:
+      - qubes-template-{{ sd_supported_fedora_version }}
+
+set-fedora-default-template-version:
+  cmd.run:
+    - name: qubes-prefs default_template {{ sd_supported_fedora_version }}
+    - require:
+      - pkg: dom0-install-fedora-template
+
+{% for sys_vm in ['sys-usb', 'sys-net', 'sys-firewall'] %}
+{% if salt['cmd.shell']('qvm-prefs '+sys_vm+' template') != sd_supported_fedora_version %}
+sd-{{ sys_vm }}-fedora-version-halt:
+  qvm.kill:
+    - name: {{ sys_vm }}
+    - require:
+      - pkg: dom0-install-fedora-template
+
+sd-{{ sys_vm }}-fedora-version-halt-wait:
+  cmd.run:
+    - name: sleep 5
+    - require:
+      - qvm: sd-{{ sys_vm }}-fedora-version-halt
+
+sd-{{ sys_vm }}-fedora-version-update:
+  qvm.vm:
+    - name: {{ sys_vm }}
+    - prefs:
+      - template: {{ sd_supported_fedora_version }}
+    - require:
+      - cmd: sd-{{ sys_vm }}-fedora-version-halt-wait
+
+sd-{{ sys_vm }}-fedora-version-start:
+  qvm.start:
+    - name: {{ sys_vm }}
+    - require:
+      - qvm: sd-{{ sys_vm }}-fedora-version-update
+{% endif %}
+{% endfor %}

--- a/dom0/sd-sys-vms.top
+++ b/dom0/sd-sys-vms.top
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+base:
+  dom0:
+    - sd-sys-vms

--- a/dom0/securedrop-update
+++ b/dom0/securedrop-update
@@ -42,7 +42,7 @@ securedrop-update-feedback "Updating application..."
 # update only fedora template: dist_upgrade is required for debian package
 # upgrades and causes fedora template upgrades to fail.
 
-qubesctl --target fedora-29 pkg.upgrade refresh=true
+qubesctl --target fedora-30 pkg.upgrade refresh=true
 
 # upgrade all (other) templates
 qubesctl --skip-dom0 --templates \

--- a/scripts/prep-salt
+++ b/scripts/prep-salt
@@ -21,6 +21,7 @@ if [[ ! -d "$SDW_SALT_DIR" ]]; then
     sudo cp -r sd-svs /srv/salt/sd
     sudo cp -r sd-workstation /srv/salt/sd
     sudo cp -r sd-export /srv/salt/sd
+    sudo cp -r sys-firewall /srv/salt/sd
     sudo cp dom0/* /srv/salt/
 fi
 

--- a/scripts/provision-all
+++ b/scripts/provision-all
@@ -9,6 +9,10 @@ set -o pipefail
 all_sdw_vms_target="$(./scripts/list-vms | perl -npE 's/\n/,/g' | perl -npE 's/,$//' )"
 
 
+echo "Configure Fedora-based system VMs"
+sudo qubesctl --show-output --targets dom0 state.sls sd-sys-vms
+sudo qubesctl --show-output --skip-dom0 --targets sys-firewall state.sls sd-sys-firewall-files
+
 echo "Create base Template to be used by others"
 sudo qubesctl --show-output --targets dom0 state.sls sd-workstation-template
 

--- a/sys-firewall/sd-copy-rpm-repo-pubkey.sh
+++ b/sys-firewall/sd-copy-rpm-repo-pubkey.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Copy the SecureDrop Release Signing TEST key on sys-firewall
+# to the RPM repo config. Must run on boot of sys-firewall,
+# so that updates to template RPMs in dom0 work.
+set -e
+set -u
+set -o pipefail
+
+cp /rw/config/RPM-GPG-KEY-securedrop-workstation-test /etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation-test
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation-test

--- a/tests/test_sys_firewall.py
+++ b/tests/test_sys_firewall.py
@@ -13,6 +13,10 @@ class SD_Sys_Firewall_Tests(SD_VM_Local_Test):
         self.assertFilesMatch("/etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation-test",  # noqa
                               "sd-workstation/apt-test-pubkey.asc")
 
+    def test_rpm_repo_public_key_script(self):
+        self.assertFilesMatch("/rw/config/sd-copy-rpm-repo-pubkey.sh",
+                              "sys-firewall/sd-copy-rpm-repo-pubkey.sh")
+
 
 def load_tests(loader, tests, pattern):
     suite = unittest.TestLoader().loadTestsFromTestCase(SD_Sys_Firewall_Tests)

--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -142,6 +142,22 @@ class SD_VM_Platform_Tests(unittest.TestCase):
         result = subprocess.check_output(cmd).decode("utf-8").rstrip("\n")
         self.assertEqual(result, "sd-svs-disp")
 
+    def test_sys_vms_use_supported_fedora(self):
+        """
+        The 'sys-*' VMs must be updated to use the latest version of Fedora,
+        to ensure critical components such as 'sys-firewall' receive security
+        updates.
+        """
+        sys_vms = [
+            "sys-firewall",
+            "sys-net",
+            "sys-usb",
+        ]
+        for vm in sys_vms:
+            wanted_template = "fedora-30"
+            found_template = self.app.domains[vm].template.name
+            self.assertEqual(wanted_template, found_template)
+
 
 def load_tests(loader, tests, pattern):
     suite = unittest.TestLoader().loadTestsFromTestCase(SD_VM_Platform_Tests)

--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -140,7 +140,7 @@ class SD_VM_Platform_Tests(unittest.TestCase):
         """
         cmd = ["qubes-prefs", "default_dispvm"]
         result = subprocess.check_output(cmd).decode("utf-8").rstrip("\n")
-        self.assertEqual(result, "fedora-30-dvm")
+        self.assertEqual(result, "sd-svs-disp")
 
 
 def load_tests(loader, tests, pattern):

--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -102,8 +102,8 @@ class SD_VM_Platform_Tests(unittest.TestCase):
         """
         # Technically we want to know whether the sys-firewall, sys-net, and
         # sys-usb VMs have their updates installed. This test assumes those
-        # AppVMs are based on fedora-29.
-        vm_name = "fedora-29"
+        # AppVMs are based on fedora-30.
+        vm_name = "fedora-30"
         vm = self.app.domains[vm_name]
         self._ensure_packages_up_to_date(vm, fedora=True)
         vm.shutdown()
@@ -140,7 +140,7 @@ class SD_VM_Platform_Tests(unittest.TestCase):
         """
         cmd = ["qubes-prefs", "default_dispvm"]
         result = subprocess.check_output(cmd).decode("utf-8").rstrip("\n")
-        self.assertEqual(result, "fedora-29-dvm")
+        self.assertEqual(result, "fedora-30-dvm")
 
 
 def load_tests(loader, tests, pattern):


### PR DESCRIPTION
Implements unattended updates to the built-in Qubes `sys-*` VMs, specifically:

* `sys-net`
* `sys-firewall`
* `sys-usb`

If the VMs are _not_ running the latest version, they will briefly be halted to change the template setting, then restarted on the new template.

Updates the default DispVM template to be `sd-svs-disp`. Enabling this as the default means that `qvm-open-in-dvm <file>` from _any_ VM will result in `sd-svs-disp` being used. 

Improves the dom0 RPM repo logic to be persistent across reboots. Doing so was required in order to get the tests passing after the template update specifically for `sys-firewall`.

Addresses changes specified in a few different issues; thus:

* Closes #262
* Closes #312
* Closes #329
* Closes #330

### Testing
In order to test, first confirm that your environment is *not* what's enforced by this PR. Specifically, your system should be configured as follows:

```
[user@dom0 ~]$ qvm-prefs sys-net template
fedora-29
[user@dom0 ~]$ qvm-prefs sys-firewall template
fedora-29
[user@dom0 ~]$ qvm-prefs sys-usb template
fedora-29
[user@dom0 ~]$ qubes-prefs default_template
fedora-29
[user@dom0 ~]$ qubes-prefs default_dispvm
fedora-29-dvm
```

The above shows the pre-merge "correct" settings, namely F29 rather than F30 throughout.
If you already have a prior version of the SDW config provisioned, do **not** run `make clean`.
Instead, simply run `make all`, which will confirm that the VMs are updated in-place despite
a pre-existing config.

Afterwards, the output of the above commands should be:

```
[user@dom0 ~]$ qvm-prefs sys-net template
fedora-30
[user@dom0 ~]$ qvm-prefs sys-firewall template
fedora-30
[user@dom0 ~]$ qvm-prefs sys-usb template
fedora-30
[user@dom0 ~]$ qubes-prefs default_template
fedora-30
[user@dom0 ~]$ qubes-prefs default_dispvm
sd-svs-disp
```

As always, ensure that `make test` passes without error. New tests have been added to verify
the above settings; the example commands are provided for clarity.

Succinct checklist for testing:

- [ ] `make all` shows no errors
- [ ] `make test` show no errors
- [ ] all `sys-*` VMs running `fedora-30`
- [ ] start/restart an AppVM, confirm `qvm-open-in-dvm <file>` opens in an SDW netless VM

