### PR TITLE
Fix make all on clean Qubes 4.0.1 install

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,7 @@ After installing Qubes, you must update both dom0 and the base templates to incl
 ```
 sudo qubes-dom0-update
 ```
-
-Finally, update all existing TemplateVMs:
+After dom0 updates complete, reboot your computer to ensure the updates have been properly applied. Finally, update all existing TemplateVMs:
 
 ```
 qubes-update-gui

--- a/dom0/sd-sys-vms.sls
+++ b/dom0/sd-sys-vms.sls
@@ -27,7 +27,7 @@ set-fedora-default-template-version:
       - pkg: dom0-install-fedora-template
       - sls: qvm.default-dispvm
 
-{% for sys_vm in ['sys-usb', 'sys-net', 'sys-firewall'] %}
+{% for sys_vm in ['sys-usb', 'sys-net', 'sys-firewall', 'default-mgmt-dvm'] %}
 {% if salt['cmd.shell']('qvm-prefs '+sys_vm+' template') != sd_supported_fedora_version %}
 sd-{{ sys_vm }}-fedora-version-halt:
   qvm.kill:

--- a/dom0/sd-sys-vms.sls
+++ b/dom0/sd-sys-vms.sls
@@ -4,6 +4,11 @@
 # Ensures that sys-* VMs (viz. sys-net, sys-firewall, sys-usb) use
 # an up-to-date version of Fedora, in order to receive security updates.
 
+include:
+  # Import the upstream Qubes-maintained default-dispvm to ensure fedora-30-dvm
+  # is created.
+  - qvm.default-dispvm
+
 {% set sd_supported_fedora_version = 'fedora-30' %}
 
 # Install latest templates required for SDW VMs.
@@ -12,11 +17,15 @@ dom0-install-fedora-template:
     - pkgs:
       - qubes-template-{{ sd_supported_fedora_version }}
 
+# qvm.default-dispvm is not strictly required here, but we want it to be
+# updated as soon as possible to ensure make clean completes successfully, as
+# is sets the default_dispvm to fedora-30-dvm
 set-fedora-default-template-version:
   cmd.run:
     - name: qubes-prefs default_template {{ sd_supported_fedora_version }}
     - require:
       - pkg: dom0-install-fedora-template
+      - sls: qvm.default-dispvm
 
 {% for sys_vm in ['sys-usb', 'sys-net', 'sys-firewall'] %}
 {% if salt['cmd.shell']('qvm-prefs '+sys_vm+' template') != sd_supported_fedora_version %}

--- a/dom0/sd-sys-whonix-vms.sls
+++ b/dom0/sd-sys-whonix-vms.sls
@@ -6,6 +6,7 @@ include:
   # The anon-whoni config pulls in sys-whonix and sys-firewall,
   # as well as ensures the latest versions of Whonix are installed.
   - qvm.anon-whonix
+  - sd-upgrade-templates
 
 # The Qubes logic is too polite about enforcing template
 # settings, using "present" rather than "prefs". Below
@@ -17,6 +18,7 @@ sys-whonix-template-config:
       - template: whonix-gw-15
     - require:
       - sls: qvm.anon-whonix
+      - sls: sd-upgrade-templates
 
 anon-whonix-template-config:
   qvm.vm:

--- a/tests/test_qubes_vms.py
+++ b/tests/test_qubes_vms.py
@@ -28,6 +28,7 @@ class SD_Qubes_VM_Tests(unittest.TestCase):
             "sys-firewall",
             "sys-net",
             "sys-usb",
+            "default-mgmt-dvm",
         ]
         for sys_vm in sys_vms:
             vm = self.app.domains[sys_vm]


### PR DESCRIPTION
Closes #373, #368, #360 
Towards #382 (we do not change the default, but ensure the default is updated)
~Supersedes~ towards #367 (because with the changes introduced here, fedora-30-dvm should always be there) 

### Test plan
- [ ] On a fresh qubes 4.0.1 install, a single `make all` should complete in a single pass
- [ ] After running securedrop-update and rebooting, all tests in `make test` should pass
- [ ] `make clean` works as expected
- [ ] there is a fedora-30-dvm vm