### PR TITLE
Add missing files to rpmspec and manifest

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Status
+
+Ready for review / Work in progress
+
+## Description of Changes
+
+Fixes #.
+
+Changes proposed in this pull request:
+
+## Testing
+
+How should the reviewer test this PR?
+Write out any special testing steps here.
+
+## Checklist
+
+### If you have made changes to the provisioning logic
+
+- [ ] Linting (`make flake8`) and tests (`make test`) pass in dom0 of a Qubes install
+
+- [ ] I have added/removed files, and have updated packaging logic in MANIFEST.in and rpm-build/SPECS/securedrop-workstation-dom0-config.spec

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,6 +11,7 @@ include LICENSE
 include VERSION
 include Makefile
 include sd-proxy/*
+include sd-whonix/*
 include sd-app/*
 include sd-workstation/*
 include scripts/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,10 @@
 include dom0/*.sls
 include dom0/*.top
+include dom0/*.j2
 include dom0/securedrop-update
+include dom0/securedrop-login
+include dom0/securedrop-launcher.desktop
+include dom0/securedrop-handle-upgrade
 include config.json.example
 include README.md
 include LICENSE
@@ -10,3 +14,6 @@ include sd-proxy/*
 include sd-app/*
 include sd-workstation/*
 include scripts/*
+include sys-firewall/*
+include launcher/*.py
+include launcher/sdw_updater_gui/*.py

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -38,6 +38,7 @@ install -m 755 -d %{buildroot}/srv/salt/sd
 install -m 755 -d %{buildroot}/srv/salt/sd/sd-app
 install -m 755 -d %{buildroot}/srv/salt/sd/sd-proxy
 install -m 755 -d %{buildroot}/srv/salt/sd/sd-journalist
+install -m 755 -d %{buildroot}/srv/salt/sd/sd-whonix
 install -m 755 -d %{buildroot}/srv/salt/sd/sd-workstation
 install -m 755 -d %{buildroot}/srv/salt/sd/sys-firewall
 install -m 755 -d %{buildroot}/usr/share/%{name}/scripts
@@ -50,10 +51,11 @@ install -m 644 dom0/securedrop-launcher.desktop %{buildroot}/srv/salt/
 install -m 655 dom0/securedrop-handle-upgrade %{buildroot}/srv/salt/
 # The next file should get installed via RPM not via salt
 install -m 755 dom0/securedrop-update %{buildroot}/srv/salt/securedrop-update
-install sd-app/* %{buildroot}/srv/salt/sd/sd-app/
-install sd-proxy/* %{buildroot}/srv/salt/sd/sd-proxy/
-install sd-workstation/* %{buildroot}/srv/salt/sd/sd-workstation/
-install sys-firewall/* %{buildroot}/srv/salt/sd/sys-firewall/
+install -m 644 sd-app/* %{buildroot}/srv/salt/sd/sd-app/
+install -m 644 sd-proxy/* %{buildroot}/srv/salt/sd/sd-proxy/
+install -m 644 sd-whonix/* %{buildroot}/srv/salt/sd/sd-whonix/
+install -m 644 sd-workstation/* %{buildroot}/srv/salt/sd/sd-workstation/
+install -m 644 sys-firewall/* %{buildroot}/srv/salt/sd/sys-firewall/
 install -m 644 Makefile %{buildroot}/usr/share/%{name}/Makefile
 install -m 755 scripts/* %{buildroot}/usr/share/%{name}/scripts/
 install -m 644 launcher/*.py %{buildroot}/opt/securedrop/launcher/

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -30,33 +30,44 @@ configuration over time.
 %{__python3} setup.py build
 
 %install
-%{__python3} setup.py install --skip-build --root %{buildroot}
+%{__python3} setup.py install --no-compile --skip-build --root %{buildroot}
+install -m 755 -d %{buildroot}/opt/securedrop/launcher
+install -m 755 -d %{buildroot}/opt/securedrop/launcher/sdw_updater_gui
 install -m 755 -d %{buildroot}/srv
 install -m 755 -d %{buildroot}/srv/salt/sd
 install -m 755 -d %{buildroot}/srv/salt/sd/sd-app
+install -m 755 -d %{buildroot}/srv/salt/sd/sd-proxy
 install -m 755 -d %{buildroot}/srv/salt/sd/sd-journalist
 install -m 755 -d %{buildroot}/srv/salt/sd/sd-workstation
-install -m 755 -d %{buildroot}/usr/share/securedrop-workstation-dom0-config/scripts
-install -m 755 -d %{buildroot}/usr/share/securedrop/icons
+install -m 755 -d %{buildroot}/srv/salt/sd/sys-firewall
+install -m 755 -d %{buildroot}/usr/share/%{name}/scripts
 install -m 644 dom0/*.sls %{buildroot}/srv/salt/
 install -m 644 dom0/*.top %{buildroot}/srv/salt/
+install -m 644 dom0/*.j2 %{buildroot}/srv/salt/
+install -m 644 dom0/securedrop-update %{buildroot}/srv/salt/
+install -m 644 dom0/securedrop-login %{buildroot}/srv/salt/
+install -m 644 dom0/securedrop-launcher.desktop %{buildroot}/srv/salt/
+install -m 655 dom0/securedrop-handle-upgrade %{buildroot}/srv/salt/
 # The next file should get installed via RPM not via salt
 install -m 755 dom0/securedrop-update %{buildroot}/srv/salt/securedrop-update
 install sd-app/* %{buildroot}/srv/salt/sd/sd-app/
+install sd-proxy/* %{buildroot}/srv/salt/sd/sd-proxy/
 install sd-workstation/* %{buildroot}/srv/salt/sd/sd-workstation/
-install -m 644 sd-proxy/logo-small.png %{buildroot}/usr/share/securedrop/icons/sd-logo.png
+install sys-firewall/* %{buildroot}/srv/salt/sd/sys-firewall/
 install -m 644 Makefile %{buildroot}/usr/share/%{name}/Makefile
 install -m 755 scripts/* %{buildroot}/usr/share/%{name}/scripts/
+install -m 644 launcher/*.py %{buildroot}/opt/securedrop/launcher/
+install -m 644 launcher/sdw_updater_gui/*.py %{buildroot}/opt/securedrop/launcher/sdw_updater_gui/
 %files
 %doc README.md LICENSE
 %{python3_sitelib}/securedrop_workstation_dom0_config*
 %{_datadir}/%{name}
-%{_datadir}/securedrop/*
 %{_bindir}/securedrop-update
 /srv/salt/sd*
+/srv/salt/dom0-xfce-desktop-file.j2
+/srv/salt/securedrop-*
 /srv/salt/fpf*
-/srv/salt/securedrop-update
-
+/opt/securedrop/*
 %post
 find /srv/salt -maxdepth 1 -type f -iname '*.top' \
     | xargs -n1 basename \
@@ -69,4 +80,3 @@ find /srv/salt -maxdepth 1 -type f -iname '*.top' \
 
 * Fri Oct 26 2018 Kushal Das <kushal@freedom.press> - 0.0.1-1
 - First release
-


### PR DESCRIPTION
Towards #406 

Some files were failing when trying to install the dom0 rpm (When attempting to apply state.highstate)

Also added a pull request template to increase awareness of adding files to manifest and spec files.

### Test plan:
Note that I have successfully completed the test plan below. Given the complexity of testing this relatively small diff, I would suggest the reviewer just perform a visual diff of this PR, but ultimately will leave it to their discretion.
- `make clean`, and ensure no lingering files in `/srv/salt`
- On this branch, in a dev vm (with docker installed), `make dom0-rpm` and copy artifact to dom0
- `make clone` (we will use the cloned repo for tests)
- in dom0, where the rpm was copied: `sudo dnf install securedrop-workstation-dom0-config-0.1.1-1.fc25.noarch.rpm`
- [x] package installs successfully
- copy your instance-specific `config.json` and `sd-journalist.sec` into `/srv/salt/sd/` (needs sudo)
- `cd /usr/share/securedrop-workstation-dom0-config`
- `./scripts/provision-all`
- [x] provision-all returns 0, no errors in stdout
- cd into your cloned workstation repo (e.g. `~/securedrop-workstation`)
- run `make test`
- [x] all tests pass
