### PR TITLE
Optimize Fedora Template updates

### DIFF
--- a/launcher/sdw_updater_gui/Updater.py
+++ b/launcher/sdw_updater_gui/Updater.py
@@ -433,7 +433,7 @@ def shutdown_and_start_vms():
     for vm in sys_vms_in_order:
         _safely_start_vm(vm)
 
-    vms_in_order = ["sd-proxy", "sd-whonix", "sd-app", "sd-gpg", "sd-log"]
+    vms_in_order = ["sys-whonix", "sd-proxy", "sd-whonix", "sd-app", "sd-gpg", "sd-log"]
     sdlog.info("Rebooting all vms for updates")
     for vm in vms_in_order:
         _safely_shutdown_vm(vm)

--- a/launcher/sdw_updater_gui/Updater.py
+++ b/launcher/sdw_updater_gui/Updater.py
@@ -108,27 +108,12 @@ def _check_updates_dom0():
 
 def _check_updates_fedora():
     """
-    Check for updates to the default Fedora TemplateVM
+    Check for updates to the default Fedora TemplateVM. Fedora has a very rapid
+    release cycle and there are almost always updates to fedora VMs. Let's just
+    return UPDATES_REQUIRED and always upgrade those VMs, since they no longer
+    trigger a full workstaiton reboot on upgrade.
     """
-    try:
-        subprocess.check_call(
-            ["qvm-run", current_templates["fedora"], "dnf check-update"]
-        )
-    except subprocess.CalledProcessError as e:
-        sdlog.error(
-            "Updates required for {} or cannot check for updates".format(
-                current_templates["fedora"]
-            )
-        )
-        sdlog.error(str(e))
-        return UpdateStatus.UPDATES_REQUIRED
-    finally:
-        reboot_status = _safely_shutdown_vm(current_templates["fedora"])
-        if reboot_status == UpdateStatus.UPDATES_FAILED:
-            return reboot_status
-
-    sdlog.info("{} is up to date".format(current_templates["fedora"]))
-    return UpdateStatus.UPDATES_OK
+    return UpdateStatus.UPDATES_REQUIRED
 
 
 def _check_updates_debian(vm):

--- a/launcher/sdw_updater_gui/Updater.py
+++ b/launcher/sdw_updater_gui/Updater.py
@@ -111,7 +111,7 @@ def _check_updates_fedora():
     Check for updates to the default Fedora TemplateVM. Fedora has a very rapid
     release cycle and there are almost always updates to fedora VMs. Let's just
     return UPDATES_REQUIRED and always upgrade those VMs, since they no longer
-    trigger a full workstaiton reboot on upgrade.
+    trigger a full workstation reboot on upgrade.
     """
     return UpdateStatus.UPDATES_REQUIRED
 

--- a/launcher/sdw_updater_gui/strings.py
+++ b/launcher/sdw_updater_gui/strings.py
@@ -9,7 +9,7 @@ description_status_updates_available = (
     "app, Qubes needs to download and install critical security updates.</p>"
     "<p>Updates should take around 5 to 10 minutes. The computer may need to be restarted "
     "after updates are complete.</p>"
-    "<p><b>Network access will be briefly interrupted as VMs are rebooting.</p>"
+    "<p><b>Network access will be briefly interrupted as VMs are rebooting.</b></p>"
     "<p><b>Any interruption in this process may break Workstation components.</p></b>"
     "<p>Please close this window if now is a bad time, or click <em>Start Updates</em> "
     "to continue.</p>"

--- a/launcher/sdw_updater_gui/strings.py
+++ b/launcher/sdw_updater_gui/strings.py
@@ -9,6 +9,7 @@ description_status_updates_available = (
     "app, Qubes needs to download and install critical security updates.</p>"
     "<p>Updates should take around 5 to 10 minutes. The computer may need to be restarted "
     "after updates are complete.</p>"
+    "<p><b>Network access will be briefly interrupted as VMs are rebooting.</p>"
     "<p><b>Any interruption in this process may break Workstation components.</p></b>"
     "<p>Please close this window if now is a bad time, or click <em>Start Updates</em> "
     "to continue.</p>"

--- a/launcher/tests/test_updater.py
+++ b/launcher/tests/test_updater.py
@@ -716,6 +716,7 @@ def test_shutdown_and_start_vms(
         call("sys-usb"),
     ]
     app_vm_calls = [
+        call("sys-whonix"),
         call("sd-proxy"),
         call("sd-whonix"),
         call("sd-app"),
@@ -749,6 +750,7 @@ def test_shutdown_and_start_vms_sysvm_fail(
         call("sys-usb"),
     ]
     app_vm_calls = [
+        call("sys-whonix"),
         call("sd-proxy"),
         call("sd-whonix"),
         call("sd-app"),


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Towards #459 

- fedora-30 updates no longer trigger workstation reboot: fedora-based AppVMs will be rebooted after the upgrade completes.
- Assumes that fedora-30 updates are required, given the frequency of updates to fedora-30

## Testing

- [ ] This is a meaningful optimization for end-users and will reduce the total time to use the workstation, without impacting the patch level of VMs.
- `make clone` and `make prep-dom0`
- [ ] Run the updater (delete `~/.securedrop_launcher/sdw-update-status` if required)
- [ ] Rebooting of VMs occurs without issue (`dnf downgrade zlib` in `fedora-30` to trigger updates)
- [ ] Updates complete successfully
- [ ] delete `~/.securedrop_launcher/sdw-update-status` 
- [ ] Run updater again, whonix-based vms properly update (doesn't take a long time, as sys-whonix is functional)
- [ ] Test coverage of Updater.py is 100%

## Checklist

### If you have made code changes

- [x] Linter (`make flake8`) passes in the development environment (this box may
      be left unchecked, as `flake8` also runs in CI)
