### PR TITLE
securedrop-admin --uninstall for staging and prod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,13 +77,7 @@ sd-log: prep-salt ## Provisions SD logging VM
 	sudo qubesctl --show-output --skip-dom0 --targets sd-log-buster-template,sd-log state.highstate
 
 clean-salt: assert-dom0 ## Purges SD Salt configuration from dom0
-	@echo "Purging Salt config..."
-	@sudo rm -rf /srv/salt/sd
-	@sudo rm -rf /srv/salt/launcher
-	@sudo find /srv/salt -maxdepth 1 -type f -iname 'fpf*' -delete
-	@sudo find /srv/salt -maxdepth 1 -type f -iname 'sd*' -delete
-	@sudo find /srv/salt -maxdepth 1 -type f -iname 'securedrop*' -delete
-	@sudo find /srv/salt/_tops -lname '/srv/salt/sd-*' -delete
+	@./scripts/clean-salt
 
 prep-salt: assert-dom0 ## Configures Salt layout for SD workstation VMs
 	@./scripts/prep-salt

--- a/dom0/sd-clean-all.sls
+++ b/dom0/sd-clean-all.sls
@@ -28,17 +28,16 @@ dom0-reset-power-management-xfce:
     - runas: {{ gui_user }}
 {% endif %}
 
+# Removes all salt-provisioned files (if these files are also provisioned via
+# RPM, they should be removed as part of remove-dom0-sdw-config-files-dev)
 remove-dom0-sdw-config-files:
   file.absent:
     - names:
-      - /opt/securedrop
       - /etc/yum.repos.d/securedrop-workstation-dom0.repo
       - /usr/bin/securedrop-update
       - /etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation
       - /etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation-test
       - /etc/cron.daily/securedrop-update-cron
-      - /srv/salt/securedrop-update
-      - /srv/salt/update-xfce-settings
       - /usr/share/securedrop/icons
       - /home/{{ gui_user }}/.config/autostart/SDWLogin.desktop
       - /usr/bin/securedrop-login
@@ -46,6 +45,17 @@ remove-dom0-sdw-config-files:
       - /etc/qubes-rpc/policy/securedrop.Proxy
       - /home/{{ gui_user }}/Desktop/securedrop-launcher.desktop
       - /home/{{ gui_user }}/.securedrop_launcher
+
+# Removes files that are provisioned by the dom0 RPM, only for the development
+# environment, since dnf takes care of those provisioned in the RPM
+{% if d.environment == "dev" %}
+remove-dom0-sdw-config-files-dev:
+  file.absent:
+    - names:
+      - /opt/securedrop
+      - /srv/salt/securedrop-update
+      - /srv/salt/update-xfce-settings
+{% endif %}
 
 sd-cleanup-etc-changes:
   file.replace:

--- a/dom0/sd-whonix-hidserv-key.sls
+++ b/dom0/sd-whonix-hidserv-key.sls
@@ -6,14 +6,20 @@
 # add hidden service auth key to torrc
 {% if d.hidserv.hostname|length == 22 %}
 sd-whonix-hidserv-key:
-  file.append:
+  file.blockreplace:
     - name: /usr/local/etc/torrc.d/50_user.conf
-    - text: HidServAuth {{ d.hidserv.hostname }} {{ d.hidserv.key }}
+    - append_if_not_found: True
+    - marker_start: "### BEGIN securedrop-workstation ###"
+    - marker_end: "### END securedrop-workstation ###"
+    - content: HidServAuth {{ d.hidserv.hostname }} {{ d.hidserv.key }}
 {% else %}
 sd-whonix-hidservv3-directory-path:
-  file.append:
+  file.blockreplace:
     - name: /usr/local/etc/torrc.d/50_user.conf
-    - text: ClientOnionAuthDir /var/lib/tor/keys
+    - append_if_not_found: True
+    - marker_start: "### BEGIN securedrop-workstation ###"
+    - marker_end: "### END securedrop-workstation ###"
+    - content: ClientOnionAuthDir /var/lib/tor/keys
 
 {% set hostname_without_onion = d.hidserv.hostname.split('.')[0] %}
 install-sd-whonix-tor-private-key:

--- a/scripts/clean-salt
+++ b/scripts/clean-salt
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Utility script to clean Saltstack config
+# files for the SecureDrop Workstation.
+set -e
+set -u
+set -o pipefail
+
+
+# Hardcoded location of SecureDrop Workstation salt config files
+SDW_SALT_DIR="/srv/salt/sd"
+SALT_DIR="/srv/salt"
+
+echo "Purging Salt config..."
+
+# If SDW Salt config dir already exists, delete all SecureDrop Workstation
+# related Salt files. In production scenarios, most of these will be provisioned
+# by the RPM package, but the top files and configs will not, so we should use a
+# common script to ensure all config is removed.
+
+if [[ ! -d "$SDW_SALT_DIR" ]]; then
+    sudo rm -rf ${SDW_SALT_DIR}
+    sudo rm -rf ${SALT_DIR}/launcher
+    sudo find ${SALT_DIR} -maxdepth 1 -type f -iname 'fpf*' -delete
+    sudo find ${SALT_DIR} -maxdepth 1 -type f -iname 'sd*' -delete
+    sudo find ${SALT_DIR} -maxdepth 1 -type f -iname 'securedrop*' -delete
+    sudo find ${SALT_DIR}/_tops -lname '/srv/salt/sd-*' -delete
+fi

--- a/scripts/securedrop-admin.py
+++ b/scripts/securedrop-admin.py
@@ -96,7 +96,12 @@ def perform_uninstall():
             ]
         )
         print("Reverting dom0 configuration")
-
+        subprocess.check_call(
+            ["sudo", "rm", "/srv/salt/sd/sd-journalist.sec"]
+        )
+        subprocess.check_call(
+            ["sudo", "rm", "/srv/salt/sd/config.json"]
+        )
         subprocess.check_call(
             ["sudo", "qubesctl", "state.sls", "sd-clean-all"]
         )
@@ -114,7 +119,6 @@ def perform_uninstall():
     print(
         "Instance secrets (Journalist Interface token and Submission private key) are still"
         "present on disk. You can delete them in /usr/share/securedrop-workstation-dom0-config"
-        "/srv/salt/sd/"
     )
 
 

--- a/scripts/securedrop-admin.py
+++ b/scripts/securedrop-admin.py
@@ -97,13 +97,10 @@ def perform_uninstall():
         )
         print("Reverting dom0 configuration")
         subprocess.check_call(
-            ["sudo", "rm", "/srv/salt/sd/sd-journalist.sec"]
-        )
-        subprocess.check_call(
-            ["sudo", "rm", "/srv/salt/sd/config.json"]
-        )
-        subprocess.check_call(
             ["sudo", "qubesctl", "state.sls", "sd-clean-all"]
+        )
+        subprocess.check_call(
+            [os.path.join(SCRIPTS_PATH, "scripts/clean-salt")]
         )
         print("Uninstalling Template")
         subprocess.check_call(

--- a/scripts/securedrop-admin.py
+++ b/scripts/securedrop-admin.py
@@ -32,6 +32,13 @@ def parse_args():
         action="store_true",
         help="Validate the configuration",
     )
+    parser.add_argument(
+        "--uninstall",
+        default=False,
+        required=False,
+        action="store_true",
+        help="Completely Uninstalls the SecureDrop Workstation",
+    )
     args = parser.parse_args()
 
     return args
@@ -72,6 +79,45 @@ def validate_config(path):
         raise SDAdminException("Error while validating configuration")
 
 
+def perform_uninstall():
+
+    try:
+        subprocess.check_call(
+            ["sudo", "qubesctl", "state.sls", "sd-clean-default-dispvm"]
+        )
+        print("Destroying all VMs")
+        subprocess.check_call(
+            [os.path.join(SCRIPTS_PATH, "scripts/destroy-vm"), "--all"]
+        )
+        subprocess.check_call(
+            [
+                "sudo", "qubesctl", "--skip-dom0", "--targets",
+                "whonix-gw-15", "state.sls", "sd-clean-whonix"
+            ]
+        )
+        print("Reverting dom0 configuration")
+
+        subprocess.check_call(
+            ["sudo", "qubesctl", "state.sls", "sd-clean-all"]
+        )
+        print("Uninstalling Template")
+        subprocess.check_call(
+            ["sudo", "dnf", "-y", "-q", "remove", "qubes-template-securedrop-workstation-buster"]
+        )
+        print("Uninstalling dom0 config package")
+        subprocess.check_call(
+            ["sudo", "dnf", "-y", "-q", "remove", "securedrop-workstation-dom0-config"]
+        )
+    except subprocess.CalledProcessError:
+        raise SDAdminException("Error during uninstall")
+
+    print(
+        "Instance secrets (Journalist Interface token and Submission private key) are still"
+        "present on disk. You can delete them in /usr/share/securedrop-workstation-dom0-config"
+        "/srv/salt/sd/"
+    )
+
+
 def main():
     args = parse_args()
     if args.validate:
@@ -82,6 +128,16 @@ def main():
         validate_config(SCRIPTS_PATH)
         copy_config()
         provision_all()
+    elif args.uninstall:
+        print(
+            "Uninstalling SecureDrop workstation will uninstall all packages and destroy all VMs"
+        )
+        response = input("Are you sure you would want to uninstall (y/N)? ")
+        if response.lower() != 'y':
+            print("Exiting.")
+            sys.exit(0)
+        else:
+            perform_uninstall()
     else:
         sys.exit(0)
 

--- a/tests/test_sd_whonix.py
+++ b/tests/test_sd_whonix.py
@@ -64,6 +64,17 @@ class SD_Whonix_Tests(SD_VM_Local_Test):
     def test_sd_whonix_verify_tor_config(self):
         self._run("tor --verify-config")
 
+    def test_whonix_torrc(self):
+        """
+        Ensure Whonix-maintained torrc files don't contain duplicate entries.
+        """
+        torrc_contents = self._get_file_contents("/etc/tor/torrc")
+        duplicate_includes = """%include /etc/torrc.d/
+%include /etc/torrc.d/95_whonix.conf"""
+        self.assertFalse(duplicate_includes in torrc_contents,
+                         "Whonix GW torrc contains duplicate %include lines")
+
+
 def load_tests(loader, tests, pattern):
     suite = unittest.TestLoader().loadTestsFromTestCase(SD_Whonix_Tests)
     return suite

--- a/tests/test_sd_whonix.py
+++ b/tests/test_sd_whonix.py
@@ -61,6 +61,8 @@ class SD_Whonix_Tests(SD_VM_Local_Test):
     def test_logging_configured(self):
         self.logging_configured()
 
+    def test_sd_whonix_verify_tor_config(self):
+        self._run("tor --verify-config")
 
 def load_tests(loader, tests, pattern):
     suite = unittest.TestLoader().loadTestsFromTestCase(SD_Whonix_Tests)


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #483

## Testing

### Dev environment
- [x] `make all` and `make clean` completes without error
### Staging (or prod) environment
- Build dom0 rpm on this branch
- [ ] dom0 rpm installs correctly
- [ ] Configure the instance (config.json and sd-journalist.sec) and run `securedrop-admin --apply`
- [ ] `securedrop-admin --uninstall` completes without error
- [ ] Files are absent from `/srv/salt` and dom0 packages are uninstalled

## Checklist

### If you have made code changes

- [x] Linter (`make flake8`) passes in the development environment (this box may
      be left unchecked, as `flake8` also runs in CI)