### PR TITLE
Install securedrop-log and setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ sd-app: prep-salt ## Provisions SD APP VM
 
 sd-whonix: prep-salt ## Provisions SD Whonix VM
 	sudo qubesctl --show-output state.sls sd-whonix
-	sudo qubesctl --show-output --skip-dom0 --targets sd-whonix-buster-template,sd-whonix state.highstate
+	sudo qubesctl --show-output --skip-dom0 --targets whonix-gw-15,sd-whonix state.highstate
 
 sd-viewer: prep-salt ## Provisions SD Submission Viewing VM
 	sudo qubesctl --show-output state.sls sd-viewer
@@ -111,9 +111,10 @@ remove-sd-log: assert-dom0 ## Destroys SD logging VM
 	@./scripts/destroy-vm sd-log
 
 clean: assert-dom0 prep-salt ## Destroys all SD VMs
+	sudo qubesctl --show-output state.sls sd-clean-default-dispvm
+	$(MAKE) destroy-all
 	sudo qubesctl --show-output state.sls sd-clean-all
 	sudo dnf -y -q remove securedrop-workstation-dom0-config 2>/dev/null || true
-	$(MAKE) destroy-all
 	$(MAKE) clean-salt
 
 test: assert-dom0 ## Runs all application tests (no integration tests yet)

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ remove-sd-log: assert-dom0 ## Destroys SD logging VM
 clean: assert-dom0 prep-salt ## Destroys all SD VMs
 	sudo qubesctl --show-output state.sls sd-clean-default-dispvm
 	$(MAKE) destroy-all
+	sudo qubesctl --show-output --skip-dom0 --targets whonix-gw-15 state.sls sd-clean-whonix
 	sudo qubesctl --show-output state.sls sd-clean-all
 	sudo dnf -y -q remove securedrop-workstation-dom0-config 2>/dev/null || true
 	$(MAKE) clean-salt

--- a/dom0/sd-app-files.sls
+++ b/dom0/sd-app-files.sls
@@ -18,3 +18,18 @@ install-securedrop-client-package:
       - securedrop-client
     - require:
       - sls: fpf-apt-test-repo
+
+install-securedrop-log-package:
+  pkg.installed:
+    - pkgs:
+      - securedrop-log
+    - require:
+      - sls: fpf-apt-test-repo
+
+sd-rsyslog-for-sd-app:
+  file.managed:
+    - name: /etc/sd-rsyslog.conf
+    - source: "salt://sd-rsyslog.conf.j2"
+    - template: jinja
+    - context:
+        vmname: sd-app

--- a/dom0/sd-app-files.sls
+++ b/dom0/sd-app-files.sls
@@ -12,19 +12,14 @@ include:
   - fpf-apt-test-repo
 
 # FPF repo is setup in "securedrop-workstation" template
-install-securedrop-client-package:
+install-securedrop-client-and-securedrop-log-package:
   pkg.installed:
     - pkgs:
       - securedrop-client
-    - require:
-      - sls: fpf-apt-test-repo
-
-install-securedrop-log-package:
-  pkg.installed:
-    - pkgs:
       - securedrop-log
     - require:
       - sls: fpf-apt-test-repo
+
 
 sd-rsyslog-for-sd-app:
   file.managed:

--- a/dom0/sd-clean-all.sls
+++ b/dom0/sd-clean-all.sls
@@ -10,16 +10,6 @@ set-fedora-as-default-dispvm:
 include:
   - sd-usb-autoattach-remove
 
-sd-cleanup-whonix-gw-15:
-  cmd.run:
-    - names:
-      - qvm-run whonix-gw-15 'sudo rm -f /etc/rsyslog.d/sdlog.conf'
-      - qvm-run whonix-gw-15 'sudo rm -f /etc/apt/sources.list.d/securedrop_workstation.list'
-      - qvm-run whonix-gw-15 'sudo systemctl restart rsyslog'
-      - qvm-run whonix-gw-15 'sudo apt-key del 4ED79CC3362D7D12837046024A3BE4A92211B03C'
-      - qvm-run whonix-gw-15 'sudo apt-key del 22245C81E3BAEB4138B36061310F561200F4AD77'
-
-
 
 remove-dom0-sdw-config-files:
   file.absent:

--- a/dom0/sd-clean-all.sls
+++ b/dom0/sd-clean-all.sls
@@ -14,8 +14,12 @@ sd-cleanup-whonix-gw-15:
   cmd.run:
     - names:
       - qvm-run whonix-gw-15 'sudo rm -f /etc/rsyslog.d/sdlog.conf'
-      - qvm-run whonix-gw-15 'sudo systemctl restart rsyslog'
+      - qvm-run whonix-gw-15 'sudo rm -f /etc/apt/sources.list.d/securedrop_workstation.list'
       - qvm-run whonix-gw-15 'sudo apt remove -y securedrop-log'
+      - qvm-run whonix-gw-15 'sudo systemctl restart rsyslog'
+      - qvm-run whonix-gw-15 'sudo apt-key del 4ED79CC3362D7D12837046024A3BE4A92211B03C'
+
+
 
 remove-dom0-sdw-config-files:
   file.absent:

--- a/dom0/sd-clean-all.sls
+++ b/dom0/sd-clean-all.sls
@@ -10,6 +10,13 @@ set-fedora-as-default-dispvm:
 include:
   - sd-usb-autoattach-remove
 
+sd-cleanup-whonix-gw-15:
+  cmd.run:
+    - names:
+      - qvm-run whonix-gw-15 'sudo rm -f /etc/rsyslog.d/sdlog.conf'
+      - qvm-run whonix-gw-15 'sudo systemctl restart rsyslog'
+      - qvm-run whonix-gw-15 'sudo apt remove -y securedrop-log'
+
 remove-dom0-sdw-config-files:
   file.absent:
     - names:

--- a/dom0/sd-clean-all.sls
+++ b/dom0/sd-clean-all.sls
@@ -15,9 +15,9 @@ sd-cleanup-whonix-gw-15:
     - names:
       - qvm-run whonix-gw-15 'sudo rm -f /etc/rsyslog.d/sdlog.conf'
       - qvm-run whonix-gw-15 'sudo rm -f /etc/apt/sources.list.d/securedrop_workstation.list'
-      - qvm-run whonix-gw-15 'sudo apt remove -y securedrop-log'
       - qvm-run whonix-gw-15 'sudo systemctl restart rsyslog'
       - qvm-run whonix-gw-15 'sudo apt-key del 4ED79CC3362D7D12837046024A3BE4A92211B03C'
+      - qvm-run whonix-gw-15 'sudo apt-key del 22245C81E3BAEB4138B36061310F561200F4AD77'
 
 
 

--- a/dom0/sd-clean-default-dispvm.sls
+++ b/dom0/sd-clean-default-dispvm.sls
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+set-fedora-as-default-dispvm:
+  cmd.run:
+    - name: qvm-check fedora-30-dvm && qubes-prefs default_dispvm fedora-30-dvm || qubes-prefs default_dispvm ''

--- a/dom0/sd-clean-whonix.sls
+++ b/dom0/sd-clean-whonix.sls
@@ -9,3 +9,12 @@ remove-securedrop-log-package-from-whonix:
   pkg.removed:
     - pkgs:
       - securedrop-log
+
+sd-cleanup-whonix-gw-15:
+  cmd.run:
+    - names:
+      - sudo rm -f /etc/rsyslog.d/sdlog.conf
+      - sudo rm -f /etc/apt/sources.list.d/securedrop_workstation.list
+      - sudo systemctl restart rsyslog
+      - sudo apt-key del 4ED79CC3362D7D12837046024A3BE4A92211B03C
+      - sudo apt-key del 22245C81E3BAEB4138B36061310F561200F4AD77

--- a/dom0/sd-clean-whonix.sls
+++ b/dom0/sd-clean-whonix.sls
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+##
+# removes securedrop-log rsyslog plugin in whonix-gw-15
+##
+
+remove-securedrop-log-package-from-whonix:
+  pkg.removed:
+    - pkgs:
+      - securedrop-log

--- a/dom0/sd-devices-files.sls
+++ b/dom0/sd-devices-files.sls
@@ -24,3 +24,19 @@ sd-devices-install-libreoffice:
 sd-devices-install-package:
   pkg.installed:
     - name: securedrop-export
+
+
+sd-devices-install-securedrop-log-package:
+  pkg.installed:
+    - pkgs:
+      - securedrop-log
+    - require:
+      - sls: fpf-apt-test-repo
+
+sd-rsyslog-for-sd-devices:
+  file.managed:
+    - name: /etc/sd-rsyslog.conf
+    - source: "salt://sd-rsyslog.conf.j2"
+    - template: jinja
+    - context:
+        vmname: sd-devices

--- a/dom0/sd-log-template-files.sls
+++ b/dom0/sd-log-template-files.sls
@@ -3,7 +3,7 @@
 include:
   - fpf-apt-test-repo
 
-install-securedrop-log-package:
+sd-log-install-securedrop-log-package:
   pkg.installed:
     - pkgs:
       - redis-server

--- a/dom0/sd-log.sls
+++ b/dom0/sd-log.sls
@@ -57,3 +57,11 @@ sd-log-private-volume-size:
         qvm-volume resize sd-log:private {{ d.vmsizes.sd_log }}GiB
     - require:
       - qvm: sd-log
+
+# Permit the SecureDrop Proxy to manage Client connections
+sd-dom-dom0-securedrop.Log:
+  file.prepend:
+    - name: /etc/qubes-rpc/policy/securedrop.Log
+    - text: |
+        @tag:sd-workstation sd-log allow
+        @anyvm @anyvm deny

--- a/dom0/sd-proxy-template-files.sls
+++ b/dom0/sd-proxy-template-files.sls
@@ -41,19 +41,14 @@ sd-proxy-configure-mimetypes:
 
 # Depends on FPF-controlled apt repo, already present
 # in underlying "securedrop-workstation" base template.
-install-securedrop-proxy-package:
+install-securedrop-proxy-and-securedrop-log-package:
   pkg.installed:
     - pkgs:
       - securedrop-proxy
-    - require:
-      - sls: fpf-apt-test-repo
-
-install-securedrop-log-package:
-  pkg.installed:
-    - pkgs:
       - securedrop-log
     - require:
       - sls: fpf-apt-test-repo
+
 
 {% import_json "sd/config.json" as d %}
 

--- a/dom0/sd-proxy-template-files.sls
+++ b/dom0/sd-proxy-template-files.sls
@@ -48,6 +48,13 @@ install-securedrop-proxy-package:
     - require:
       - sls: fpf-apt-test-repo
 
+install-securedrop-log-package:
+  pkg.installed:
+    - pkgs:
+      - securedrop-log
+    - require:
+      - sls: fpf-apt-test-repo
+
 {% import_json "sd/config.json" as d %}
 
 install-securedrop-proxy-yaml-config:
@@ -58,3 +65,11 @@ install-securedrop-proxy-yaml-config:
     - context:
         hostname: {{ d.hidserv.hostname }}
     - mode: 0644
+
+sd-rsyslog-for-sd-proxy:
+  file.managed:
+    - name: /etc/sd-rsyslog.conf
+    - source: "salt://sd-rsyslog.conf.j2"
+    - template: jinja
+    - context:
+        vmname: sd-proxy

--- a/dom0/sd-rsyslog.conf.j2
+++ b/dom0/sd-rsyslog.conf.j2
@@ -1,0 +1,3 @@
+[sd-rsyslog]
+remotevm = sd-log
+localvm = {{ vmname }}

--- a/dom0/sd-viewer-files.sls
+++ b/dom0/sd-viewer-files.sls
@@ -28,3 +28,18 @@ sd-viewer-install-libreoffice:
         attempts: 3
         interval: 60
     - install_recommends: False
+
+sd-viewer-install-logging:
+  pkg.installed:
+    - pkgs:
+      - securedrop-log
+    - require:
+      - sls: fpf-apt-test-repo
+
+sd-rsyslog-for-sd-viewer:
+  file.managed:
+    - name: /etc/sd-rsyslog.conf
+    - source: "salt://sd-rsyslog.conf.j2"
+    - template: jinja
+    - context:
+        vmname: sd-viewer

--- a/dom0/sd-whonix-rsyslog-enable.sls
+++ b/dom0/sd-whonix-rsyslog-enable.sls
@@ -13,11 +13,17 @@ sd-rsyslog-for-sd-whonix:
     - context:
         vmname: sd-whonix
 
+
+# We can not place the file on the template under /etc/rsyslog.d/ because of whonix
+# template. This sdlog.conf file is the same from the securedrop-log package, to
+# make sure that rsyslogd use our logging plugin.
 sd-rsyslog-sdlog-conf-for-sd-whonix:
   file.managed:
     - name: /rw/config/sdlog.conf
     - source: "salt://sdlog.conf"
 
+# Because whonix-gw-15 template is not allowing to create the config file on
+# package install time, we do it via rc.local call.
 sd-rc-enable-logging:
   file.blockreplace:
     - name: /rw/config/rc.local

--- a/dom0/sd-whonix-rsyslog-enable.sls
+++ b/dom0/sd-whonix-rsyslog-enable.sls
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+##
+# Enables securedrop-log rsyslog plugin in sd-whonix
+##
+
+sd-rsyslog-for-sd-whonix:
+  file.managed:
+    - name: /rw/config/sd-rsyslog.conf
+    - source: "salt://sd-rsyslog.conf.j2"
+    - template: jinja
+    - context:
+        vmname: sd-whonix
+
+
+sd-rc-enable-logging:
+  file.blockreplace:
+    - name: /rw/config/rc.local
+    - append_if_not_found: True
+    - marker_start: "### BEGIN securedrop-workstation ###"
+    - marker_end: "### END securedrop-workstation ###"
+    - content: |
+        # Add sd-rsyslog.conf file for syslog
+        ln -sf /rw/config/sd-rsyslog.conf /etc/sd-rsyslog.conf
+        systemctl restart rsyslog
+  cmd.run:
+    - name: ln -sf /rw/config/sd-rsyslog.conf /etc/sd-rsyslog.conf && systemctl restart rsyslog
+
+

--- a/dom0/sd-whonix-rsyslog-enable.sls
+++ b/dom0/sd-whonix-rsyslog-enable.sls
@@ -13,6 +13,10 @@ sd-rsyslog-for-sd-whonix:
     - context:
         vmname: sd-whonix
 
+sd-rsyslog-sdlog-conf-for-sd-whonix:
+  file.managed:
+    - name: /rw/config/sdlog.conf
+    - source: "salt://sdlog.conf"
 
 sd-rc-enable-logging:
   file.blockreplace:
@@ -23,6 +27,9 @@ sd-rc-enable-logging:
     - content: |
         # Add sd-rsyslog.conf file for syslog
         ln -sf /rw/config/sd-rsyslog.conf /etc/sd-rsyslog.conf
+        if [ ! -f /etc/rsyslog.d/sdlog.conf ]; then
+            ln -sf /rw/config/sdlog.conf /etc/rsyslog.d/sdlog.conf
+        fi
         systemctl restart rsyslog
   cmd.run:
     - name: ln -sf /rw/config/sd-rsyslog.conf /etc/sd-rsyslog.conf && systemctl restart rsyslog

--- a/dom0/sd-whonix-template-files.sls
+++ b/dom0/sd-whonix-template-files.sls
@@ -1,21 +1,22 @@
 # -*- coding: utf-8 -*-
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+##
+# sd-whonix-template-files
+# ========
+#
+# Installs configuration packages specific to the sd-whonix
+# used for network calls.
+#
+##
+
 include:
   - fpf-apt-test-repo
 
-install-securedrop-log-package:
+sd-whonix-install-logging:
   pkg.installed:
     - pkgs:
-      - redis-server
-      - redis
       - securedrop-log
     - require:
       - sls: fpf-apt-test-repo
 
-redis:
-  service.running:
-    - enable: True
-
-securedrop-log:
-  service.running:
-    - enable: True

--- a/dom0/sd-workstation-template-files.sls
+++ b/dom0/sd-workstation-template-files.sls
@@ -11,6 +11,14 @@ sd-workstation-template-install-kernel-config-packages:
     - require:
       - sls: fpf-apt-test-repo
 
+
+sd-workstation-install-securedrop-log-package:
+  pkg.installed:
+    - pkgs:
+      - securedrop-log
+    - require:
+      - sls: fpf-apt-test-repo
+
 # Ensure that paxctld starts immediately. For AppVMs,
 # use qvm.features.enabled = ["paxctld"] to ensure service start.
 sd-workstation-template-enable-paxctld:

--- a/dom0/sd-workstation.top
+++ b/dom0/sd-workstation.top
@@ -10,6 +10,7 @@ base:
     - sd-upgrade-templates
     - sd-dom0-qvm-rpc
     - sd-sys-whonix-vms
+    - sd-log
     - sd-devices
     - sd-gpg
     - sd-proxy
@@ -17,7 +18,9 @@ base:
     - sd-app
     - sd-whonix
     - sd-remove-unused-templates
-    - sd-log
+
+  sd-log-buster-template:
+    - sd-log-template-files
   sd-devices-buster-template:
     - sd-devices-files
   sd-gpg:
@@ -34,12 +37,13 @@ base:
     - sd-sys-firewall-files
   sd-whonix:
     - sd-whonix-hidserv-key
-  sd-log-buster-template:
-    - sd-log-template-files
+    - sd-whonix-rsyslog-enable
   securedrop-workstation-buster:
     - sd-workstation-template-files
   sys-usb:
     - sd-usb-autoattach-add
+  whonix-gw-15:
+    - sd-whonix-template-files
 
   # "Placeholder" config to trigger TemplateVM boots,
   # so upgrades can be applied automatically via cron.

--- a/dom0/sdlog.conf
+++ b/dom0/sdlog.conf
@@ -1,0 +1,4 @@
+module(load="omprog")
+action(type="omprog"
+       binary="/usr/sbin/sd-rsyslog"
+       template="RSYSLOG_TraditionalFileFormat")

--- a/scripts/provision-all
+++ b/scripts/provision-all
@@ -18,9 +18,11 @@ echo "Set up dom0 config files, including RPC policies, and create VMs"
 sudo qubesctl --show-output state.highstate
 
 echo "Setup sd-log-buster-template vm first"
-sudo qubesctl --show-output --skip-dom0 --targets sd-log-buster-template state.sls sd-log-template-files
+sudo qubesctl --show-output --skip-dom0 --targets sd-log-buster-template state.highstate
 # Provision whonix-gw-15 with log additions because it isn't tagged with sd-workstation (we don't want it removed after a make clean)
-sudo qubesctl --show-output --skip-dom0 --targets whonix-gw-15 state.highstate sd-whonix-template-files
+sudo qubesctl --show-output --skip-dom0 --targets whonix-gw-15 state.highstate
+sudo qubesctl --show-output --skip-dom0 --targets whonix-gw-15 state.sls sd-whonix-template-files
+
 
 # Format list of all VMs comma-separated, for use as qubesctl target
 # We run this after dom0's highstate, so that the VMs are available for listing by tag.

--- a/scripts/provision-all
+++ b/scripts/provision-all
@@ -21,8 +21,8 @@ echo "Setup sd-log-buster-template vm first"
 sudo qubesctl --show-output --skip-dom0 --targets sd-log-buster-template state.highstate
 # Provision whonix-gw-15 with log additions because it isn't tagged with sd-workstation (we don't want it removed after a make clean)
 sudo qubesctl --show-output --skip-dom0 --targets whonix-gw-15 state.highstate
-sudo qubesctl --show-output --skip-dom0 --targets whonix-gw-15 state.sls sd-whonix-template-files
-
+#sudo qubesctl --show-output --skip-dom0 --targets whonix-gw-15 state.sls sd-whonix-template-files
+qvm-shutdown --wait whonix-gw-15
 
 # Format list of all VMs comma-separated, for use as qubesctl target
 # We run this after dom0's highstate, so that the VMs are available for listing by tag.

--- a/scripts/provision-all
+++ b/scripts/provision-all
@@ -17,6 +17,11 @@ sudo qubesctl --show-output --skip-dom0 --targets sys-firewall state.sls sd-sys-
 echo "Set up dom0 config files, including RPC policies, and create VMs"
 sudo qubesctl --show-output state.highstate
 
+echo "Setup sd-log-buster-template vm first"
+sudo qubesctl --show-output --skip-dom0 --targets sd-log-buster-template state.sls sd-log-template-files
+# Provision whonix-gw-15 with log additions because it isn't tagged with sd-workstation (we don't want it removed after a make clean)
+sudo qubesctl --show-output --skip-dom0 --targets whonix-gw-15 state.highstate sd-whonix-template-files
+
 # Format list of all VMs comma-separated, for use as qubesctl target
 # We run this after dom0's highstate, so that the VMs are available for listing by tag.
 all_sdw_vms_target="$(qvm-ls --tags sd-workstation --raw-list | perl -npE 's/\n/,/g' | perl -npE 's/,$//' )"

--- a/tests/base.py
+++ b/tests/base.py
@@ -112,3 +112,19 @@ class SD_VM_Local_Test(unittest.TestCase):
             return False
 
         return True
+
+    def logging_configured(self, vmname=""):
+        """
+        Make sure rsyslog is configured to send in data to sd-log vm.
+        """
+        if not vmname:
+            vmname = self.vm_name
+        self.assertTrue(self._fileExists("/etc/sd-rsyslog.conf"))
+        # Then we check the configuration inside of the file.
+        file_content = self._get_file_contents("/etc/sd-rsyslog.conf")
+        static_content = """[sd-rsyslog]
+remotevm = sd-log
+localvm = {0}
+""".format(vmname)
+        self.assertEqual(file_content, static_content)
+        self.assertTrue(self._package_is_installed("securedrop-log"))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -49,6 +49,9 @@ class SD_App_Tests(SD_VM_Local_Test):
         results = json.loads(self._run(cmd))
         self.assertTrue(results['profiles']['/usr/bin/securedrop-client'] == "enforce")
 
+    def test_logging_configured(self):
+        self.logging_configured()
+
 
 def load_tests(loader, tests, pattern):
     suite = unittest.TestLoader().loadTestsFromTestCase(SD_App_Tests)

--- a/tests/test_proxy_vm.py
+++ b/tests/test_proxy_vm.py
@@ -40,6 +40,9 @@ class SD_Proxy_Tests(SD_VM_Local_Test):
         """
         assert self._fileExists(self.whonix_apt_list)
 
+    def test_logging_configured(self):
+        self.logging_configured()
+
 
 def load_tests(loader, tests, pattern):
     suite = unittest.TestLoader().loadTestsFromTestCase(SD_Proxy_Tests)

--- a/tests/test_sd_devices.py
+++ b/tests/test_sd_devices.py
@@ -19,6 +19,9 @@ class SD_Devices_Tests(SD_VM_Local_Test):
         self.assertTrue(self._package_is_installed("printer-driver-brlaser"))
         self.assertTrue(self._package_is_installed("securedrop-export"))
 
+    def test_logging_configured(self):
+        self.logging_configured(vmname="sd-devices")
+
 
 def load_tests(loader, tests, pattern):
     suite = unittest.TestLoader().loadTestsFromTestCase(SD_Devices_Tests)

--- a/tests/test_sd_whonix.py
+++ b/tests/test_sd_whonix.py
@@ -58,6 +58,9 @@ class SD_Whonix_Tests(SD_VM_Local_Test):
         """
         assert self._fileExists(self.whonix_apt_list)
 
+    def test_logging_configured(self):
+        self.logging_configured()
+
 
 def load_tests(loader, tests, pattern):
     suite = unittest.TestLoader().loadTestsFromTestCase(SD_Whonix_Tests)

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -19,6 +19,9 @@ class SD_Viewer_Tests(SD_VM_Local_Test):
     def test_sd_viewer_libreoffice_installed(self):
         self.assertTrue(self._package_is_installed("libreoffice"))
 
+    def test_logging_configured(self):
+        self.logging_configured()
+
 
 def load_tests(loader, tests, pattern):
     suite = unittest.TestLoader().loadTestsFromTestCase(SD_Viewer_Tests)

--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -121,6 +121,7 @@ class SD_VM_Tests(unittest.TestCase):
         self.assertFalse(vm.template_for_dispvms)
         self._check_kernel(vm)
         self._check_service_running(vm, "paxctld")
+        self._check_service_running(vm, "securedrop-log")
         self.assertFalse(vm.template_for_dispvms)
         self.assertTrue('sd-workstation' in vm.tags)
         # Check the size of the private volume


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Resolves #440 

Sets up `securedrop-log` service in related VMs. All logs should be flowing into `sd-log` vm.

Changes proposed in this pull request:

## Testing

- [ ] `make all` should have logging ready.
- [ ] Checks logs at `/home/user/QubesIncomingLogs/` directory in `sd-logs` vm

## Checklist

### If you have made changes to the provisioning logic

- [ ] Linting (`make flake8`) and tests (`make test`) pass in dom0 of a Qubes install

- [ ] I have added/removed files, and have updated packaging logic in MANIFEST.in and rpm-build/SPECS/securedrop-workstation-dom0-config.spec
