### PR TITLE
Fix prep-dom0 target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,9 +122,7 @@ flake8: ## Lints all Python files with flake8
 template: ## Builds securedrop-workstation Qube template RPM
 	./builder/build-workstation-template
 
-prep-dom0: prep-salt # Copies dom0 config files for VM updates
-	sudo qubesctl top.enable sd-vm-updates
-	sudo qubesctl top.enable sd-dom0-files
+prep-dom0: prep-salt # Copies dom0 config files
 	sudo qubesctl --show-output --targets dom0 state.highstate
 
 destroy-all: ## Destroys all VMs managed by Workstation salt config


### PR DESCRIPTION
Fixes #394 

top.enable was removed in #351 in favor of sd-workstation.top file. top.enable will now be handled by prep-salt target, invoked by prep-dom0.

### Test plan
1. On master:
- [ ] `make prep-dom0` fails with the error described in #394 

2. On this branch:
- [ ] `make prep-dom0` completes successfully
- [ ] `make test`, all tests pass (specifically dom0 tests)