### PR TITLE
Update latest qubes release to 4.0.2 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Installing this project is involved. It requires an up-to-date Qubes 4.0 install
 
 ### Install Qubes
 
-Before trying to use this project, install [Qubes 4.0.1](https://www.qubes-os.org/downloads/) on your development machine. Accept the default VM configuration during the install process.
+Before trying to use this project, install [Qubes 4.0.2](https://www.qubes-os.org/downloads/) on your development machine. Accept the default VM configuration during the install process.
 
 After installing Qubes, you must update both dom0 and the base templates to include the latest versions of apt packages. Open a terminal in `dom0` by clicking on the Qubes menu top-right of the screen and left-clicking on Terminal Emulator and run:
 


### PR DESCRIPTION
Closes #279 
Qubes 4.0.2 [has been released](https://www.qubes-os.org/news/2020/01/02/qubes-4-0-2/). Good news, the current install logic "just works" on Qubes 4.0.2.

Tested as follows:
- `make all`, `make test`, all tests pass
- `make clean`, `make all`, `make test`, all tests pass
- Client works as expected

I think a visual diff of the README changes is sufficient here, given the similarities between 4.0.2 and a fully patched 4.0.1 Qubes install.