### PR TITLE
Write `sdw-last-updated` after upgrades in REBOOT_REQUIRED case

### DIFF
--- a/launcher/sdw_updater_gui/UpdaterApp.py
+++ b/launcher/sdw_updater_gui/UpdaterApp.py
@@ -246,11 +246,13 @@ class UpdateThread(QThread):
             results[vm] = result
             self.progress_signal.emit(progress)
 
-        # write the flags to disk after successful updates, including updates
-        # that require a reboot.
         run_results = Updater.overall_update_status(results)
         Updater._write_updates_status_flag_to_disk(run_results)
-        if run_results in {UpdateStatus.UPDATES_OK, UpdateStatus.REBOOT_REQUIRED}:
+        # Write the "last updated" date to disk if the system is up-to-date.
+        # Even though no updates have been newly applied at this stage, for the
+        # purposes of security checks, all we need to know is that the system is
+        # up-to-date as of this run.
+        if run_results == UpdateStatus.UPDATES_OK:
             Updater._write_last_updated_flags_to_disk()
         # populate signal contents
         message = results  # copy all the information from results
@@ -290,7 +292,9 @@ class UpgradeThread(QThread):
         # write flags to disk
         run_results = Updater.overall_update_status(results)
         Updater._write_updates_status_flag_to_disk(run_results)
-        if run_results == UpdateStatus.UPDATES_OK:
+        # Write the "last updated" date to disk if the system is up-to-date
+        # after applying upgrades, regardless of whether a reboot is still pending.
+        if run_results in {UpdateStatus.UPDATES_OK, UpdateStatus.REBOOT_REQUIRED}:
             Updater._write_last_updated_flags_to_disk()
         # populate signal results
         message = results  # copy all information from updater call


### PR DESCRIPTION
## Status

Ready for review. 
## Description 

The UpdateThread never newly discovers that a reboot is required, it only picks up a reboot requirement from prior runs. Even if we added logic to discover the reboot requirement earlier, we won't know for sure whether updates have been successfully applied until the UpgradeThreads have completed.

Resolves #462
## Test plan

1. Note the contents of `~/.securedrop_launcher/sdw-last-updated` or delete it from disk.
2. Check if you have updates available in `fedora-30` by running `dnf check-update` inside the template. If you do not, attempt to ensure a system state in which updates are available.
3. Force a run of the preflight updater by running `/opt/securedrop/launcher-sdw-launcher.py --skip-delta 0` in `dom0`. While the command runs, observe its output in `~/.securedrop-launcher/launcher.log`.
4. Wait for the update check to finish.
   - [ ] Observe that `~/.securedrop_launcher/sdw-last-updated` has **not** been modified yet.
5. Apply the available updates. Do not reboot yet.
   -  [ ] Observe that `~/.securedrop_launcher/sdw-last-updated` has been updated.
6. Restart the updater and re-check for updates.
   - [ ] Observe that  `~/.securedrop_launcher/sdw-last-updated` has **not** been modified again.

## Checklist
- [x] No packaging changes required
- [ ] `make test` succeeds in `dom0` (haven't re-run; no provisioning changes in this PR)