### PR TITLE
add centralized logging VM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,10 @@ sd-export: prep-salt ## Provisions SD Export VM
 	sudo qubesctl --show-output state.sls sd-export
 	sudo qubesctl --show-output --skip-dom0 --targets sd-export-buster-template,sd-export-usb,sd-export-usb-dvm state.highstate
 
+sd-log: prep-salt ## Provisions SD logging VM
+	sudo qubesctl --show-output state.sls sd-log
+	sudo qubesctl --show-output --skip-dom0 --targets sd-log-buster-template,sd-log state.highstate
+
 clean-salt: assert-dom0 ## Purges SD Salt configuration from dom0
 	@echo "Purging Salt config..."
 	@sudo rm -rf /srv/salt/sd
@@ -76,6 +80,9 @@ remove-sd-gpg: assert-dom0 ## Destroys SD GPG keystore VM
 remove-sd-export: assert-dom0 ## Destroys SD EXPORT VMs
 	@./scripts/destroy-vm sd-export-usb
 	@./scripts/destroy-vm sd-export-usb-dvm
+
+remove-sd-log: assert-dom0 ## Destroys SD logging VM
+	@./scripts/destroy-vm sd-log
 
 clean: assert-dom0 prep-salt destroy-all ## Destroys all SD VMs
 	sudo qubesctl --show-output state.sls sd-clean-all

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Currently, the following VMs are provisioned:
 - `sd-whonix` is the Tor gateway used to contact the journalist Tor hidden service. It's configured with the auth key for the hidden service. The default Qubes Whonix workstation uses the non-SecureDrop Whonix gateway, and thus won't be able to access the *Journalist Interface*.
 - `sd-gpg` is a Qubes split-gpg AppVM, used to hold submission decryption keys and do the actual submission crypto.
 - `sd-dispvm` is an AppVM used as the template for the disposable VMs used for processing and opening files.
+- `sd-log` is an AppVM used for centralized logging - logs will appear in `~/QubesIncomingLogs` from each AppVM using the centralized logging service.
 
 Submissions are processed in the following steps:
 
@@ -599,6 +600,14 @@ The *GPG VM* does not have network access, and the Qubes split-gpg mechanism res
 
 * An adversary can decrypt and encrypted message or submission.
 * An adversary can store and view any message that is being decrypted by the *SecureDrop Workstation*.
+* An adversary can attempt to elevate their privileges and escape the VM.
+
+#### What Compromise of the *Log VM* (`sd-log`) Can Achieve
+
+The *Log VM* does not have network access nor does it contain any other secrets.
+
+* An adversary can read log messages from any VM using the centralized logging service.
+* An adversary can tamper with log messages from any VM using the centralized logging service.
 * An adversary can attempt to elevate their privileges and escape the VM.
 
 #### What Compromise of `dom0` Can Achieve

--- a/README.md
+++ b/README.md
@@ -567,6 +567,7 @@ The *Display VM* (sd-svs-disp) is disposable, does not have network access, and 
 * An adversary can read the decrypted submission.
 * An adversary can attempt to elevate their privileges and escape the VM.
 * An adversary can attempt to communicate through a side channel to another VM or device in the *SecureDrop Workstation's* environment.
+* An adversary can exhaust storage in the centralized logging VM (`sd-log`).
 
 #### What Compromise of the *Proxy VM* (`sd-proxy`) Can Achieve
 
@@ -576,6 +577,7 @@ The *Display VM* (sd-svs-disp) is disposable, does not have network access, and 
   * Access encrypted messages and submissions.
   * Access plaintext journalist passwords to the *Journalist Interface*.
 * An adversary can attempt to elevate their privileges and escape the VM.
+* An adversary can exhaust storage in the centralized logging VM (`sd-log`).
 
 #### What Compromise of the *Whonix Gateway VM* (`sd-whonix`) Can Achieve
 
@@ -593,6 +595,7 @@ The *SVS VM* is where securedrop-client resides. It does not have network access
 * An adversary can decrypt arbitrary encrypted submissions.
 * An adversary can interact with the SecureDrop *Journalist Interface* or modify SecureDrop client code.
 * An adversary can attempt to elevate their privileges and escape the VM.
+* An adversary can exhaust storage in the centralized logging VM (`sd-log`).
 
 #### What Compromise of the *GPG VM* (`sd-gpg`) Can Achieve
 

--- a/dom0/sd-clean-all.sls
+++ b/dom0/sd-clean-all.sls
@@ -18,6 +18,8 @@ remove-dom0-sdw-config-files:
       - /usr/share/securedrop/icons
       - /home/{{ gui_user }}/.config/autostart/SDWLogin.desktop
       - /usr/bin/securedrop-login
+      - /etc/qubes-rpc/policy/securedrop.Log
+      - /etc/qubes-rpc/policy/securedrop.Proxy
 
 sd-cleanup-sys-firewall:
   cmd.run:

--- a/dom0/sd-log-template-files.sls
+++ b/dom0/sd-log-template-files.sls
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+include:
+  - fpf-apt-test-repo
+
+install-securedrop-log-package:
+  pkg.installed:
+    - pkgs:
+      - securedrop-log
+    - require:
+      - sls: fpf-apt-test-repo

--- a/dom0/sd-log.sls
+++ b/dom0/sd-log.sls
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+#
+# Installs 'sd-log' AppVM for collecting and storing logs
+# from all SecureDrop related VMs.
+# This VM has no network configured.
+##
+include:
+  - sd-workstation-template
+  - sd-upgrade-templates
+
+sd-log-template:
+  qvm.vm:
+    - name: sd-log-buster-template
+    - clone:
+      - source: securedrop-workstation-buster
+      - label: red
+    - tags:
+      - add:
+        - sd-workstation
+    - require:
+      - sls: sd-workstation-template
+
+sd-log:
+  qvm.vm:
+    - name: sd-log
+    - present:
+      - template: sd-log-buster-template
+      - label: red
+    - prefs:
+      - netvm: ""
+      - autostart: true
+    - tags:
+      - add:
+        - sd-workstation
+    - features:
+      - enable:
+        - service.paxctld
+    - require:
+      - qvm: sd-log-buster-template
+
+# Allow any SecureDrop VM to log to the centralized log VM
+sd-log-dom0-securedrop.Log:
+  file.prepend:
+    - name: /etc/qubes-rpc/policy/securedrop.Log
+    - text: |
+        @tag:sd-workstation sd-log allow
+        @anyvm @anyvm deny

--- a/dom0/sd-workstation.top
+++ b/dom0/sd-workstation.top
@@ -16,6 +16,7 @@ base:
     - sd-svs
     - sd-whonix
     - sd-remove-unused-templates
+    - sd-log
   sd-export-buster-template:
     - sd-export-files
   sd-gpg:
@@ -32,6 +33,8 @@ base:
     - sd-sys-firewall-files
   sd-whonix:
     - sd-whonix-hidserv-key
+  sd-log-buster-template:
+    - sd-log-template-files
   securedrop-workstation-buster:
     - sd-workstation-template-files
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -8,6 +8,7 @@ from qubesadmin import Qubes
 # Reusable constant for DRY import across tests
 WANTED_VMS = [
     "sd-gpg",
+    "sd-log",
     "sd-proxy",
     "sd-svs",
     "sd-svs-disp",

--- a/tests/test_log_vm.py
+++ b/tests/test_log_vm.py
@@ -1,0 +1,21 @@
+import unittest
+
+from base import SD_VM_Local_Test
+
+
+class SD_Log_Tests(SD_VM_Local_Test):
+    def setUp(self):
+        self.vm_name = "sd-log"
+        super(SD_Log_Tests, self).setUp()
+
+    def test_sd_log_package_installed(self):
+        self.assertTrue(self._package_is_installed("securedrop-log"))
+
+    def test_log_utility_installed(self):
+        self.assertTrue(self._fileExists("/usr/sbin/securedrop-log"))
+        self.assertTrue(self._fileExists("/etc/qubes-rpc/securedrop.Log"))
+
+
+def load_tests(loader, tests, pattern):
+    suite = unittest.TestLoader().loadTestsFromTestCase(SD_Log_Tests)
+    return suite

--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -102,6 +102,19 @@ class SD_VM_Tests(unittest.TestCase):
         self._check_kernel(vm)
         self.assertTrue('sd-workstation' in vm.tags)
 
+    def test_sd_log_config(self):
+        vm = self.app.domains["sd-log"]
+        nvm = vm.netvm
+        self.assertTrue(nvm is None)
+        self.assertTrue(vm.template == "sd-log-buster-template")
+        self.assertTrue(vm.autostart is True)
+        self.assertFalse(vm.provides_network)
+        self.assertFalse(vm.template_for_dispvms)
+        self._check_kernel(vm)
+        self._check_service_running(vm, "paxctld")
+        self.assertFalse(vm.template_for_dispvms)
+        self.assertTrue('sd-workstation' in vm.tags)
+
     def test_sd_workstation_template(self):
         vm = self.app.domains["securedrop-workstation-buster"]
         nvm = vm.netvm
@@ -154,6 +167,14 @@ class SD_VM_Tests(unittest.TestCase):
         vm_type = vm.klass
         self.assertTrue(vm_type == "DispVM")
         self.assertTrue('sd-workstation' in vm.tags)
+        self._check_kernel(vm)
+
+    def sd_log_template(self):
+        vm = self.app.domains["sd-log-buster-template"]
+        nvm = vm.netvm
+        self.assertTrue(nvm is None)
+        self.assertTrue('sd-workstation' in vm.tags)
+        self.assertFalse(vm.template_for_dispvms)
         self._check_kernel(vm)
 
 


### PR DESCRIPTION
Fixes #19, integrating the [logging service](https://github.com/freedomofpress/securedrop-log) @kushaldas wrote (which works beautifully based on qubesbuilder.BuildLog) using a new centralized logging VM:

* Adds a non-networked `sd-log` AppVM which starts on boot
* Allows RPC calls to `sd-log` from any `sd-workstation` tagged VM

# Testing

1. `make all` should provision the `sd-log` VM
2. You can test this functionally using [this branch](https://github.com/freedomofpress/securedrop-client/tree/centralized-logging) from `securedrop-client`. When you run the client, you should see logs continue to appear in `~/.securedrop_client/logs/` as well as in the `sd-log` AppVM in `~/QubesIncomingLogs`
3. new tests should pass (`make test`)

TODO after merge:
1. Add the qubes logging handler on all the Python subcomponents of the workstation
2. Go through each subcomponent/VM and audit the logging that is currently performed 
(will file more detailed followups about these things)