### PR TITLE
Fixes vmname via rc.local

### DIFF
--- a/dom0/sd-app-enable-logging.sls
+++ b/dom0/sd-app-enable-logging.sls
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+##
+# Enables securedrop-log rsyslog plugin in sd-app
+##
+
+sd-rsyslog-for-sd-app:
+  file.managed:
+    - name: /rw/config/sd-rsyslog.conf
+    - source: "salt://sd-rsyslog.conf.j2"
+    - template: jinja
+    - context:
+        vmname: sd-app
+
+
+# Because the vm should use a different name from the template.
+sd-app-enable-logging:
+  file.blockreplace:
+    - name: /rw/config/rc.local
+    - append_if_not_found: True
+    - marker_start: "### BEGIN securedrop-workstation ###"
+    - marker_end: "### END securedrop-workstation ###"
+    - content: |
+        # Add sd-rsyslog.conf file for syslog
+        rm -f /etc/sd-rsyslog.conf
+        ln -sf /rw/config/sd-rsyslog.conf /etc/sd-rsyslog.conf
+        systemctl restart rsyslog
+  cmd.run:
+    - name: rm -f /etc/sd-rsyslog.conf && ln -sf /rw/config/sd-rsyslog.conf /etc/sd-rsyslog.conf && systemctl restart rsyslog
+
+

--- a/dom0/sd-app-files.sls
+++ b/dom0/sd-app-files.sls
@@ -27,4 +27,4 @@ sd-rsyslog-for-sd-app:
     - source: "salt://sd-rsyslog.conf.j2"
     - template: jinja
     - context:
-        vmname: sd-app
+        vmname: sd-app-buster-template

--- a/dom0/sd-devices-dvm-enable-logging.sls
+++ b/dom0/sd-devices-dvm-enable-logging.sls
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+##
+# Enables securedrop-log rsyslog plugin in sd-devices
+##
+
+sd-rsyslog-for-sd-devices:
+  file.managed:
+    - name: /rw/config/sd-rsyslog.conf
+    - source: "salt://sd-rsyslog.conf.j2"
+    - template: jinja
+    - context:
+        vmname: sd-devices
+
+
+# Because the vm should use a different name from the template.
+sd-devices-enable-logging:
+  file.blockreplace:
+    - name: /rw/config/rc.local
+    - append_if_not_found: True
+    - marker_start: "### BEGIN securedrop-workstation ###"
+    - marker_end: "### END securedrop-workstation ###"
+    - content: |
+        # Add sd-rsyslog.conf file for syslog
+        rm -f /etc/sd-rsyslog.conf
+        ln -sf /rw/config/sd-rsyslog.conf /etc/sd-rsyslog.conf
+        systemctl restart rsyslog
+  cmd.run:
+    - name: rm -f /etc/sd-rsyslog.conf && ln -sf /rw/config/sd-rsyslog.conf /etc/sd-rsyslog.conf && systemctl restart rsyslog
+
+

--- a/dom0/sd-devices-files.sls
+++ b/dom0/sd-devices-files.sls
@@ -39,4 +39,4 @@ sd-rsyslog-for-sd-devices:
     - source: "salt://sd-rsyslog.conf.j2"
     - template: jinja
     - context:
-        vmname: sd-devices
+        vmname: sd-devices-buster-template

--- a/dom0/sd-proxy-enable-logging.sls
+++ b/dom0/sd-proxy-enable-logging.sls
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+##
+# Enables securedrop-log rsyslog plugin in sd-proxy
+##
+
+sd-rsyslog-for-sd-proxy:
+  file.managed:
+    - name: /rw/config/sd-rsyslog.conf
+    - source: "salt://sd-rsyslog.conf.j2"
+    - template: jinja
+    - context:
+        vmname: sd-proxy
+
+
+# Because the vm should use a different name from the template.
+sd-proxy-enable-logging:
+  file.blockreplace:
+    - name: /rw/config/rc.local
+    - append_if_not_found: True
+    - marker_start: "### BEGIN securedrop-workstation ###"
+    - marker_end: "### END securedrop-workstation ###"
+    - content: |
+        # Add sd-rsyslog.conf file for syslog
+        rm -f /etc/sd-rsyslog.conf
+        ln -sf /rw/config/sd-rsyslog.conf /etc/sd-rsyslog.conf
+        systemctl restart rsyslog
+  cmd.run:
+    - name: rm -f /etc/sd-rsyslog.conf && ln -sf /rw/config/sd-rsyslog.conf /etc/sd-rsyslog.conf && systemctl restart rsyslog
+
+

--- a/dom0/sd-proxy-template-files.sls
+++ b/dom0/sd-proxy-template-files.sls
@@ -61,10 +61,10 @@ install-securedrop-proxy-yaml-config:
         hostname: {{ d.hidserv.hostname }}
     - mode: 0644
 
-sd-rsyslog-for-sd-proxy:
+sd-rsyslog-for-sd-proxy-template:
   file.managed:
     - name: /etc/sd-rsyslog.conf
     - source: "salt://sd-rsyslog.conf.j2"
     - template: jinja
     - context:
-        vmname: sd-proxy
+        vmname: sd-proxy-buster-template

--- a/dom0/sd-viewer-enable-logging.sls
+++ b/dom0/sd-viewer-enable-logging.sls
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+##
+# Enables securedrop-log rsyslog plugin in sd-viewer
+##
+
+sd-rsyslog-for-sd-viewer:
+  file.managed:
+    - name: /rw/config/sd-rsyslog.conf
+    - source: "salt://sd-rsyslog.conf.j2"
+    - template: jinja
+    - context:
+        vmname: sd-viewer
+
+
+# Because the vm should use a different name from the template.
+sd-viewer-enable-logging:
+  file.blockreplace:
+    - name: /rw/config/rc.local
+    - append_if_not_found: True
+    - marker_start: "### BEGIN securedrop-workstation ###"
+    - marker_end: "### END securedrop-workstation ###"
+    - content: |
+        # Add sd-rsyslog.conf file for syslog
+        rm -f /etc/sd-rsyslog.conf
+        ln -sf /rw/config/sd-rsyslog.conf /etc/sd-rsyslog.conf
+        systemctl restart rsyslog
+  cmd.run:
+    - name: rm -f /etc/sd-rsyslog.conf && ln -sf /rw/config/sd-rsyslog.conf /etc/sd-rsyslog.conf && systemctl restart rsyslog
+
+

--- a/dom0/sd-viewer-files.sls
+++ b/dom0/sd-viewer-files.sls
@@ -42,4 +42,4 @@ sd-rsyslog-for-sd-viewer:
     - source: "salt://sd-rsyslog.conf.j2"
     - template: jinja
     - context:
-        vmname: sd-viewer
+        vmname: sd-viewer-buster-template

--- a/dom0/sd-workstation.top
+++ b/dom0/sd-workstation.top
@@ -30,8 +30,15 @@ base:
     - sd-proxy-template-files
   sd-app:
     - sd-app-config
+    - sd-app-enable-logging
+  sd-proxy:
+    - sd-proxy-enable-logging
   sd-viewer-buster-template:
     - sd-viewer-files
+  sd-viewer:
+    - sd-viewer-enable-logging
+  sd-devices-dvm:
+    - sd-devices-dvm-enable-logging
   sd-app-buster-template:
     - sd-app-files
   sys-firewall:


### PR DESCRIPTION
## Status

Work in progress

## Description of Changes

All VMs and templates has separate vmname for securedrop-log
via rsyslog.

Fixes #476 (partially) till now.

## Testing

- [ ] `make all`
- [ ] Check `sd-log` vm for separate logs for the app vms and template vms.
- [ ] `make test` shows no errors

## Checklist

### If you have made code changes

- [ ] Linter (`make flake8`) passes in the development environment (this box may
      be left unchecked, as `flake8` also runs in CI)

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0` of a Qubes install

- [ ] This PR adds/removes files, and includes required updates to the packaging
      logic in `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`
