### PR TITLE
Fixes #321 Adds v3 onion address support to workstation

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -3,5 +3,5 @@
   "hidserv": {
     "hostname": "avgfxawdn6c3coe3.onion",
     "key": "Il8Xas7uf6rjtc0LxYwhrx"
-  }
+  },
 }

--- a/config.json.example
+++ b/config.json.example
@@ -3,5 +3,5 @@
   "hidserv": {
     "hostname": "avgfxawdn6c3coe3.onion",
     "key": "Il8Xas7uf6rjtc0LxYwhrx"
-  },
+  }
 }

--- a/dom0/sd-proxy-template-files.sls
+++ b/dom0/sd-proxy-template-files.sls
@@ -56,5 +56,5 @@ install-securedrop-proxy-yaml-config:
     - source: salt://sd/sd-proxy/sd-proxy.yaml
     - template: jinja
     - context:
-        hostname: {{ d.hidserv.hostname}}
+        hostname: {{ d.hidserv.hostname }}
     - mode: 0644

--- a/dom0/sd-whonix-hidserv-key.sls
+++ b/dom0/sd-whonix-hidserv-key.sls
@@ -25,6 +25,6 @@ install-sd-whonix-tor-private-key:
         hostname: {{ hostname_without_onion }}
         key: {{ d.hidserv.key }}
     - mode: 0600
-    - user: root
-    - group: root
+    - user: debian-tor
+    - group: debian-tor
 {% endif %}

--- a/dom0/sd-whonix-hidserv-key.sls
+++ b/dom0/sd-whonix-hidserv-key.sls
@@ -4,7 +4,27 @@
 {% import_json "sd/config.json" as d %}
 
 # add hidden service auth key to torrc
+{% if d.hidserv.hostname|length == 22 %}
 sd-whonix-hidserv-key:
   file.append:
     - name: /usr/local/etc/torrc.d/50_user.conf
     - text: HidServAuth {{ d.hidserv.hostname }} {{ d.hidserv.key }}
+{% else %}
+sd-whonix-hidservv3-directory-path:
+  file.append:
+    - name: /usr/local/etc/torrc.d/50_user.conf
+    - text: ClientOnionAuthDir /var/lib/tor/keys
+
+{% set hostname_without_onion = d.hidserv.hostname.split('.')[0] %}
+install-sd-whonix-tor-private-key:
+  file.managed:
+    - name: /var/lib/tor/keys/app-journalist.auth_private
+    - source: salt://sd/sd-whonix/app-journalist.yaml
+    - template: jinja
+    - context:
+        hostname: {{ hostname_without_onion }}
+        key: {{ d.hidserv.key }}
+    - mode: 0600
+    - user: root
+    - group: root
+{% endif %}

--- a/scripts/prep-salt
+++ b/scripts/prep-salt
@@ -19,6 +19,7 @@ if [[ ! -d "$SDW_SALT_DIR" ]]; then
     sudo mkdir -p /srv/salt/sd
     sudo cp -r sd-proxy /srv/salt/sd
     sudo cp -r sd-svs /srv/salt/sd
+    sudo cp -r sd-whonix /srv/salt/sd
     sudo cp -r sd-workstation /srv/salt/sd
     sudo cp -r sys-firewall /srv/salt/sd
     sudo cp dom0/* /srv/salt/

--- a/sd-whonix/app-journalist.yaml
+++ b/sd-whonix/app-journalist.yaml
@@ -1,0 +1,1 @@
+{{ hostname }}:descriptor:x25519:{{ key }}

--- a/tests/base.py
+++ b/tests/base.py
@@ -66,7 +66,7 @@ class SD_VM_Local_Test(unittest.TestCase):
 
     def _get_file_contents(self, path):
         cmd = ["qvm-run", "-p", self.vm_name,
-               "/bin/cat {}".format(path)]
+               "sudo /bin/cat {}".format(path)]
         contents = subprocess.check_output(cmd).decode("utf-8")
         return contents
 

--- a/tests/test_sd_whonix.py
+++ b/tests/test_sd_whonix.py
@@ -6,7 +6,7 @@ from jinja2 import Template
 from base import SD_VM_Local_Test
 
 
-def skip_if_v3_is_missing():
+def v2_onion_services():
     """
     Returns True if v3 address is not setup
     """
@@ -38,7 +38,7 @@ class SD_Whonix_Tests(SD_VM_Local_Test):
 
             self.assertFileHasLine("/usr/local/etc/torrc.d/50_user.conf", line)
 
-    @unittest.skipIf(skip_if_v3_is_missing(), "Onion v3 address is not setup")
+    @unittest.skipIf(v2_onion_services(), "Onion v3 address is not setup")
     def test_v3_auth_private_file(self):
         with open("config.json") as c:
             config = json.load(c)

--- a/tests/test_sd_whonix.py
+++ b/tests/test_sd_whonix.py
@@ -2,7 +2,20 @@ import unittest
 import json
 from jinja2 import Template
 
+
 from base import SD_VM_Local_Test
+
+
+def skip_if_v3_is_missing():
+    """
+    Returns True if v3 address is not setup
+    """
+    with open("config.json") as c:
+        config = json.load(c)
+        if len(config["hidserv"]["hostname"]) == 22:
+            return True
+        else:
+            return False
 
 
 class SD_Whonix_Tests(SD_VM_Local_Test):
@@ -14,11 +27,28 @@ class SD_Whonix_Tests(SD_VM_Local_Test):
     def test_accept_sd_xfer_extracted_file(self):
         with open("config.json") as c:
             config = json.load(c)
-            t = Template("HidServAuth {{ d.hidserv.hostname }}"
-                         " {{ d.hidserv.key }}")
-            line = t.render(d=config)
+            if len(config["hidserv"]["hostname"]) == 22:
+                t = Template(
+                    "HidServAuth {{ d.hidserv.hostname }}" " {{ d.hidserv.key }}"
+                )
+                line = t.render(d=config)
+
+            else:
+                line = "ClientOnionAuthDir /var/lib/tor/keys"
 
             self.assertFileHasLine("/usr/local/etc/torrc.d/50_user.conf", line)
+
+    @unittest.skipIf(skip_if_v3_is_missing(), "Onion v3 address is not setup")
+    def test_v3_auth_private_file(self):
+        with open("config.json") as c:
+            config = json.load(c)
+            hostname = config["hidserv"]["hostname"].split(".")[0]
+            keyvalue = config["hidserv"]["key"]
+            line = "{0}:descriptor:x25519:{1}".format(hostname, keyvalue)
+
+            self.assertFileHasLine(
+                "/var/lib/tor/keys/app-journalist.auth_private", line
+            )
 
     def test_sd_whonix_repo_enabled(self):
         """


### PR DESCRIPTION
## Big change

The `config.json` file should only contain either v2 address + key, or v3 address + key.

## How to test?

### For existing installs

- [ ] Update the config.json file
- [ ]  Run `make all`
- [ ] Restart all the sd related vms, and then run `make test`
- [ ] All tests should pass and one v3_auth_private_file test should be skipped
- [ ] Test replying via `securedrop-client` in `sd-svs` 

### For v3 address

- [ ] Update the `config.json` with the v3 onion address and the `key` with the key from the `app-journalist.auth_private` file.

The `app-journalist.auth_private`  file has `onion_address_56_chars:descriptor:x25519:private_key` format. 

- [ ] `make all`.
- [ ] Reboot all related VMs, and then `make test`, all tests should pass.
- [ ] Test replying via `securedrop-client` in `sd-svs` 


This PR will still need one more commit to update the README file. That I will add after we can decide on the right wordings.