### PR TITLE
Add AppArmor test for securedrop-client

### DIFF
--- a/tests/test_svs.py
+++ b/tests/test_svs.py
@@ -44,6 +44,11 @@ class SD_SVS_Tests(SD_VM_Local_Test):
         line = '{{"journalist_key_fingerprint": "{}"}}'.format(submission_fpr)
         self.assertFileHasLine("/home/user/.securedrop_client/config.json", line)
 
+    def test_sd_client_apparmor(self):
+        cmd = "sudo aa-status --json"
+        results = json.loads(self._run(cmd))
+        self.assertTrue(results['profiles']['/usr/bin/securedrop-client'] == "enforce")
+
 
 def load_tests(loader, tests, pattern):
     suite = unittest.TestLoader().loadTestsFromTestCase(SD_SVS_Tests)

--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -4,7 +4,7 @@ from qubesadmin import Qubes
 from base import WANTED_VMS
 
 
-EXPECTED_KERNEL_VERSION = "4.14.151-grsec-workstation"
+EXPECTED_KERNEL_VERSION = "4.14.158-grsec-workstation"
 
 
 class SD_VM_Tests(unittest.TestCase):


### PR DESCRIPTION
Closes #234 

This PR provides tests to ensure the apparmor profile for the securedrop-client is properly running

### Merge order
The changes introduced here span several repositories, and must be merged in the order that follows: 

- [x] Kernel config:  https://github.com/freedomofpress/ansible-role-grsecurity-build/pull/54
- [x] Kernel packaging changes: https://github.com/freedomofpress/securedrop-debian-packaging/pull/116
- [x] Image (meta)packages: https://github.com/freedomofpress/securedrop-dev-packages-lfs/pull/30
- [x] securedrop-client changes (apparmor profile, version increment): https://github.com/freedomofpress/securedrop-client/pull/673
- [x] 0.0.11 tag created in securedrop-client
- [x] https://github.com/freedomofpress/securedrop-debian-packaging/pull/105 (ci should be re-run and pass after 0.0.11 client tag is pushed.
- [x] All the boxes above are checked, this PR (https://github.com/freedomofpress/securedrop-workstation/pull/364) can now be reviewed.
### Test plan
- run securedrop-update
- [ ] securedrop-client version running in sd-svs is 0.0.11
- make clone this branch (no need to make all, this branch only changes tests)
- make test
- [ ] all tests pass