### PR TITLE
Fixes #390 provides proper link to docs for transfer device

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ Optionally you can use the `printer-test` device to send a printer test page and
 
 #### Create the transfer device
 
-You can find instructions to create a luks-encrypted transfer device in the [SecureDrop docs](https://docs.securedrop.org/en/latest/set_up_transfer_device.html).
+You can find instructions to create a luks-encrypted transfer device in the [SecureDrop docs](https://docs.securedrop.org/en/latest/set_up_transfer_and_export_device.html).
 
 #### Exporting
 


### PR DESCRIPTION
Updates the link to the latest HTML page name in the SecureDrop
documentation

### How to test?

Verify that you can open the URL in the README for creating transfer devices.