### PR TITLE
Shores up update cron logic

### DIFF
--- a/dom0/securedrop-update
+++ b/dom0/securedrop-update
@@ -31,28 +31,35 @@ function securedrop-update-feedback() {
         'SecureDrop: $msg'"
 }
 
-# `qubesctl pkg.upgrade` will automatically update dom0 packages, as well,
-# but we *first* want the freshest RPMs from dom0, *then* we'll want to
-# update the VMs themselves.
+function get_sdw_target_vms() {
+    qvm-ls --tags sd-workstation --raw-data --fields NAME,CLASS \
+        | perl -F'\|' -lanE 'say $F[0] if $F[1] eq "TemplateVM"' \
+        | perl -npE 's/\n/,/g' \
+        | perl -npE 's/,$//'
+}
+
 securedrop-update-feedback "Updating dom0 configuration..."
-sudo qubes-dom0-update -y
 
-securedrop-update-feedback "Updating application..."
+# Install latest RPMs inside dom0
+qubesctl state.sls update.qubes-dom0
 
-# update only fedora template: dist_upgrade is required for debian package
-# upgrades and causes fedora template upgrades to fail.
-
-qubesctl --target fedora-30 pkg.upgrade refresh=true
-
-# upgrade all (other) templates
-qubesctl --skip-dom0 --templates \
-    --max-concurrency "$SECUREDROP_MAX_CONCURRENCY" \
-    pkg.upgrade refresh=true dist_upgrade=true
-
+# Configure VM state (network settings, RPC policies)
 securedrop-update-feedback "Updating VM configuration..."
-qubesctl \
+qubesctl state.highstate
+
+securedrop-update-feedback "Installing updates for VM applications..."
+
+qubesctl --skip-dom0 --targets fedora-30 state.sls update.qubes-vm
+
+# Format list of all VMs comma-separated, for use as qubesctl target
+sdw_target_vms="$(get_sdw_target_vms)"
+
+# Use the Qubes-provided "update.qubes-vm" state to upgrade packages
+# Update all SDW templates.
+qubesctl --skip-dom0 \
     --max-concurrency "$SECUREDROP_MAX_CONCURRENCY" \
-    state.highstate
+    --targets "$sdw_target_vms" \
+    state.sls update.qubes-vm
 
 securedrop-update-feedback \
     "Updates installed. Please reboot the workstation \


### PR DESCRIPTION
Still using bash, but pared down the qubesctl calls to what's strictly necessary. Also replaced pkg.upgrade with the Qubes-maintained "update.qubes-vm" Salt state, which intelligently handles Debian/Fedora VMs. It first applies critical patches, such as for DSA-4371-1/CVE-2019-3462, for patching apt, then ensures all packages are up to date.

Ideally we'd leverage the Admin API here, but to aid in review, let's fix the most egregious problems, and go from there.

The major reduction in run time due to these changes is that _only_ the SDW Template VMs are updated, whereas the previous logic used `--templates` to update _all_ TemplateVMs on the host system. 

Closes #339. 

### Testing

```
make clone
make prep-salt
sudo qubesctl --show-output state.sls sd-dom0-files
time sudo securedrop-update
```

Confirm no errors, and a reasonable runtime. On my system (T480), the run took ~6m.