### PR TITLE
Fixes #348 resizes private volume sizes of sd-app sd-log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ clean-salt: assert-dom0 ## Purges SD Salt configuration from dom0
 
 prep-salt: assert-dom0 ## Configures Salt layout for SD workstation VMs
 	@./scripts/prep-salt
+	@./scripts/validate-config
 
 remove-sd-whonix: assert-dom0 ## Destroys SD Whonix VM
 	@./scripts/destroy-vm sd-whonix

--- a/config.json.example
+++ b/config.json.example
@@ -3,5 +3,9 @@
   "hidserv": {
     "hostname": "avgfxawdn6c3coe3.onion",
     "key": "Il8Xas7uf6rjtc0LxYwhrx"
-  }
+  },
+  "vmsizes": {
+        "sd_app": 10,
+        "sd_log": 5
+      }
 }

--- a/dom0/sd-app.sls
+++ b/dom0/sd-app.sls
@@ -45,6 +45,16 @@ sd-app:
     - require:
       - qvm: sd-app-buster-template
 
+{% import_json "sd/config.json" as d %}
+
+# The private volume size should be defined in the config.json
+sd-app-private-volume-size:
+  cmd.run:
+    - name: >
+        qvm-volume resize sd-app:private {{ d.vmsizes.sd_app }}GiB
+    - require:
+      - qvm: sd-app
+
 # Ensure the Qubes menu is populated with relevant app entries,
 # so that Nautilus/Files can be started via GUI interactions.
 sd-app-template-sync-appmenus:

--- a/dom0/sd-log.sls
+++ b/dom0/sd-log.sls
@@ -47,3 +47,13 @@ sd-log-dom0-securedrop.Log:
     - text: |
         @tag:sd-workstation sd-log allow
         @anyvm @anyvm deny
+
+{% import_json "sd/config.json" as d %}
+
+# The private volume size should be set in config.json
+sd-log-private-volume-size:
+  cmd.run:
+    - name: >
+        qvm-volume resize sd-log:private {{ d.vmsizes.sd_log }}GiB
+    - require:
+      - qvm: sd-log

--- a/scripts/validate-config
+++ b/scripts/validate-config
@@ -7,6 +7,7 @@ import json
 import re
 import os
 import subprocess
+from qubesadmin import Qubes
 
 
 TOR_V3_HOSTNAME_REGEX = r'^[a-z2-7]{56}\.onion$'
@@ -31,6 +32,7 @@ class SDWConfigValidator(object):
         self.confirm_onion_config_valid()
         self.confirm_submission_privkey_file()
         self.confirm_submission_privkey_fingerprint()
+        self.validate_existing_size()
 
     def confirm_config_file_exists(self):
         try:
@@ -87,6 +89,33 @@ class SDWConfigValidator(object):
         with open(self.config_filepath, 'r') as f:
             j = json.load(f)
         return j
+
+    def validate_existing_size(self):
+        """This method checks for existing private volume size and new
+        values in the config.json"""
+        assert "vmsizes" in self.config
+        assert "sd_app" in self.config["vmsizes"]
+        assert "sd_log" in self.config["vmsizes"]
+
+        assert isinstance(self.config["vmsizes"]["sd_app"], int), \
+            "Private volume size of sd-app must be an integer value."
+        assert isinstance(self.config["vmsizes"]["sd_log"], int), \
+            "Private volume size of sd-log must be an integer value."
+
+        app = Qubes()
+        if "sd-app" in app.domains:
+            vm = app.domains["sd-app"]
+            vol = vm.volumes["private"]
+            assert (
+                vol.size <= self.config["vmsizes"]["sd_app"] * 1024 * 1024 * 1024
+            ), "sd-app private volume is already bigger than configuration."
+
+        if "sd-log" in app.domains:
+            vm = app.domains["sd-log"]
+            vol = vm.volumes["private"]
+            assert (
+                vol.size <= self.config["vmsizes"]["sd_log"] * 1024 * 1024 * 1024
+            ), "sd-log private volume is already bigger than configuration."
 
 
 if __name__ == "__main__":

--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -1,4 +1,5 @@
 import unittest
+import json
 
 from qubesadmin import Qubes
 from base import WANTED_VMS
@@ -10,6 +11,8 @@ EXPECTED_KERNEL_VERSION = "4.14.158-grsec-workstation"
 class SD_VM_Tests(unittest.TestCase):
     def setUp(self):
         self.app = Qubes()
+        with open("config.json") as c:
+            self.config = json.load(c)
 
     def tearDown(self):
         pass
@@ -78,6 +81,12 @@ class SD_VM_Tests(unittest.TestCase):
         self._check_service_running(vm, "paxctld")
         self.assertTrue('sd-workstation' in vm.tags)
         self.assertTrue('sd-client' in vm.tags)
+        # Check the size of the private volume
+        # Should be 10GB
+        # >>> 1024 * 1024 * 10 * 1024
+        size = self.config["vmsizes"]["sd_app"]
+        vol = vm.volumes["private"]
+        self.assertEqual(vol.size, size * 1024 * 1024 * 1024)
 
     def test_sd_viewer_config(self):
         vm = self.app.domains["sd-viewer"]
@@ -114,6 +123,12 @@ class SD_VM_Tests(unittest.TestCase):
         self._check_service_running(vm, "paxctld")
         self.assertFalse(vm.template_for_dispvms)
         self.assertTrue('sd-workstation' in vm.tags)
+        # Check the size of the private volume
+        # Should be same of config.json
+        # >>> 1024 * 1024 * 5 * 1024
+        size = self.config["vmsizes"]["sd_log"]
+        vol = vm.volumes["private"]
+        self.assertEqual(vol.size, size * 1024 * 1024 * 1024)
 
     def test_sd_workstation_template(self):
         vm = self.app.domains["securedrop-workstation-buster"]


### PR DESCRIPTION
sd-app:private is now 10GB
sd-log:private is now 5GB

## How to test?

- [ ] Clone the repo to `dom0` and get the config.json and sd-journalist.sec file for your installation
- [ ] Update config.json to have the vmsizes, 

```
"vmsizes": {
    "sd_app": 10,
    "sd_log": 5
  },
```
- [ ] run `make sd-app`
- [ ] run `make sd-log`
- [ ] run `make test`
- [ ] Now, manually change the size for `sd-app` to 11GB `qvm-volume resize sd-app:private 11GiB
- [ ] Run `make sd-app` again, this should fail with a proper failure message.

 All of these commands should execute properly.

If you can check the private volume size of the `sd-app` and `sd-log` vm in the GUI too.