### PR TITLE
Fixes #15 removes our logging plugin for sd-log

### DIFF
--- a/dom0/sd-log-disable-plugin.sls
+++ b/dom0/sd-log-disable-plugin.sls
@@ -3,6 +3,9 @@
 
 ##
 # Disable securedrop-log rsyslog plugin in sd-log vm
+# Fixes https://github.com/freedomofpress/securedrop-log/issues/15
+# Due to a single Debian package for both logging and also sd-log vm
+# we need to do the following step.
 ##
 
 
@@ -13,7 +16,7 @@ sd-log-remove-rsyslog-qubes-plugin:
     - marker_start: "### BEGIN securedrop-workstation ###"
     - marker_end: "### END securedrop-workstation ###"
     - content: |
-        # Add sd-rsyslog.conf file for syslog
+        # Removes sdlog.conf file for rsyslog
         rm -f /etc/rsyslog.d/sdlog.conf
         systemctl restart rsyslog
   cmd.run:

--- a/dom0/sd-log-disable-plugin.sls
+++ b/dom0/sd-log-disable-plugin.sls
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+##
+# Disable securedrop-log rsyslog plugin in sd-log vm
+##
+
+
+sd-log-remove-rsyslog-qubes-plugin:
+  file.blockreplace:
+    - name: /rw/config/rc.local
+    - append_if_not_found: True
+    - marker_start: "### BEGIN securedrop-workstation ###"
+    - marker_end: "### END securedrop-workstation ###"
+    - content: |
+        # Add sd-rsyslog.conf file for syslog
+        rm -f /etc/rsyslog.d/sdlog.conf
+        systemctl restart rsyslog
+  cmd.run:
+    - name: rm -f /etc/rsyslog.d/sdlog.conf && systemctl restart rsyslog

--- a/dom0/sd-workstation.top
+++ b/dom0/sd-workstation.top
@@ -45,6 +45,8 @@ base:
     - sd-usb-autoattach-add
   whonix-gw-15:
     - sd-whonix-template-files
+  sd-log:
+    - sd-log-disable-plugin
 
   # "Placeholder" config to trigger TemplateVM boots,
   # so upgrades can be applied automatically via cron.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This PR removes the sdlog.conf for rsyslog via rc.local file
for the sd-log vm.

Fixes https://github.com/freedomofpress/securedrop-log/issues/15

## Testing

- [ ] `make all`
- [ ] `sd-log` vm should not have any error at `/var/log/syslog` file.
- [ ] `sd-log` vm `/rw/config/rc.local` file has the following lines:

```
# Add sd-rsyslog.conf file for syslog
rm -f /etc/rsyslog.d/sdlog.conf
systemctl restart rsyslog
```

## Checklist

### If you have made code changes

- [ ] Linter (`make flake8`) passes in the development environment (this box may
      be left unchecked, as `flake8` also runs in CI)

### If you have made changes to the provisioning logic

- [x] All tests (`make test`) pass in `dom0` of a Qubes install

- [x] This PR adds/removes files, and includes required updates to the packaging
      logic in `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`
