### PR TITLE
More reliable make all, provide whonix-*-15 TemplateVM updates

### DIFF
--- a/dom0/sd-dom0-files.sls
+++ b/dom0/sd-dom0-files.sls
@@ -49,12 +49,20 @@ dom0-workstation-rpm-repo:
     - require:
       - file: dom0-rpm-test-key
 
+dom0-remove-securedrop-workstation-stretch-template:
+  pkg.removed:
+    - pkgs:
+      - qubes-template-securedrop-workstation
+    - require:
+      - file: dom0-workstation-rpm-repo
+
 dom0-install-securedrop-workstation-template:
   pkg.installed:
     - pkgs:
       - qubes-template-securedrop-workstation-buster
     - require:
       - file: dom0-workstation-rpm-repo
+      - pkg: dom0-remove-securedrop-workstation-stretch-template
 
 # Copy script to system location so admins can run ad-hoc
 dom0-update-securedrop-script:

--- a/dom0/sd-dom0-files.sls
+++ b/dom0/sd-dom0-files.sls
@@ -145,3 +145,17 @@ dom0-login-autostart-script:
     - user: root
     - group: root
     - mode: 755
+
+dom0-tag-whonix-ws-15:
+  qvm.vm:
+    - name: whonix-ws-15
+    - tags:
+      - add:
+        - sd-workstation-updates
+
+dom0-tag-whonix-gw-15:
+  qvm.vm:
+    - name: whonix-gw-15
+    - tags:
+      - add:
+        - sd-workstation-updates

--- a/dom0/sd-export.sls
+++ b/dom0/sd-export.sls
@@ -17,6 +17,7 @@ sd-export-template:
     - tags:
       - add:
         - sd-workstation
+        - sd-workstation-updates
     - require:
       - sls: sd-workstation-template
       - sls: sd-upgrade-templates

--- a/dom0/sd-proxy.sls
+++ b/dom0/sd-proxy.sls
@@ -23,6 +23,7 @@ sd-proxy-template:
       - add:
         - sd-workstation
         - sd-buster
+        - sd-workstation-updates
 
 sd-proxy:
   qvm.vm:

--- a/dom0/sd-svs-disp.sls
+++ b/dom0/sd-svs-disp.sls
@@ -20,6 +20,10 @@ sd-svs-disp-template:
     - clone:
       - source: securedrop-workstation-buster
       - label: green
+    - tags:
+      - add:
+        - sd-workstation
+        - sd-workstation-updates
     - require:
       - sls: sd-workstation-template
       - sls: sd-upgrade-templates

--- a/dom0/sd-svs.sls
+++ b/dom0/sd-svs.sls
@@ -21,6 +21,7 @@ sd-svs-template:
       - add:
         - sd-workstation
         - sd-buster
+        - sd-workstation-updates
     - require:
       - sls: sd-workstation-template
       - sls: sd-upgrade-templates

--- a/dom0/sd-workstation-template.sls
+++ b/dom0/sd-workstation-template.sls
@@ -15,6 +15,7 @@ sd-workstation-template:
       - add:
         - sd-workstation
         - sd-buster
+        - sd-workstation-updates
     - features:
       - enable:
         - service.paxctld

--- a/dom0/securedrop-update
+++ b/dom0/securedrop-update
@@ -32,7 +32,7 @@ function securedrop-update-feedback() {
 }
 
 function get_sdw_target_vms() {
-    qvm-ls --tags sd-workstation --raw-data --fields NAME,CLASS \
+    qvm-ls --tags sd-workstation-updates --raw-data --fields NAME,CLASS \
         | perl -F'\|' -lanE 'say $F[0] if $F[1] eq "TemplateVM"' \
         | perl -npE 's/\n/,/g' \
         | perl -npE 's/,$//'

--- a/tests/test_dom0_config.py
+++ b/tests/test_dom0_config.py
@@ -8,6 +8,16 @@ STRETCH_TEMPLATES = [
     "sd-proxy-template",
 ]
 
+VMS_TO_UPDATE = [
+    "sd-svs-buster-template",
+    "sd-svs-disp-buster-template",
+    "sd-proxy-buster-template",
+    "sd-export-buster-template",
+    "whonix-ws-15",
+    "whonix-gw-15",
+    "securedrop-workstation-buster"
+]
+
 
 class SD_Qubes_Dom0_Templates_Tests(unittest.TestCase):
 
@@ -22,6 +32,15 @@ class SD_Qubes_Dom0_Templates_Tests(unittest.TestCase):
         contents = subprocess.check_output(cmd).decode("utf-8").strip()
         for template in STRETCH_TEMPLATES:
             self.assertTrue(template not in contents)
+
+    def test_vms_to_update_are_tagged(self):
+        cmd = ["qvm-ls",
+               "--tags", "sd-workstation-updates",
+               "--raw-data",
+               "--fields", "NAME"]
+        contents = subprocess.check_output(cmd).decode("utf-8").strip()
+        for template in VMS_TO_UPDATE:
+            self.assertTrue(template in contents)
 
 
 def load_tests(loader, tests, pattern):

--- a/tests/test_dom0_config.py
+++ b/tests/test_dom0_config.py
@@ -6,6 +6,7 @@ STRETCH_TEMPLATES = [
     "sd-svs-disp-template",
     "sd-export-template",
     "sd-proxy-template",
+    "securedrop-workstation"
 ]
 
 VMS_TO_UPDATE = [
@@ -29,9 +30,10 @@ class SD_Qubes_Dom0_Templates_Tests(unittest.TestCase):
 
     def test_Templates_cleaned_up(self):
         cmd = ["qvm-ls", "--raw-list"]
-        contents = subprocess.check_output(cmd).decode("utf-8").strip()
+        contents = subprocess.check_output(cmd).decode("utf-8").split()
         for template in STRETCH_TEMPLATES:
-            self.assertTrue(template not in contents)
+            for line in contents:
+                self.assertFalse(template == line)
 
     def test_vms_to_update_are_tagged(self):
         cmd = ["qvm-ls",


### PR DESCRIPTION
Closes #370, closes #374 

- Tags TemplateVMs that should be updated with a tag : `sd-workstation-updates`
- Removes the old `securedrop-workstation` template, which was conflicting with salt provisioning logic.
#### Test Plan
- [ ] `make all` and `make test` should pass.
- [ ] Observe `securedrop-workstation` template is removed
- [ ] invoke securedrop-update manually (`sudo securedrop-update`) and ensure all SDW-relevant VMs are updated.