### PR TITLE
More robust config validation logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,12 +108,7 @@ test-gpg: assert-dom0 ## Runs tests for SD GPG functionality
 	python3 -m unittest -v tests.test_gpg
 
 validate: assert-dom0 ## Checks for local requirements in dev env
-	@bash -c "test -e config.json" || \
-		{ echo "ERROR: missing 'config.json'!" && \
-		echo "Create from 'config.json.example'." && exit 1 ; }
-	@bash -c "test -e sd-journalist.sec" || \
-		{ echo "ERROR: missing 'sd-journalist.sec" && \
-		echo "Create from 'sd-journalist.sec.example'." && exit 1 ; }
+	@./scripts/validate-config
 
 .PHONY: flake8
 flake8: ## Lints all Python files with flake8

--- a/scripts/validate-config
+++ b/scripts/validate-config
@@ -8,9 +8,11 @@ import re
 import os
 
 
+TOR_V3_HOSTNAME_REGEX = r'^[a-z2-7]{56}\.onion$'
+TOR_V3_AUTH_REGEX = r'^[A-Z2-7]{52}$'
+
 TOR_V2_HOSTNAME_REGEX = r'^[a-z2-7]{16}\.onion$'
 TOR_V2_AUTH_COOKIE_REGEX = r'^[a-zA-z0-9+/]{22}$'
-
 
 # CONFIG_FILEPATH = "/srv/salt/sd/config.json"
 CONFIG_FILEPATH = "config.json"
@@ -25,8 +27,7 @@ class SDWConfigValidator(object):
         self.config_filepath = CONFIG_FILEPATH
         self.confirm_config_file_exists()
         self.config = self.read_config_file()
-        self.confirm_onion_v2_url()
-        self.confirm_onion_v2_auth()
+        self.confirm_onion_config_valid()
         self.confirm_usb_export_device()
         self.confirm_submission_privkey_file()
         self.confirm_submission_privkey_fingerprint()
@@ -38,6 +39,28 @@ class SDWConfigValidator(object):
             msg = "Config file does not exist: {}".format(self.config_filepath)
             msg += "Create from config.json.example"
             raise AssertionError(msg)
+
+    def confirm_onion_config_valid(self):
+        """
+        We support both v2 and v3 Onion Services, so if the values
+        in config file match either format, good enough.
+        """
+        try:
+            self.confirm_onion_v3_url()
+            self.confirm_onion_v3_auth()
+        except AssertionError:
+            self.confirm_onion_v2_url()
+            self.confirm_onion_v2_auth()
+
+    def confirm_onion_v3_url(self):
+        assert "hidserv" in self.config
+        assert "hostname" in self.config["hidserv"]
+        assert re.match(TOR_V3_HOSTNAME_REGEX, self.config["hidserv"]["hostname"])
+
+    def confirm_onion_v3_auth(self):
+        assert "hidserv" in self.config
+        assert "key" in self.config["hidserv"]
+        assert re.match(TOR_V3_AUTH_REGEX, self.config["hidserv"]["key"])
 
     def confirm_onion_v2_url(self):
         assert "hidserv" in self.config

--- a/scripts/validate-config
+++ b/scripts/validate-config
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""
+Utility to verify that SecureDrop Workstation config is properly structured.
+Checks for
+"""
+import json
+import re
+import os
+
+
+TOR_V2_HOSTNAME_REGEX = r'^[a-z2-7]{16}\.onion$'
+TOR_V2_AUTH_COOKIE_REGEX = r'^[a-zA-z0-9+/]{22}$'
+
+
+# CONFIG_FILEPATH = "/srv/salt/sd/config.json"
+CONFIG_FILEPATH = "config.json"
+
+
+class ValidationError(Exception):
+    pass
+
+
+class SDWConfigValidator(object):
+    def __init__(self):
+        self.config_filepath = CONFIG_FILEPATH
+        self.confirm_config_file_exists()
+        self.config = self.read_config_file()
+        self.confirm_onion_v2_url()
+        self.confirm_onion_v2_auth()
+        self.confirm_usb_export_device()
+        self.confirm_submission_privkey_file()
+        self.confirm_submission_privkey_fingerprint()
+
+    def confirm_config_file_exists(self):
+        try:
+            assert os.path.exists(self.config_filepath)
+        except AssertionError:
+            msg = "Config file does not exist: {}".format(self.config_filepath)
+            msg += "Create from config.json.example"
+            raise AssertionError(msg)
+
+    def confirm_onion_v2_url(self):
+        assert "hidserv" in self.config
+        assert "hostname" in self.config["hidserv"]
+        assert re.match(TOR_V2_HOSTNAME_REGEX, self.config["hidserv"]["hostname"])
+
+    def confirm_onion_v2_auth(self):
+        assert "hidserv" in self.config
+        assert "key" in self.config["hidserv"]
+        assert re.match(TOR_V2_AUTH_COOKIE_REGEX, self.config["hidserv"]["key"])
+
+    def confirm_usb_export_device(self):
+        assert "usb" in self.config
+        assert "device" in self.config["usb"]
+        usb_config = self.config["usb"]["device"]
+        assert usb_config.startswith("sys-usb")
+
+    def confirm_submission_privkey_file(self):
+        assert os.path.exists("sd-journalist.sec")
+
+    def confirm_submission_privkey_fingerprint(self):
+        assert "submission_key_fpr" in self.config
+        assert re.match('^[a-fA-F0-9]{40}$', self.config["submission_key_fpr"])
+
+    def read_config_file(self):
+        with open(self.config_filepath, 'r') as f:
+            j = json.load(f)
+        return j
+
+
+if __name__ == "__main__":
+    validator = SDWConfigValidator()

--- a/scripts/validate-config
+++ b/scripts/validate-config
@@ -6,6 +6,7 @@ Checks for
 import json
 import re
 import os
+import subprocess
 
 
 TOR_V3_HOSTNAME_REGEX = r'^[a-z2-7]{56}\.onion$'
@@ -79,7 +80,11 @@ class SDWConfigValidator(object):
         assert usb_config.startswith("sys-usb")
 
     def confirm_submission_privkey_file(self):
-        assert os.path.exists("sd-journalist.sec")
+        secret_key_filename = "sd-journalist.sec"
+        assert os.path.exists(secret_key_filename)
+        gpg_cmd = ["gpg", secret_key_filename]
+        # Call out to gpg to confirm it's a valid keyfile
+        subprocess.check_call(gpg_cmd, stdout=subprocess.DEVNULL)
 
     def confirm_submission_privkey_fingerprint(self):
         assert "submission_key_fpr" in self.config


### PR DESCRIPTION
Retains the two previous checks:

  1. Does config.json exist?
  2. Does sd-journalist.sec exist?

Adds several checks verifying the contents of config.json.
There's a minimum of user-friendly messages explaining specifically what
the problem is. We can add those messages over time, aiming to balance
utility for Admins and developers.

Assumes that a v2 Onion URL is used. We can update that logic when we
add support for v3 Onion URLs.

Closes #240.

### Testing

- [ ] `make validate` passes in dom0 with v3 Onion URL info
- [ ] `make validate` passes in dom0 with v2 Onion URL info
- [ ] `make validate` fails when a known-bad value is in `config.json` as appending characters to the Onion URL