### PR TITLE
Replace securedrop-login action with preflight updater

### DIFF
--- a/dom0/securedrop-login
+++ b/dom0/securedrop-login
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """
-Utility script for SecureDrop Workstation config. Updates the TemplateVM
-used for SDW DispVMs by installing all available apt packages.
+Utility script for SecureDrop Workstation config. Launches the SecureDrop
+Workstation updater on boot. It will prompt users to apply template and
+dom0 updates
 
 The update process is intended to run at XFCE login, via a desktop file.
 """
@@ -9,17 +10,11 @@ import os
 import subprocess
 import logging
 import time
-import sys
 
-import qubesadmin
-
-
+LAUNCHER_PATH = "/opt/securedrop/launcher/sdw-launcher.py"
 SCRIPT_NAME = os.path.basename(__file__)
 logger = logging.getLogger(SCRIPT_NAME)
 logging.basicConfig(level=logging.INFO)
-
-
-SDW_DISPVM_TEMPLATE = "sd-viewer-template"
 
 
 if __name__ == "__main__":
@@ -28,20 +23,5 @@ if __name__ == "__main__":
     # to the user.
     time.sleep(5)
 
-    # Ensure target VM exists
-    q = qubesadmin.Qubes()
-    if SDW_DISPVM_TEMPLATE not in q.domains:
-        # Log message isn't logged to syslog, only stderr
-        logger.error("VM does not exist: {}".format(SDW_DISPVM_TEMPLATE))
-        sys.exit(1)
-
-    cmd = [
-        "sudo",
-        "qubesctl",
-        "--skip-dom0",
-        "--targets",
-        SDW_DISPVM_TEMPLATE,
-        "state.sls",
-        "update.qubes-vm",
-    ]
+    cmd = ["python3", LAUNCHER_PATH]
     subprocess.check_call(cmd)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Closes #415.

Changes proposed in this pull request:

## Testing
- [x] `make prep-dom0` completes without error
- [ ] `make test` completes without error (all tests pass)
- Reboot the workstation
- [ ] The preflight updater (or the client) starts at boot
- [ ] The 5 second value is sufficient for the network to connect on boot

Note: sometimes I have issues with my local wireless network not connecting immediately on boot. 

The updater is not aware of network connectivity, and fails closed: if no internet connectivity is detected, the update check returns non-zero and will indicate that updates are required. Given the implications/complexity of checking for Internet connectivity (and only launch if Internet connectivity is present), I propose we merge as-is (and open a follow-up, if we think this is a useful feature)
## Checklist

### If you have made code changes

- [x] Linter (`make flake8`) passes in the development environment (this box may
      be left unchecked, as `flake8` also runs in CI)

### If you have made changes to the provisioning logic

- [x] All tests (`make test`) pass in `dom0` of a Qubes install
