### PR TITLE
Rename desktop icon

### DIFF
--- a/dom0/securedrop-launcher.desktop
+++ b/dom0/securedrop-launcher.desktop
@@ -3,5 +3,5 @@ Version=1.0
 Type=Application
 Terminal=false
 Icon=/usr/share/securedrop/icons/sd-logo.png
-Name=SecureDrop Workstation Launcher
+Name=SecureDrop
 Exec=/opt/securedrop/launcher/sdw-launcher.py


### PR DESCRIPTION
"Launcher" is unnecessarily verbose for an icon shortcut and does
not match the window title.

Towards #413

# Testing

- After reprovisioning, the icon should have the new label. I have in fact tested this, so given that it's a simple string change, I leave it up to the reviewer if another run-through is required.