### PR TITLE
Detect process conflicts with sdw-notify

### DIFF
--- a/launcher/sdw-notify.py
+++ b/launcher/sdw-notify.py
@@ -22,6 +22,11 @@ def main():
     """
 
     Util.configure_logging(Notify.LOG_FILE)
+
+    if Util.is_conflicting_process_running(Notify.CONFLICTING_PROCESSES):
+        # Conflicting system process may be running in dom0. Logged.
+        sys.exit(1)
+
     if Util.can_obtain_lock(Updater.LOCK_FILE) is False:
         # Preflight updater is already running. Logged.
         sys.exit(1)

--- a/launcher/sdw_notify/Notify.py
+++ b/launcher/sdw_notify/Notify.py
@@ -23,6 +23,12 @@ LOCK_FILE = "sdw-notify.lock"
 # Log file name, base directories defined in sdw_util
 LOG_FILE = "sdw-notify.log"
 
+# Process names that should not be running while this script runs. We do not
+# want to encourage running the updater during provisioning or system updates.
+# Caution is advised in expanding this list; a more precise detection method
+# is generally preferable.
+CONFLICTING_PROCESSES = ["qubesctl", "make"]
+
 # The maximum uptime this script should permit (specified in seconds) before
 # showing a warning. This is to avoid situations where the user boots the
 # computer after several days and immediately sees a warning.

--- a/launcher/sdw_util/Util.py
+++ b/launcher/sdw_util/Util.py
@@ -5,8 +5,10 @@ Utility functions used by both the launcher and notifier scripts
 import fcntl
 import os
 import logging
+import subprocess
 
 from logging.handlers import TimedRotatingFileHandler
+from shlex import quote
 
 # The directory where status files and logs are stored
 BASE_DIRECTORY = os.path.join(os.path.expanduser("~"), ".securedrop_launcher")
@@ -94,3 +96,16 @@ def can_obtain_lock(basename):
         return False
 
     return True
+
+
+def is_conflicting_process_running(list):
+    """
+    Check if any process of the given name is currently running. Aborts on the
+    first match.
+    """
+    for name in list:
+        result = subprocess.run(args=["pgrep", quote(name)], stdout=subprocess.DEVNULL)
+        if result.returncode == 0:
+            sdlog.error("Conflicting process '{}' is currently running.".format(name))
+            return True
+    return False

--- a/launcher/sdw_util/Util.py
+++ b/launcher/sdw_util/Util.py
@@ -8,7 +8,6 @@ import logging
 import subprocess
 
 from logging.handlers import TimedRotatingFileHandler
-from shlex import quote
 
 # The directory where status files and logs are stored
 BASE_DIRECTORY = os.path.join(os.path.expanduser("~"), ".securedrop_launcher")
@@ -104,7 +103,9 @@ def is_conflicting_process_running(list):
     first match.
     """
     for name in list:
-        result = subprocess.run(args=["pgrep", quote(name)], stdout=subprocess.DEVNULL)
+        result = subprocess.run(
+            args=["pgrep", name], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        )
         if result.returncode == 0:
             sdlog.error("Conflicting process '{}' is currently running.".format(name))
             return True

--- a/launcher/tests/test_util.py
+++ b/launcher/tests/test_util.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 import re
 import subprocess
 
@@ -11,6 +12,8 @@ BUSY_LOCK_REGEX = r"Error obtaining lock on '.*'."
 
 # Regex for failure to obtain lock due to permission error
 LOCK_PERMISSION_REGEX = r"Error writing to lock file '.*'"
+
+CONFLICTING_PROCESS_REGEX = r"Conflicting process .* is currently running."
 
 relpath_util = "../sdw_util/Util.py"
 path_to_util = os.path.join(os.path.dirname(os.path.abspath(__file__)), relpath_util)
@@ -166,3 +169,31 @@ def test_log():
         path = os.path.join(tmpdir, basename)
         count = len(open(path).readlines())
         assert count == 3
+
+
+@pytest.mark.parametrize(
+    "return_code,expected_result", [(0, True), (1, False)],
+)
+@mock.patch("Util.sdlog.error")
+@mock.patch("Util.sdlog.warning")
+@mock.patch("Util.sdlog.info")
+def test_for_conflicting_process(
+    mocked_info, mocked_warning, mocked_error, return_code, expected_result
+):
+    """
+    Test whether we can successfully detect conflicting processes.
+    """
+    # We mock the pgrep call itself, which means we _won't_ detect behavior
+    # changes at that level.
+    completed_process = subprocess.CompletedProcess(args=[], returncode=return_code)
+    with mock.patch("subprocess.run", return_value=completed_process) as mocked_run:
+        running_process = util.is_conflicting_process_running(["crush-all-humans"])
+        mocked_run.assert_called_once()
+        if expected_result is True:
+            assert running_process is True
+            mocked_error.assert_called_once()
+            error_string = mocked_error.call_args[0][0]
+            assert re.search(CONFLICTING_PROCESS_REGEX, error_string) is not None
+        else:
+            assert running_process is False
+            assert not mocked_error.called

--- a/launcher/tests/test_util.py
+++ b/launcher/tests/test_util.py
@@ -187,7 +187,7 @@ def test_for_conflicting_process(
     # changes at that level.
     completed_process = subprocess.CompletedProcess(args=[], returncode=return_code)
     with mock.patch("subprocess.run", return_value=completed_process) as mocked_run:
-        running_process = util.is_conflicting_process_running(["crush-all-humans"])
+        running_process = util.is_conflicting_process_running(["cowsay"])
         mocked_run.assert_called_once()
         if expected_result is True:
             assert running_process is True


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Resolves #453.

We check for a defined list of processes using `pgrep` to ensure that `sdw-notify` does not run when provisioning or similar system updates are already underway.

## Test plan

Setup:
1. Check out this branch and run `make prep-dom0`
2. Ensure that `~/.securedrop_launcher/sdw-last-updated` does not exist, to force the notification to always appear.

Tests:
- [ ] Run `/opt/securedrop/launcher/sdw-notify.py`. The notification _should_ show up.
- [ ] Run `make test` and run `/opt/securedrop/launcher/sdw-notify.py` while it is doing its thing. The notification should _not_ appear, and you should see a log entry in `~/.securedrop_launcher/logs/sdw-notify.log` explaining why.
- [ ]  (optional, for good measure) Run the Qubes GUI updater and kick off a graphical update process (`qubesctl` must be running in the process list). Run `sdw-notify` while that's underway. Result should be the same as above.

## Checklist
- [x] Tested in Qubes
- [x] `make flake8` passes
- [x] `make test` passes
- [x] no packaging changes
- [x] made with love