### PR TITLE
Add sanitization script for XFCE settings in prod

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ include dom0/securedrop-admin
 include dom0/securedrop-login
 include dom0/securedrop-launcher.desktop
 include dom0/securedrop-handle-upgrade
+include dom0/update-xfce-settings
 include config.json.example
 include README.md
 include LICENSE

--- a/dom0/sd-clean-all.sls
+++ b/dom0/sd-clean-all.sls
@@ -12,6 +12,21 @@ set-fedora-as-default-dispvm:
 include:
   - sd-usb-autoattach-remove
 
+# Reset desktop icon size to its original value
+dom0-reset-icon-size-xfce:
+  cmd.script:
+    - name: salt://update-xfce-settings
+    - args: reset-icon-size
+    - runas: {{ gui_user }}
+
+# Reset power management options to their original values
+{% if d.environment == "prod" or d.environment == "staging" %}
+dom0-reset-power-management-xfce:
+  cmd.script:
+    - name: salt://update-xfce-settings
+    - args: reset-power-management
+    - runas: {{ gui_user }}
+{% endif %}
 
 remove-dom0-sdw-config-files:
   file.absent:
@@ -23,6 +38,7 @@ remove-dom0-sdw-config-files:
       - /etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation-test
       - /etc/cron.daily/securedrop-update-cron
       - /srv/salt/securedrop-update
+      - /srv/salt/update-xfce-settings
       - /usr/share/securedrop/icons
       - /home/{{ gui_user }}/.config/autostart/SDWLogin.desktop
       - /usr/bin/securedrop-login

--- a/dom0/sd-dom0-files.sls
+++ b/dom0/sd-dom0-files.sls
@@ -118,6 +118,13 @@ dom0-create-opt-securedrop-directory:
 
 {% set gui_user = salt['cmd.shell']('groupmems -l -g qubes') %}
 
+# Increase the default icon size for the GUI user for usability/accessibility reasons
+dom0-adjust-desktop-icon-size-xfce:
+  cmd.script:
+    - name: salt://update-xfce-settings
+    - args: adjust-icon-size
+    - runas: {{ gui_user }}
+
 dom0-login-autostart-directory:
   file.directory:
     - name: /home/{{ gui_user }}/.config/autostart
@@ -206,4 +213,13 @@ dom0-install-securedrop-workstation-dom0-config:
     - require:
       - file: dom0-workstation-rpm-repo
 
+{% endif %}
+
+# Hide suspend/hibernate options in menus in prod systems
+{% if d.environment == "prod" or d.environment == "staging" %}
+dom0-disable-unsafe-power-management-xfce:
+  cmd.script:
+    - name: salt://update-xfce-settings
+    - args: disable-unsafe-power-management
+    - runas: {{ gui_user }}
 {% endif %}

--- a/dom0/update-xfce-settings
+++ b/dom0/update-xfce-settings
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+# A maintenance script for altering the XFCE config for the currently logged in
+# user to settings more appropriate for SecureDrop Workstation, or resetting
+# them back to default values. Typically only called by provisioning logic.
+#
+# Note that all properties are initially unset if the user has never modified
+# them, so we have to consistently use the -n flag to create them if needed.
+#
+# This script must run as the user whose preferences are changed.
+
+set -e
+set -u
+set -o pipefail
+
+TASK=${1:-none}
+ICONSIZE=64
+
+if ! [ -x "$(command -v xfconf-query)" ]; then
+  echo "Error: xfconf-query is not installed." >&2
+  exit 1
+fi
+
+# This script requires a valid DBUS session to work. When run non-interactively,
+# we assume that a sesssion is running for the current user.
+if [ -z "${DBUS_SESSION_BUS_ADDRESS:-}" ]; then
+   export DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/$(id -u)/bus"
+fi
+
+
+if [[ $TASK == "disable-unsafe-power-management" ]]; then
+  echo "update-xfce-settings: Disabling unsafe power management options for user $USER"
+
+  # Trim "Actions" menu (top right) to essentials.
+  #
+  # - Remove suspend/hibernate (unsafe with full-disk encryption)
+  # - Remove "Switch user" (single user system)
+  # - Remove "Log out" (saves sessions by default, which is not recommended)
+  # - Add "Restart" so that it remains accessible
+  #
+  # TODO: Make this more resilient by querying the plugin list first.
+  xfconf-query -c xfce4-panel -np '/plugins/plugin-2/items' \
+    -t 'string' -s '+lock-screen' \
+    -t 'string' -s '+separator' \
+    -t 'string' -s '+restart' \
+    -t 'string' -s '+shutdown'
+
+  # "Log out" is still accessible via the application menu (top left), so we
+  # remove suspend and hibernate there as well.
+  xfconf-query -c xfce4-session -np '/shutdown/ShowSuspend' -t 'bool' -s 'false'
+  xfconf-query -c xfce4-session -np '/shutdown/ShowHibernate' -t 'bool' -s 'false'
+
+elif [[ $TASK == "adjust-icon-size" ]]; then
+  echo "update-xfce-settings: Adjusting icon size for user $USER to $ICONSIZE px"
+  xfconf-query -c xfce4-desktop -np '/desktop-icons/icon-size' -t 'int' -s $ICONSIZE
+
+elif [[ $TASK == "reset-power-management" ]]; then
+  echo "update-xfce-settings: Resetting power management options for user $USER"
+
+  # Does not retain its default config, so resetting to Qubes default values
+  xfconf-query -c xfce4-panel -p '/plugins/plugin-2/items' \
+    -t 'string' -s '+lock-screen' \
+    -t 'string' -s '+switch-user' \
+    -t 'string' -s '+separator' \
+    -t 'string' -s '+suspend' \
+    -t 'string' -s '-hibernate' \
+    -t 'string' -s '-separator' \
+    -t 'string' -s '+shutdown' \
+    -t 'string' -s '-restart' \
+    -t 'string' -s '+separator' \
+    -t 'string' -s '+logout' \
+    -t 'string' -s '-logout-dialog'
+
+  xfconf-query -c xfce4-session -p '/shutdown/ShowSuspend' -r
+  xfconf-query -c xfce4-session -p '/shutdown/ShowHibernate' -r
+
+elif [[ $TASK == "reset-icon-size" ]]; then
+  echo "update-xfce-settings: Resetting icon size to default for user $USER"
+  xfconf-query -c xfce4-desktop -p '/desktop-icons/icon-size' -r
+
+else
+  echo "Syntax: update-xfce-settings [task]"
+  echo
+  echo "Task must be one of:"
+  echo
+  echo " disable-unsafe-power-management   Disable suspend and hibernation buttons"
+  echo " adjust-icon-size                  Increase the default desktop icon size"
+  echo " reset-power-management            Reset power management settings to default"
+  echo " reset-icon-size                   Reset icon size to default"
+fi

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -62,6 +62,7 @@ install -m 644 dom0/*.conf %{buildroot}/srv/salt/
 install -m 644 dom0/securedrop-login %{buildroot}/srv/salt/
 install -m 644 dom0/securedrop-launcher.desktop %{buildroot}/srv/salt/
 install -m 655 dom0/securedrop-handle-upgrade %{buildroot}/srv/salt/
+install -m 655 dom0/update-xfce-settings %{buildroot}/srv/salt/
 install -m 755 scripts/securedrop-admin.py %{buildroot}/%{_bindir}/securedrop-admin
 install -m 644 sd-app/* %{buildroot}/srv/salt/sd/sd-app/
 install -m 644 sd-proxy/* %{buildroot}/srv/salt/sd/sd-proxy/
@@ -92,6 +93,7 @@ install -m 644 launcher/sdw_util/*.py %{buildroot}/srv/salt/launcher/sdw_util/
 /srv/salt/sd*
 /srv/salt/dom0-xfce-desktop-file.j2
 /srv/salt/securedrop-*
+/srv/salt/update-xfce-settings
 /srv/salt/fpf*
 /srv/salt/launcher*
 


### PR DESCRIPTION
Ensures that the "Suspend" and "Hibernate" options are not available in the user menu (provided by the "Action Buttons" plugin in XFCE) or the logout dialog, in staging or production. Adjusts the icon size so desktop icon caption is readable.

This is done via a new `dom0` Salt script `update-xfce-settings`, so we have a single place we can update if XFCE/Qubes behavior changes. I've added it to the RPM but not bumped the RPM version.

- Resolves #473
- Resolves #413

## Status

Ready for review

## Test plan

### Testing production config

From a `make clean` state or a previously provisioned dev environment:

1. Verify that your desktop icon size is set to the default value (right-click on desktop, "Desktop Settings", "Icons" - should be set to 32px). Cancel out of the dialog.
2. Click the user menu in the top right and verify that it uses Qubes OS defaults. You should have the following options: **Lock Screen**, **Switch User**, **Suspend**,  **Shut Down**, **Log Out**. The logout dialog should give you the option to suspend or hibernate.
3. `make clone` this branch into dom0
4. Ensure you have a valid `config.json`. Run `scripts/configure-environment  --environment prod` to switch it to production. (Note: That script currently messes up JSON formatting, make sure you have a copy if you care about that.)
5. Run `make prep-dom0`.
6. - [ ] Observe that the desktop icon is now larger with readable text, and that the icon size has been increased to 64 px.
7. - [ ] Observe that the user menu now has the options  **Lock Screen**, **Restart**, **Shut down**, and that you are no longer able to suspend or hibernate form the logout menu.

### Testing cleanup
1. Run `make clean`
2. - [ ]  Observe that the desktop icon size (via settings), menu, and logout dialog have been resest to their original values.

### Testing that only the icon size is modified in development environment
1. Set your `config.json` to `dev` using the same method as before.
2. Rebuild your environment with `make all`
4. - [ ] Observe that the icon size is increased, and that the user menu and logout dialog are **not** modified from the default.

## Checklist
- [x] Contains required RPM updates (but does **not** bump RPM version yet)
- [ ] `make test` run in dom0