### PR TITLE
Fully power off workstation after lid close

### DIFF
--- a/dom0/sd-clean-all.sls
+++ b/dom0/sd-clean-all.sls
@@ -29,9 +29,11 @@ remove-dom0-sdw-config-files:
       - /home/{{ gui_user }}/Desktop/securedrop-launcher.desktop
       - /home/{{ gui_user }}/.securedrop_launcher
 
-sd-cleanup-crontab:
+sd-cleanup-etc-changes:
   file.replace:
-    - name: /etc/crontab
+    - names:
+      - /etc/crontab
+      - /etc/systemd/logind.conf
     - pattern: '### BEGIN securedrop-workstation ###.*### END securedrop-workstation ###\s*'
     - flags:
       - MULTILINE

--- a/dom0/sd-clean-all.sls
+++ b/dom0/sd-clean-all.sls
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 
+{% import_json "sd/config.json" as d %}
+
 set-fedora-as-default-dispvm:
   cmd.run:
     - name: qvm-check fedora-30-dvm && qubes-prefs default_dispvm fedora-30-dvm || qubes-prefs default_dispvm ''
@@ -40,6 +42,12 @@ sd-cleanup-etc-changes:
       - DOTALL
     - repl: ''
     - backup: no
+
+{% if d.environment == "prod" or d.environment == "staging" %}
+apply-systemd-changes:
+  cmd.run:
+    - name: sudo systemctl restart systemd-logind
+{% endif %}
 
 sd-cleanup-sys-firewall:
   cmd.run:

--- a/dom0/sd-dom0-systemd.sls
+++ b/dom0/sd-dom0-systemd.sls
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+##
+# Updates to systemd configuration in dom0
+##
+
+{% import_json "sd/config.json" as d %}
+{% if d.environment == "prod" or d.environment == "staging" %}
+# Power off instead of suspend on lid close, for security reasons, but only in
+# prod and staging, to avoid interfering with developer workflows
+dom0-poweroff:
+  file.blockreplace:
+    - name: /etc/systemd/logind.conf
+    - append_if_not_found: True
+    - marker_start: "### BEGIN securedrop-workstation ###"
+    - marker_end: "### END securedrop-workstation ###"
+    - content: |
+        HandleLidSwitch=poweroff
+{% endif %}

--- a/dom0/sd-dom0-systemd.sls
+++ b/dom0/sd-dom0-systemd.sls
@@ -16,4 +16,8 @@ dom0-poweroff:
     - marker_end: "### END securedrop-workstation ###"
     - content: |
         HandleLidSwitch=poweroff
+
+apply-systemd-changes:
+  cmd.run:
+    - name: sudo systemctl restart systemd-logind
 {% endif %}

--- a/dom0/sd-workstation.top
+++ b/dom0/sd-workstation.top
@@ -6,6 +6,7 @@ base:
     - sd-sys-vms
     - sd-dom0-files
     - sd-dom0-crontab
+    - sd-dom0-systemd
     - sd-workstation-template
     - sd-upgrade-templates
     - sd-dom0-qvm-rpc


### PR DESCRIPTION
## Description

In production or staging environment, fully powers off the workstation instead of merely suspending to disk if the laptop lid is closed, in order to protect full-disk encryption key. 

## Status

Ready for review. Towards #178, but does not resolve as "suspend" is still an option in the logout menu.

## Test plan

Since we've not issued a new prod release yet, I suggest testing this PR by running the Salt state on its own.

### Testing production config
1. `make clone` this branch into dom0
2. Ensure you have a valid `config.json`. Run `scripts/configure-environment  --environment prod` to switch it to production. (Note: That script currently messes up JSON formatting, make sure you have a copy if you care about that.)
3. `make prep-salt` to deploy salt config in `dom0`
4. Open a new `dom0` terminal and follow the logind logs with `journalctl -f -u systemd-logind`
5. In the original terminal, deploy the salt state added in this PR with `sudo qubesctl --show-output --targets dom0 state.sls sd-dom0-systemd`
6. - [ ] Observe in the journal that `systemd-logind` was restarted
7. - [ ] Observe that `/etc/systemd/logind.conf` now contains the `HandleLidSwitch=poweroff` directive.
8. Detach any external displays.
9. - [ ] Close the laptop lid and observe that the system is ultimately powered off (this can take up to a minute or so).
10. Reboot (sorry!).

### Testing cleanup
1. Follow the logind logs again in a separate terminal.
2. In a `dom0` terminal, run `sudo qubesctl --show-output --targets dom0 state.sls sd-clean-all` to undo the changes from the previous run. (Note: This will remove other files in `dom0` and force you to re-run `make all` for a working environment.)
3. - [ ] Observe in the journal that `systemd-logind` is restarted.
4. - [ ] Observe that `/etc/systemd/logind.conf` no longer contains the line in question.
5. Close your laptop lid.
6. - [ ] Observe that the system is again suspended, if that was your previous configuration.

### Testing that change has no impact in dev env
1. Set your `config.json` to `dev` using the same method as before.
2. Re-deploy it with `make prep-salt`.
3. Re-run the salt state `sd-dom0-systemd` as before.
4. - [ ] Observe that  `/etc/systemd/logind.conf` has _not_ been modified and `systemd-logind` has _not_ been restarted.


## Checklist

- [x] Linter (`make flake8`) passes
- [ ] `make test` not re-run yet
- [x] Adds files to RPM contents implicitly through existing wildcard rules
- [ ] Does not bump RPM version