### PR TITLE
Converts sd-proxy to SDW template base

### DIFF
--- a/dom0/sd-proxy.sls
+++ b/dom0/sd-proxy.sls
@@ -17,7 +17,7 @@ sd-proxy-template:
   qvm.vm:
     - name: sd-proxy-buster-template
     - clone:
-      - source: whonix-ws-15
+      - source: securedrop-workstation-buster
       - label: blue
     - tags:
       - add:
@@ -33,7 +33,6 @@ sd-proxy:
     - prefs:
       - template: sd-proxy-buster-template
       - netvm: sd-whonix
-      - kernelopts: "nopat apparmor=1 security=apparmor"
       - autostart: true
     - tags:
       - add:

--- a/tests/test_proxy_vm.py
+++ b/tests/test_proxy_vm.py
@@ -7,7 +7,6 @@ from base import SD_VM_Local_Test
 class SD_Proxy_Tests(SD_VM_Local_Test):
     def setUp(self):
         self.vm_name = "sd-proxy"
-        self.whonix_apt_list = "/etc/apt/sources.list.d/whonix.list"
         super(SD_Proxy_Tests, self).setUp()
 
     def test_do_not_open_here(self):
@@ -32,13 +31,14 @@ class SD_Proxy_Tests(SD_VM_Local_Test):
         for line in wanted_lines:
             self.assertFileHasLine("/etc/sd-proxy.yaml", line)
 
-    def test_whonix_ws_repo_enabled(self):
+    def test_whonix_ws_repo_absent(self):
         """
-        During Whonix 14 -> 15 migration, we removed the apt list file
-        (because the repo wasn't serving, due to EOL status). Let's
-        make sure it's there, since we're past 14 now.
+        The sd-proxy VM was previously based on Whonix Workstation,
+        but we've since moved to the standard SDW Debian-based template.
+        Guard against regressions by ensuring the old Whonix apt list
+        is missing.
         """
-        assert self._fileExists(self.whonix_apt_list)
+        assert not self._fileExists("/etc/apt/sources.list.d/whonix.list")
 
     def test_logging_configured(self):
         self.logging_configured()

--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -62,8 +62,6 @@ class SD_VM_Tests(unittest.TestCase):
         vm = self.app.domains["sd-proxy"]
         nvm = vm.netvm
         self.assertTrue(nvm.name == "sd-whonix")
-        wanted_kernelopts = "nopat apparmor=1 security=apparmor"
-        self.assertEqual(vm.kernelopts, wanted_kernelopts)
         self.assertTrue(vm.template == "sd-proxy-buster-template")
         self.assertTrue(vm.autostart is True)
         self.assertFalse(vm.provides_network)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Refs #459, #456. 

Changes proposed in this pull request:

* Converts `sd-proxy` to use the `securedrop-workstation-buster` template, rather than Whonix Gateway 15
* Updates config tests to match
   
We do this in order to speed up the time it takes for updates to run (#459), as well as nudge us toward full template consolidation (#471). Since `sd-proxy` still has its NetVM set to `sd-whonix`, it's able to resolve Onion URLs just fine.

The diff is quite simple here. The proof is in the test plan. 

## Testing

N.B. We tried to make this change a while back, and abandoned it due to client sync frequency. See related comment here: https://github.com/freedomofpress/securedrop-workstation/pull/206#issuecomment-437720243 (hat tip to @emkll for digging up that gem). Given the dramatic improvements to client sync functionality since then, we should be in a fine position to move forward now. Still, the test plan includes mention of idle state to make sure. 

You'll need to apply the workaround https://github.com/freedomofpress/securedrop-workstation/issues/485#issuecomment-595244676 in order to review effectively.

### Client connectivity

- [ ] `make clone && make clean && make all && make test` passes without error
- [ ] Run the client (OK to run `securedrop-client` directly in a terminal on `sd-app`, to sidestep the preflight updater)
- [ ] Log in as usual, confirm no errors
- [ ] Interact with test source and submissions, open a few in DVMs to confirm download working
- [ ] Leave the client idle for at least 10 minutes. This is to ensure that despite the networking change, the client is able to communicate with the server over time
- [ ] Return to the client, interacting with new sources, downloading new submissions, and confirm no networking errors

### Update time
Next, let's confirm the assumption that apt updates are significantly faster. 

- [ ] Open a terminal on `sd-proxy-buster-template` and run `time { sudo apt-get update && sudo apt-get install -y firefox-esr; }`, record the time
- [ ] Open a terminal on `sd-proxy` and run `time { sudo apt-get update && sudo apt-get install -y firefox-esr; }`, record the time

There are the times I observed when testing locally:

```
# sd-proxy-buster-template (clearnet)
real	0m24.228s
user	0m7.873s
sys	0m3.150s

# sd-proxy (tor)
real	2m18.338s
user	0m9.796s
sys	0m3.799s
```

Note that you'll need to edit `dom0:/etc/qubes-rpc/policy/qubes.ClipboardPaste` if you wish to copy/paste your results here.

## Checklist

### If you have made code changes

- [ ] Linter (`make flake8`) passes in the development environment (this box may
      be left unchecked, as `flake8` also runs in CI)

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0` of a Qubes install

- [ ] This PR adds/removes files, and includes required updates to the packaging
      logic in `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`
