### PR TITLE
Updates sd-svs-disp-template on XFCE login

### DIFF
--- a/dom0/dom0-xfce-desktop-file.j2
+++ b/dom0/dom0-xfce-desktop-file.j2
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Encoding=UTF-8
+Version=0.9.4
+Type=Application
+Name={{ desktop_name }}
+Comment={{ desktop_comment }}
+Exec={{ desktop_exec }}
+OnlyShowIn=XFCE;
+StartupNotify=false
+Terminal=false
+Hidden=false

--- a/dom0/sd-clean-all.sls
+++ b/dom0/sd-clean-all.sls
@@ -5,6 +5,8 @@ set-fedora-as-default-dispvm:
   cmd.run:
     - name: qubes-prefs default_dispvm fedora-30-dvm
 
+{% set gui_user = salt['cmd.shell']('groupmems -l -g qubes') %}
+
 remove-dom0-sdw-config-files:
   file.absent:
     - names:
@@ -14,6 +16,8 @@ remove-dom0-sdw-config-files:
       - /etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation-test
       - /etc/cron.daily/securedrop-update-cron
       - /usr/share/securedrop/icons
+      - /home/{{ gui_user }}/.config/autostart/SDWLogin.desktop
+      - /usr/bin/securedrop-login
 
 sd-cleanup-sys-firewall:
   cmd.run:

--- a/dom0/sd-dom0-files.sls
+++ b/dom0/sd-dom0-files.sls
@@ -160,3 +160,36 @@ dom0-whonix-ws-14-install-python-futures:
     - require:
       - file: dom0-create-opt-securedrop-directory
       - cmd: dom0-whonix-ws-disable-apt-list
+
+{% set gui_user = salt['cmd.shell']('groupmems -l -g qubes') %}
+
+dom0-login-autostart-directory:
+  file.directory:
+    - name: /home/{{ gui_user }}/.config/autostart
+    - user: {{ gui_user }}
+    - group: {{ gui_user }}
+    - mode: 700
+    - makedirs: True
+
+dom0-login-autostart-desktop-file:
+  file.managed:
+    - name: /home/{{ gui_user }}/.config/autostart/SDWLogin.desktop
+    - source: "salt://dom0-xfce-desktop-file.j2"
+    - template: jinja
+    - context:
+        desktop_name: SDWLogin
+        desktop_comment: Updates SecureDrop Workstation DispVMs at login
+        desktop_exec: /usr/bin/securedrop-login
+    - user: {{ gui_user }}
+    - group: {{ gui_user }}
+    - mode: 664
+    - require:
+      - file: dom0-login-autostart-directory
+
+dom0-login-autostart-script:
+  file.managed:
+    - name: /usr/bin/securedrop-login
+    - source: "salt://securedrop-login"
+    - user: root
+    - group: root
+    - mode: 755

--- a/dom0/securedrop-login
+++ b/dom0/securedrop-login
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""
+Utility script for SecureDrop Workstation config. Updates the TemplateVM
+used for SDW DispVMs by installing all available apt packages.
+
+The update process is intended to run at XFCE login, via a desktop file.
+"""
+import os
+import subprocess
+import logging
+import time
+import sys
+
+import qubesadmin
+
+
+SCRIPT_NAME = os.path.basename(__file__)
+logger = logging.getLogger(SCRIPT_NAME)
+logging.basicConfig(level=logging.INFO)
+
+
+SDW_DISPVM_TEMPLATE = "sd-svs-disp-template"
+
+
+if __name__ == "__main__":
+    # Wait for the dom0 GUI widgets to load
+    # If we don't wait, a "Houston, we have a problem..." message is displayed
+    # to the user.
+    time.sleep(5)
+
+    # Ensure target VM exists
+    q = qubesadmin.Qubes()
+    if SDW_DISPVM_TEMPLATE not in q.domains:
+        # Log message isn't logged to syslog, only stderr
+        logger.error("VM does not exist: {}".format(SDW_DISPVM_TEMPLATE))
+        sys.exit(1)
+
+    cmd = [
+        "sudo",
+        "qubesctl",
+        "--skip-dom0",
+        "--targets",
+        SDW_DISPVM_TEMPLATE,
+        "state.sls",
+        "update.qubes-vm",
+    ]
+    subprocess.check_call(cmd)


### PR DESCRIPTION
Uses a dom0 desktop file, calling a one-off script, to run the Salt
state "update.qubes-vm" against just the `sd-svs-disp-template`
TemplateVM. Regardless of whether updates are available, the system will
check, and install them if found.

Refs #341, but doesn't implement the user-facing notifs sufficient to close.

### Testing
If you already have the SDW configured (particularly `sd-svs-disp-template` exists), then you can reaplce the `make all` step below with `make prep-salt && sudo qubesctl --show-output state.sls sd-dom0-files` 

```
make clone
make all
```

Then log out of your session. If you are not using XFCE as your WM in Qubes, make sure to select XFCE on the login screen. Login. You should see the `sd-svs-disp-template` start up for updates to be applied, then automatically shut down. 