### PR TITLE
Fix split logic tests in dev, bump kernel version

### DIFF
--- a/tests/test_dom0_rpm_repo.py
+++ b/tests/test_dom0_rpm_repo.py
@@ -17,7 +17,6 @@ class SD_Dom0_Rpm_Repo_Tests(unittest.TestCase):
         self.maxDiff = None
         with open("config.json") as c:
             config = json.load(c)
-            # default to prod
             if 'environment' not in config:
                 config['environment'] = 'dev'
 

--- a/tests/test_dom0_rpm_repo.py
+++ b/tests/test_dom0_rpm_repo.py
@@ -19,7 +19,7 @@ class SD_Dom0_Rpm_Repo_Tests(unittest.TestCase):
             config = json.load(c)
             # default to prod
             if 'environment' not in config:
-                config['environment'] = 'prod'
+                config['environment'] = 'dev'
 
             if config['environment'] == 'prod':
                 self.pubkey_wanted = self.pubkey_wanted_prod

--- a/tests/test_sys_firewall.py
+++ b/tests/test_sys_firewall.py
@@ -15,7 +15,7 @@ class SD_Sys_Firewall_Tests(SD_VM_Local_Test):
             config = json.load(c)
             # default to prod
             if 'environment' not in config:
-                config['environment'] = 'prod'
+                config['environment'] = 'dev'
 
             if config['environment'] == 'prod':
                 self.pubkey_wanted = SD_Dom0_Rpm_Repo_Tests.pubkey_wanted_prod

--- a/tests/test_sys_firewall.py
+++ b/tests/test_sys_firewall.py
@@ -13,7 +13,6 @@ class SD_Sys_Firewall_Tests(SD_VM_Local_Test):
         super(SD_Sys_Firewall_Tests, self).setUp()
         with open("config.json") as c:
             config = json.load(c)
-            # default to prod
             if 'environment' not in config:
                 config['environment'] = 'dev'
 

--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -5,7 +5,7 @@ from qubesadmin import Qubes
 from base import WANTED_VMS
 
 
-EXPECTED_KERNEL_VERSION = "4.14.158-grsec-workstation"
+EXPECTED_KERNEL_VERSION = "4.14.169-grsec-workstation"
 
 
 class SD_VM_Tests(unittest.TestCase):

--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -23,7 +23,6 @@ class SD_VM_Platform_Tests(unittest.TestCase):
         self.app = Qubes()
         with open("config.json") as c:
             config = json.load(c)
-            # default to prod
             if 'environment' not in config:
                 config['environment'] = 'dev'
 

--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -25,7 +25,7 @@ class SD_VM_Platform_Tests(unittest.TestCase):
             config = json.load(c)
             # default to prod
             if 'environment' not in config:
-                config['environment'] = 'prod'
+                config['environment'] = 'dev'
 
             if config['environment'] == 'prod':
                 self.apt_url = FPF_APT_SOURCES_BUSTER


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Towards #441. Due to the way configure-environment script introduced in #432 only writes the config in /srv/salt and that tests are not shipped as part of staging and prod packages (they need to be checked out in dom0 separately), it seemed acceptable to default to dev values here for tests.

## Testing

I think a visual review here is sufficient, as I have already tested the changes locally (make clean, make all, make test, as well as quick client functionality review - download, decrypt, view, export, reply)

- [x] Defaulting to `dev` for tests make sense

#### Optional functional testing
- [x] All tests pass on this branch (after make clean, make all, make test on this branch)