### PR TITLE
Reserve 5% progress for VM reboot sequence

### DIFF
--- a/launcher/sdw_updater_gui/Updater.py
+++ b/launcher/sdw_updater_gui/Updater.py
@@ -84,7 +84,7 @@ def apply_updates(vms):
         else:
             upgrade_results = _apply_updates_vm(vm)
 
-        progress_percentage = int(((progress_current + 1) / len(vms)) * 100)
+        progress_percentage = int(((progress_current + 1) / len(vms)) * 100 - 5)
         yield vm, progress_percentage, upgrade_results
 
     _shutdown_and_start_vms()

--- a/launcher/sdw_updater_gui/UpdaterApp.py
+++ b/launcher/sdw_updater_gui/UpdaterApp.py
@@ -55,6 +55,8 @@ class UpdaterApp(QtGui.QMainWindow, Ui_UpdaterDialog):
         is used to check for TemplateVM updates
         """
         logger.info("Signal: update_status {}".format(str(result)))
+        self.progress = 100
+        self.progressBar.setProperty("value", self.progress)
 
         if result["recommended_action"] == UpdateStatus.UPDATES_REQUIRED:
             logger.info("Updates required")


### PR DESCRIPTION
Closes #411 

The progress bar will now reach 100% only when reboots are applied to AppVMs

#### Test plan
- On this branch: `make clone`, `make prep-dom0`
- Make sure you have 1 vm that needs updates
- [ ] 5% an acceptable value of progress to reserve for AppVM reboots?
- [ ] When update are complete (and the vm reboot cascade is observed), the progress bar indicates 95%