### PR TITLE
Change JSON key "last_updated" in `sdw-update-flag` to "last_status_update"

### DIFF
--- a/dom0/sd-clean-all.sls
+++ b/dom0/sd-clean-all.sls
@@ -21,7 +21,7 @@ remove-dom0-sdw-config-files:
       - /etc/qubes-rpc/policy/securedrop.Log
       - /etc/qubes-rpc/policy/securedrop.Proxy
       - /home/{{ gui_user }}/Desktop/securedrop-launcher.desktop
-      - /home/{{ gui_user }}/.securedrop_launcher/sdw-update-flag
+      - /home/{{ gui_user }}/.securedrop_launcher
 
 sd-cleanup-sys-firewall:
   cmd.run:

--- a/dom0/sd-clean-all.sls
+++ b/dom0/sd-clean-all.sls
@@ -21,6 +21,7 @@ remove-dom0-sdw-config-files:
       - /etc/qubes-rpc/policy/securedrop.Log
       - /etc/qubes-rpc/policy/securedrop.Proxy
       - /home/{{ gui_user }}/Desktop/securedrop-launcher.desktop
+      - /home/{{ gui_user }}/.securedrop_launcher/sdw-update-flag
 
 sd-cleanup-sys-firewall:
   cmd.run:

--- a/launcher/sdw_updater_gui/Updater.py
+++ b/launcher/sdw_updater_gui/Updater.py
@@ -282,7 +282,7 @@ def _write_updates_status_flag_to_disk(status):
         current_date = str(datetime.now().strftime(DATE_FORMAT))
 
         with open(flag_file_path_dom0, "w") as f:
-            flag_contents = {"last_updated": current_date, "status": status.value}
+            flag_contents = {"last_status_update": current_date, "status": status.value}
             json.dump(flag_contents, f)
     except Exception as e:
         sdlog.error("Error writing update status flag to dom0")
@@ -303,7 +303,7 @@ def last_required_reboot_performed():
         return True
 
     if int(flag_contents["status"]) == int(UpdateStatus.REBOOT_REQUIRED.value):
-        reboot_time = datetime.strptime(flag_contents["last_updated"], DATE_FORMAT)
+        reboot_time = datetime.strptime(flag_contents["last_status_update"], DATE_FORMAT)
         boot_time = datetime.now() - _get_uptime()
 
         # The session was started *before* the reboot was requested by

--- a/launcher/sdw_updater_gui/Updater.py
+++ b/launcher/sdw_updater_gui/Updater.py
@@ -15,9 +15,9 @@ from datetime import datetime, timedelta
 from enum import Enum
 
 DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
-FLAG_FILE_STATUS_SD_APP = "/home/user/.securedrop_client/sdw-update-flag"
+FLAG_FILE_STATUS_SD_APP = "/home/user/.securedrop_client/sdw-update-status"
 FLAG_FILE_LAST_UPDATED_SD_APP = "/home/user/.securedrop_client/sdw-last-updated"
-FLAG_FILE_STATUS_DOM0 = ".securedrop_launcher/sdw-update-flag"
+FLAG_FILE_STATUS_DOM0 = ".securedrop_launcher/sdw-update-status"
 FLAG_FILE_LAST_UPDATED_DOM0 = ".securedrop_launcher/sdw-last-updated"
 
 sdlog = logging.getLogger(__name__)

--- a/launcher/tests/test_updater.py
+++ b/launcher/tests/test_updater.py
@@ -796,7 +796,7 @@ def test_read_dom0_update_flag_from_disk_fails(
 @mock.patch(
     "Updater.read_dom0_update_flag_from_disk",
     return_value={
-        "last_updated": "1999-09-09 14:12:12",
+        "last_status_update": "1999-09-09 14:12:12",
         "status": UpdateStatus.REBOOT_REQUIRED.value,
     },
 )
@@ -813,7 +813,7 @@ def test_last_required_reboot_performed_successful(
 @mock.patch(
     "Updater.read_dom0_update_flag_from_disk",
     return_value={
-        "last_updated": str(datetime.now().strftime(updater.DATE_FORMAT)),
+        "last_status_update": str(datetime.now().strftime(updater.DATE_FORMAT)),
         "status": UpdateStatus.REBOOT_REQUIRED.value,
     },
 )
@@ -828,7 +828,7 @@ def test_last_required_reboot_performed_failed(mocked_info, mocked_error, mocked
 @mock.patch(
     "Updater.read_dom0_update_flag_from_disk",
     return_value={
-        "last_updated": str(datetime.now().strftime(updater.DATE_FORMAT)),
+        "last_status_update": str(datetime.now().strftime(updater.DATE_FORMAT)),
         "status": UpdateStatus.UPDATES_OK.value,
     },
 )


### PR DESCRIPTION
The use of `last_updated` here is ambiguous with with the usage in the separate file `sdw-last-udpated`, which contains the time of the last successful update of the SecureDrop Workstation.

The `last_updated` key in `sdw-last-updated` contains the timestamp of the last time the status itself was written to disk, regardless of success or failure.

I have also renamed the file itself to `sdw-update-status` for clarity, since that is the purpose of the file.

## Status

Ready for review

## Testing

- Tests should still pass
- Verify that the status file is written as expected to `sdw-update-status` when running the updater
- Verify that `make clean` removes file under old name