### PR TITLE
Update mimetype handling and --view-only for open-in-dvm

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -59,8 +59,11 @@ class SD_VM_Local_Test(unittest.TestCase):
 
         self.vm.start()
 
-    def _run(self, cmd):
-        full_cmd = ["qvm-run", "-p", self.vm_name, cmd]
+    def _run(self, cmd, user=""):
+        full_cmd = ["qvm-run", "-p"]
+        if user:
+            full_cmd += ["-u", user]
+        full_cmd += [self.vm_name, cmd]
         contents = subprocess.check_output(full_cmd).decode("utf-8").strip()
         return contents
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -26,7 +26,7 @@ class SD_App_Tests(SD_VM_Local_Test):
     def test_mimeapps(self):
         cmd = "perl -F= -lane 'print $F[1]' /usr/share/applications/mimeapps.list | sort | uniq -c"
         results = self._run(cmd)
-        expected_results = "2 \n    294 open-in-dvm.desktop;"
+        expected_results = "2 \n    295 open-in-dvm.desktop;"
         self.assertEqual(results, expected_results)
 
     def test_mimeapps_functional(self):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -20,8 +20,12 @@ class SD_App_Tests(SD_VM_Local_Test):
         contents = self._get_file_contents(
             "/usr/share/applications/open-in-dvm.desktop"
         )
-        expected_content = "TryExec=/usr/bin/qvm-open-in-vm"
-        self.assertTrue(expected_content in contents)
+        expected_contents = [
+            "TryExec=/usr/bin/qvm-open-in-vm",
+            "Exec=/usr/bin/qvm-open-in-vm --view-only '@dispvm:sd-viewer' %f"
+        ]
+        for line in expected_contents:
+            self.assertTrue(line in contents)
 
     def test_mimeapps(self):
         cmd = "perl -F= -lane 'print $F[1]' /usr/share/applications/mimeapps.list | sort | uniq -c"

--- a/tests/test_sd_devices.py
+++ b/tests/test_sd_devices.py
@@ -35,6 +35,17 @@ class SD_Devices_Tests(SD_VM_Local_Test):
                     actual_app = self._run("xdg-mime query default {}".format(mime_type))
                     self.assertEqual(actual_app, expected_app)
 
+    def test_open_in_dvm_desktop(self):
+        contents = self._get_file_contents(
+            "/usr/share/applications/open-in-dvm.desktop"
+        )
+        expected_contents = [
+            "TryExec=/usr/bin/qvm-open-in-vm",
+            "Exec=/usr/bin/qvm-open-in-vm --view-only '@dispvm:sd-viewer' %f"
+        ]
+        for line in expected_contents:
+            self.assertTrue(line in contents)
+
 
 def load_tests(loader, tests, pattern):
     suite = unittest.TestLoader().loadTestsFromTestCase(SD_Devices_Tests)

--- a/tests/test_sd_whonix.py
+++ b/tests/test_sd_whonix.py
@@ -62,7 +62,9 @@ class SD_Whonix_Tests(SD_VM_Local_Test):
         self.logging_configured(vmname=True)
 
     def test_sd_whonix_verify_tor_config(self):
-        self._run("tor --verify-config")
+        # User must be debian-tor for v3 Onion, due to restrictive
+        # mode on the client keys directory.
+        self._run("tor --verify-config", user="debian-tor")
 
     def test_whonix_torrc(self):
         """

--- a/tests/vars/sd-devices.mimeapps
+++ b/tests/vars/sd-devices.mimeapps
@@ -5,6 +5,7 @@ text/x-vcard=open-in-dvm.desktop;
 text/directory=open-in-dvm.desktop;
 text/calendar=open-in-dvm.desktop;
 application/x-cd-image=open-in-dvm.desktop;
+application/x-desktop=open-in-dvm.desktop;
 application/x-raw-disk-image=open-in-dvm.desktop;
 application/x-raw-disk-image-xz-compressed=open-in-dvm.desktop;
 image/x-compressed-xcf=open-in-dvm.desktop;

--- a/tests/vars/sd-viewer.mimeapps
+++ b/tests/vars/sd-viewer.mimeapps
@@ -11,6 +11,7 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document=libreoff
 application/vnd.openxmlformats-officedocument.spreadsheetml.sheet=libreoffice-base.desktop
 application/vnd.openxmlformats-officedocument.presentationml.presentation=libreoffice-base.desktop
 application/pdf=org.gnome.Evince.desktop
+application/x-desktop=org.gnome.gedit.desktop
 audio/mpeg=audacious.desktop
 audio/x-vorbis+ogg=audacious.desktop
 audio/x-wav=audacious.desktop


### PR DESCRIPTION
## Status

Ready for review 

:exclamation: Temporary commit will need to be removed prior to merge :exclamation: 
This is due to the use of https://github.com/freedomofpress/securedrop-workstation/wiki/Evaluating-new-deb-package-behavior for reviewer convenience

The reviewer of this PR should also review and merge the following PRs before merging this one:

- [x] https://github.com/freedomofpress/securedrop-debian-packaging/pull/155
- [x] https://github.com/freedomofpress/securedrop-client/pull/972
- [x] https://github.com/freedomofpress/securedrop-export/pull/60

## Description of Changes

Fixes https://github.com/freedomofpress/securedrop-client/issues/960
Fixes https://github.com/freedomofpress/securedrop-client/issues/961


## Testing
In a dev VM:
- Visually review diffs in the 3 PRs above
- Build securedrop-client, securedrop-export and securedrop-workstation-svs-disp on the branches onf the PRs in the section above
-  copy built debs in `sd-workstation` folder

In dom0:
- `make clone` and move `config.json` and `sd-journalist.sec` in place, if necessary
- [ ]  `make all` completes without issue
- [ ] `make test` all tests pass (except update tests for sd-app, due to 0.1.3 < 0.1.3 nightly series)

In Tor browser
- submit a desktop file to source interface (debian-xterm.desktop works well since it's installed in most places)

In sd-app
- [ ] Client opens desktop file in dvm (and in gedit)
- [ ] `xdg-open` that file on disk manually (from /home/user/.securedrop-client/data/...) opens in a dvm
- Modify rules to permit Qubes.Filecopy from sd-app to sd-devices, and copy desktop file to sd-devices
- [ ] `xdg-open` that file on disk manually (from ~/QubesIncoming/sd-app/...) opens in a dvm (I recommend you use a plaintext file for convenience for next step)
- [ ] In the DispVM, the file is opened in read-only mode
- [ ] manually editing the file in `/tmp/sd-app...` and then closing the application does *not* modify the file in sd-app
## Checklist

### If you have made code changes

### If you have made changes to the provisioning logic

- [x] All tests (`make test`) pass in `dom0` of a Qubes install
