### PR TITLE
Adds gnome-disks to sd-devices tests

### DIFF
--- a/tests/test_sd_devices.py
+++ b/tests/test_sd_devices.py
@@ -19,6 +19,7 @@ class SD_Devices_Tests(SD_VM_Local_Test):
         self.assertTrue(self._package_is_installed("cryptsetup"))
         self.assertTrue(self._package_is_installed("printer-driver-brlaser"))
         self.assertTrue(self._package_is_installed("securedrop-export"))
+        self.assertTrue(self._package_is_installed("gnome-disk-utility"))
 
     def test_logging_configured(self):
         self.logging_configured()


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #511. This PR is mostly to help with review and testing of 
https://github.com/freedomofpress/securedrop-export/pull/63 and https://github.com/freedomofpress/securedrop-debian-packaging/pull/158

Changes proposed in this pull request:
Adds gnome-disks to sd-devices VMs
## Testing
- Check out this branch of securedrop-workstation
- Check out branches in https://github.com/freedomofpress/securedrop-export/pull/63 and https://github.com/freedomofpress/securedrop-debian-packaging/pull/158
- Build securedrop-export 0.2.3 using those branches
- Copy securedrop-export 0.2.3 to `sd-workstation` folder of this repo
- Run `make clone`
- [ ] `make all` is successful
- [ ] `make test` has all tests passing (specifically `test_sd_export_package_installed`)
- [ ] Running `gnome-disks` inside `sd-devices` opens the gnome disk utility
## Merging

The following tasks should all be done in one pass, after all 3 PRs have been reviewed/approved:
- [ ] Drop the temporary commit
- [ ] Merge https://github.com/freedomofpress/securedrop-export/pull/63
- [ ] Create 0.2.3 tag in `securedrop-export`
- [ ] Re-run CI on https://github.com/freedomofpress/securedrop-debian-packaging/pull/158
- [ ] Merge https://github.com/freedomofpress/securedrop-debian-packaging/pull/158
- [ ] Merge this PR
## Checklist

### If you have made code changes

- [x] Linter (`make flake8`) passes in the development environment (this box may
      be left unchecked, as `flake8` also runs in CI)

### If you have made changes to the provisioning logic

- [x] All tests (`make test`) pass in `dom0` of a Qubes install
