### PR TITLE
Add sd-upgrade-template target to all sd vms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,32 +20,32 @@ qubes-rpc: prep-salt ## Places default deny qubes-rpc policies for sd-svs and sd
 	sudo qubesctl --show-output --targets sd-dom0-qvm-rpc state.highstate
 
 sd-workstation-template: prep-salt ## Provisions base template for SDW AppVMs
-	sudo qubesctl --show-output state.sls sd-workstation-template
-	sudo qubesctl --show-output --skip-dom0 --targets sd-workstation-template state.highstate
+	sudo qubesctl --show-output state.sls sd-workstation-buster-template
+	sudo qubesctl --show-output --skip-dom0 --targets sd-workstation-buster-template state.highstate
 
 sd-proxy: prep-salt ## Provisions SD Proxy VM
 	sudo qubesctl --show-output state.sls sd-proxy
-	sudo qubesctl --show-output --skip-dom0 --targets sd-proxy-template state.highstate
+	sudo qubesctl --show-output --skip-dom0 --targets sd-proxy-buster-template,sd-proxy state.highstate
 
 sd-gpg: prep-salt ## Provisions SD GPG keystore VM
 	sudo qubesctl --show-output state.sls sd-gpg
-	sudo qubesctl --show-output --skip-dom0 --targets sd-gpg state.highstate
+	sudo qubesctl --show-output --skip-dom0 --targets sd-workstation-buster-template,sd-gpg state.highstate
 
 sd-svs: prep-salt ## Provisions SD SVS VM
 	sudo qubesctl --show-output state.sls sd-svs
-	sudo qubesctl --show-output --skip-dom0 --targets sd-svs-template,sd-svs state.highstate
+	sudo qubesctl --show-output --skip-dom0 --targets sd-svs-buster-template,sd-svs state.highstate
 
 sd-whonix: prep-salt ## Provisions SD Whonix VM
 	sudo qubesctl --show-output state.sls sd-whonix
-	sudo qubesctl --show-output --skip-dom0 --targets sd-whonix-template,sd-whonix state.highstate
+	sudo qubesctl --show-output --skip-dom0 --targets sd-whonix-buster-template,sd-whonix state.highstate
 
 sd-svs-disp: prep-salt ## Provisions SD Submission Viewing VM
 	sudo qubesctl --show-output state.sls sd-svs-disp
-	sudo qubesctl --show-output --skip-dom0 --targets sd-svs-disp-template,sd-svs-disp state.highstate
+	sudo qubesctl --show-output --skip-dom0 --targets sd-svs-disp-buster-template,sd-svs-disp state.highstate
 
 sd-export: prep-salt ## Provisions SD Export VM
 	sudo qubesctl --show-output state.sls sd-export
-	sudo qubesctl --show-output --skip-dom0 --targets sd-export-template,sd-export-usb,sd-export-usb-dvm state.highstate
+	sudo qubesctl --show-output --skip-dom0 --targets sd-export-buster-template,sd-export-usb,sd-export-usb-dvm state.highstate
 
 clean-salt: assert-dom0 ## Purges SD Salt configuration from dom0
 	@echo "Purging Salt config..."

--- a/dom0/sd-export.sls
+++ b/dom0/sd-export.sls
@@ -7,6 +7,7 @@
 ##
 include:
   - sd-workstation-template
+  - sd-upgrade-templates
 
 sd-export-template:
   qvm.vm:

--- a/dom0/sd-gpg.sls
+++ b/dom0/sd-gpg.sls
@@ -11,6 +11,7 @@
 
 include:
   - sd-workstation-template
+  - sd-upgrade-templates
 
 sd-gpg:
   qvm.vm:

--- a/dom0/sd-svs-disp.sls
+++ b/dom0/sd-svs-disp.sls
@@ -13,6 +13,7 @@
 
 include:
   - sd-workstation-template
+  - sd-upgrade-templates
 
 sd-svs-disp-template:
   qvm.vm:

--- a/dom0/sd-svs.sls
+++ b/dom0/sd-svs.sls
@@ -10,6 +10,7 @@
 ##
 include:
   - sd-workstation-template
+  - sd-upgrade-templates
 
 sd-svs-template:
   qvm.vm:

--- a/dom0/sd-whonix.sls
+++ b/dom0/sd-whonix.sls
@@ -14,6 +14,7 @@ include:
   # The anon-whoni config pulls in sys-whonix and sys-firewall,
   # as well as ensures the latest versions of Whonix are installed.
   - qvm.anon-whonix
+  - sd-upgrade-templates
 
 sd-whonix:
   qvm.vm:
@@ -33,3 +34,4 @@ sd-whonix:
         - sd-buster
     - require:
       - sls: qvm.anon-whonix
+      - sls: sd-upgrade-templates

--- a/dom0/securedrop-handle-upgrade
+++ b/dom0/securedrop-handle-upgrade
@@ -57,9 +57,13 @@ if [[ $TASK == "prepare" ]]; then
         fi
     fi
 
+    # for sd-whonix, we must make sure sd-proxy is shut down as well as sd-whonix
+    # is netvm for sd-proxy. In the unlikely even proxy is updated but whonix
+    # is not, we want to ensure a smooth upgrade.
     if qvm-check --quiet sd-whonix; then
         BASE_TEMPLATE=$(qvm-prefs sd-whonix template)
         if [[ ! $BASE_TEMPLATE =~ "15" ]]; then
+            qvm-shutdown --wait sd-proxy
             qvm-shutdown --wait sd-whonix
         fi
     fi


### PR DESCRIPTION
Fixes #371, ensures the makefile targets for each VMs can now provision VMs individually. Because sd-upgrade-templates was not a target, the provisioning would fail.

### Test plan
On `master`:
- `make sd-gpg` fails
- `make sd-whonix` fails
- `make sd-svs` fails

On this branch:
- `make clone` to bring in the changes of this branch into `dom0`
- `make sd-gpg` completes without error, make test passes
- `make sd-whonix` completes without error, make test passes
- `make sd-svs` completes without error, make test passes