### PR TITLE
Fix/tweak strings in securedrop-admin

### DIFF
--- a/scripts/securedrop-admin.py
+++ b/scripts/securedrop-admin.py
@@ -114,7 +114,7 @@ def perform_uninstall():
         raise SDAdminException("Error during uninstall")
 
     print(
-        "Instance secrets (Journalist Interface token and Submission private key) are still"
+        "Instance secrets (Journalist Interface token and Submission private key) are still "
         "present on disk. You can delete them in /usr/share/securedrop-workstation-dom0-config"
     )
 
@@ -131,9 +131,10 @@ def main():
         provision_all()
     elif args.uninstall:
         print(
-            "Uninstalling SecureDrop workstation will uninstall all packages and destroy all VMs"
+            "Uninstalling will remove all packages and destroy all VMs associated\n"
+            "with SecureDrop Workstation."
         )
-        response = input("Are you sure you would want to uninstall (y/N)? ")
+        response = input("Are you sure you want to uninstall (y/N)? ")
         if response.lower() != 'y':
             print("Exiting.")
             sys.exit(0)


### PR DESCRIPTION
- Add missing whitespace
- Make it clearer that uninstall refers to the SecureDrop Workstation,
  not to Qubes as a whole ("destroy all VMs" language was pretty scary)

## Status

Ready for review

## Checklist

### If you have made code changes

- [x] Linter (`make flake8`) passes in the development environment (this box may
      be left unchecked, as `flake8` also runs in CI)
