### PR TITLE
Installs Buster-based SDW template RPM

### DIFF
--- a/dom0/sd-dom0-files.sls
+++ b/dom0/sd-dom0-files.sls
@@ -47,6 +47,7 @@ dom0-install-securedrop-workstation-template:
   pkg.installed:
     - pkgs:
       - qubes-template-securedrop-workstation
+      - qubes-template-securedrop-workstation-buster
     - require:
       - file: dom0-workstation-rpm-repo
 

--- a/scripts/publish-rpm
+++ b/scripts/publish-rpm
@@ -48,7 +48,7 @@ echo "Validating RPM signatures..."
 while read -r f; do
     fname="$(basename "$f")"
     sig_results="$(container_run rpm -Kv "$fname")"
-    if ! grep -qP '^\s+V4 RSA/SHA256 Signature, key ID \w+: OK$' <<< "$sig_results"; then
+    if ! grep -qP '^\s+V4 RSA/SHA(256|512) Signature, key ID \w+: OK$' <<< "$sig_results"; then
         echo "Failed to validate signature on $fname"
         echo "Is the RPM signed? rpm -Kv showed:"
         echo "$sig_results"


### PR DESCRIPTION
### Status

Refs #306. Closes #344. 

Updates the Salt logic to pull in the latest, Buster-based template RPM. The artifact that should be installed is presented here: https://github.com/freedomofpress/securedrop-workstation-dev-rpm-packages-lfs/pull/3

### Testing
In dom0:

```
sudo dnf remove qubes-template-securedrop-workstation-buster # in case you had a copy before, make sure it's gone
make all
qvm-check securedrop-workstation-buster # confirm it exists
```