### PR TITLE
Clean action: better handling of default dispvm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,9 +84,10 @@ remove-sd-export: assert-dom0 ## Destroys SD EXPORT VMs
 remove-sd-log: assert-dom0 ## Destroys SD logging VM
 	@./scripts/destroy-vm sd-log
 
-clean: assert-dom0 prep-salt destroy-all ## Destroys all SD VMs
+clean: assert-dom0 prep-salt ## Destroys all SD VMs
 	sudo qubesctl --show-output state.sls sd-clean-all
 	sudo dnf -y -q remove securedrop-workstation-dom0-config 2>/dev/null || true
+	$(MAKE) destroy-all
 	$(MAKE) clean-salt
 
 test: assert-dom0 ## Runs all application tests (no integration tests yet)
@@ -132,7 +133,6 @@ prep-dom0: prep-salt # Copies dom0 config files for VM updates
 	sudo qubesctl --show-output --targets dom0 state.highstate
 
 destroy-all: ## Destroys all VMs managed by Workstation salt config
-	qubes-prefs default_dispvm fedora-30-dvm
 	./scripts/destroy-vm --all
 
 .PHONY: update-pip-requirements

--- a/dom0/sd-clean-all.sls
+++ b/dom0/sd-clean-all.sls
@@ -3,7 +3,7 @@
 
 set-fedora-as-default-dispvm:
   cmd.run:
-    - name: qubes-prefs default_dispvm fedora-30-dvm
+    - name: qvm-check fedora-30-dvm && qubes-prefs default_dispvm fedora-30-dvm || qubes-prefs default_dispvm ''
 
 {% set gui_user = salt['cmd.shell']('groupmems -l -g qubes') %}
 


### PR DESCRIPTION
We shouldn't assume that `fedora-30-dvm` exists. It will if a developer
has manually performed the following actions:

  * install fedora-30 template
  * set fedora-30 to the default_template
  * run `qvm.default-dispvm` Salt state

If the system has fedora-30-dvm already present, then it makes sense to
use it as the default DispVM, otherwise we'll just clear out the default
DispVM setting, leaving it blank.

Closes #360


### Testing
If you do _not_ have `fedora-30-dvm` locally:

```
qvm-check fedora-30-dvm # should show "no such domain"
make clone 
make clean
qubes-prefs default_dispvm # should show nothing (i.e. no default)
```

Then run:

```
make clone
make clean
```

And confirm no errors. 

If you _do_ have `fedora-30-dvm`, then:

```
qvm-check fedora-30-dvm # should show "exists"
make clone
make clean
qubes-prefs default_dispvm # should show 'fedora-30-dvm'
```
