### PR TITLE
Fix dom0 updates when invoking via apply_updates

### DIFF
--- a/launcher/sdw_updater_gui/Updater.py
+++ b/launcher/sdw_updater_gui/Updater.py
@@ -80,7 +80,7 @@ def apply_updates(vms):
         upgrade_results = UpdateStatus.UPDATES_FAILED
 
         if vm == "dom0":
-            upgrade_results = _apply_updates_dom0(vm)
+            upgrade_results = _apply_updates_dom0()
         else:
             upgrade_results = _apply_updates_vm(vm)
 

--- a/launcher/tests/test_updater.py
+++ b/launcher/tests/test_updater.py
@@ -347,7 +347,8 @@ def test_apply_updates(
 
     assert updater.overall_update_status(results) == UpdateStatus.UPDATES_OK
     assert not mocked_error.called
-    apply_dom0.assert_called_once()
+    # Ensure _apply_updates_dom0 is not called with a parameter
+    apply_dom0.assert_called_once_with()
     assert not apply_vm.called
 
 


### PR DESCRIPTION
Closes #419 , this was an unfortunate combination of over mocking and not verifying the parameters when checking the mocked call.

#### Test Plan
This test requires that you have dom0 updates. Unfortunately, I have not found a way to downgrade packages in dom0 (`sudo qubes-dom0-update --action=downgrade <package>` does not work as the package are lowest version for the ones i tried)
- In dom0, run `make clone` and `make prep-dom0`
- [ ] Run the updater from the desktop icon and ensure the dom0 upgrade occurs smoothly
- [ ] The diff in `test_updater.py` should catch this regression regression should it occur in the future