### PR TITLE
Consistently refer to dev VM as `sd-dev`, remove `work` VM references

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ Qubes provisioning is handled by Salt on `dom0`, so this project must be copied 
 
 *Understand that [copying data to dom0](https://www.qubes-os.org/doc/copy-from-dom0/#copying-to-dom0) goes against the grain of the Qubes security philosophy, and should only done with trusted code and for very specific purposes, such as Qubes-related development tasks. Still, be aware of the risks, especially if you rely on your Qubes installation for other sensitive work.*
 
-That process is a little tricky, but here's one way to do it: assuming this code is checked out in your `work` VM at `/home/user/projects/securedrop-workstation`, run the following in `dom0`:
+That process is a little tricky, but here's one way to do it: assuming this code is checked out in your `sd-dev` VM at `/home/user/projects/securedrop-workstation`, run the following in `dom0`:
 
-    qvm-run --pass-io work 'tar -c -C /home/user/projects securedrop-workstation' | tar xvf -
+    qvm-run --pass-io sd-dev 'tar -c -C /home/user/projects securedrop-workstation' | tar xvf -
 
 After that initial manual step, the code in your development VM may be copied into place on `dom0` by setting the `SECUREDROP_DEV_VM` and `SECUREDROP_DEV_DIR` environmental variables to reflect the VM and directory to which you've cloned this repo, and running `make clone` from the root of the project on `dom0`:
 
@@ -199,7 +199,7 @@ Be aware that running tests *will* power down running SecureDrop VMs, and may re
 
 The `securedrop-update` script will automatically update packages in all TemplateVMs, as well as `dom0`, as part of a daily cron job. This script will also run the salt provisioning logic to ensure the state is consistent. Because AppVMs must be rebooted after a TemplateVM upgrade, a message will inform users to reboot their workstations to apply changes.
 
-To update workstation provisioning logic, one must use the `work` AppVM that was created during the install. From your checkout directory, run the following commands (replace `<tag>` with the tag of the release you are working with):
+To update workstation provisioning logic, one must use the `sd-dev` AppVM that was created during the install. From your checkout directory, run the following commands (replace `<tag>` with the tag of the release you are working with):
 
 ```
 git fetch --tags


### PR DESCRIPTION
We've started recommending that the VM should be called `sd-dev`, so
let's follow that convention everywhere.