### PR TITLE
 Rename `securedrop-workstation-svs-disp` package per VM renames

### DIFF
--- a/dom0/sd-viewer-files.sls
+++ b/dom0/sd-viewer-files.sls
@@ -16,7 +16,7 @@ include:
 sd-viewer-install-mimetype-handler-package:
   pkg.installed:
     - pkgs:
-      - securedrop-workstation-svs-disp
+      - securedrop-workstation-viewer
       - evince
     - require:
       - sls: fpf-apt-test-repo

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -8,8 +8,8 @@ class SD_Viewer_Tests(SD_VM_Local_Test):
         self.vm_name = "sd-viewer"
         super(SD_Viewer_Tests, self).setUp()
 
-    def test_sd_svs_disp_config_package_installed(self):
-        pkg = "securedrop-workstation-svs-disp"
+    def test_sd_viewer_config_package_installed(self):
+        pkg = "securedrop-workstation-viewer"
         self.assertTrue(self._package_is_installed(pkg))
 
     def test_sd_viewer_evince_installed(self):


### PR DESCRIPTION
Draft for comments, blocked on https://github.com/freedomofpress/securedrop-debian-packaging/pull/130