### PR TITLE
Ensure TemplateVMs are shut down prior to rebooting

### DIFF
--- a/launcher/sdw_updater_gui/Updater.py
+++ b/launcher/sdw_updater_gui/Updater.py
@@ -407,13 +407,21 @@ def shutdown_and_start_vms():
     """
 
     sdw_vms_in_order = [
-        "sys-whonix",
-        "sd-proxy",
-        "sd-whonix",
         "sd-app",
+        "sd-proxy",
+        "sys-whonix",
+        "sd-whonix",
         "sd-gpg",
         "sd-log",
     ]
+
+    # All TemplateVMs minus dom0
+    sdw_templates = [val for key, val in current_templates.items() if key != "dom0"]
+
+    sdlog.info("Ensure TemplateVMs are shut down")
+    for vm in sdw_templates:
+        _safely_shutdown_vm(vm)
+
     sdlog.info("Shutting down SDW VMs for updates")
     for vm in sdw_vms_in_order:
         _safely_shutdown_vm(vm)

--- a/launcher/tests/test_updater.py
+++ b/launcher/tests/test_updater.py
@@ -653,17 +653,27 @@ def test_shutdown_and_start_vms(
         call("sys-net"),
         call("sys-firewall"),
     ]
+    template_vm_calls = [
+        call("fedora-30"),
+        call("sd-viewer-buster-template"),
+        call("sd-app-buster-template"),
+        call("sd-log-buster-template"),
+        call("sd-devices-buster-template"),
+        call("sd-proxy-buster-template"),
+        call("whonix-gw-15"),
+        call("securedrop-workstation-buster"),
+    ]
     app_vm_calls = [
-        call("sys-whonix"),
-        call("sd-proxy"),
-        call("sd-whonix"),
         call("sd-app"),
+        call("sd-proxy"),
+        call("sys-whonix"),
+        call("sd-whonix"),
         call("sd-gpg"),
         call("sd-log"),
     ]
     updater.shutdown_and_start_vms()
     mocked_call.assert_has_calls(sys_vm_kill_calls)
-    mocked_shutdown.assert_has_calls(app_vm_calls)
+    mocked_shutdown.assert_has_calls(template_vm_calls + app_vm_calls)
     app_vm_calls_reversed = list(reversed(app_vm_calls))
     mocked_start.assert_has_calls(sys_vm_start_calls + app_vm_calls_reversed)
     assert not mocked_error.called
@@ -690,12 +700,22 @@ def test_shutdown_and_start_vms_sysvm_fail(
         call("sys-firewall"),
     ]
     app_vm_calls = [
-        call("sys-whonix"),
-        call("sd-proxy"),
-        call("sd-whonix"),
         call("sd-app"),
+        call("sd-proxy"),
+        call("sys-whonix"),
+        call("sd-whonix"),
         call("sd-gpg"),
         call("sd-log"),
+    ]
+    template_vm_calls = [
+        call("fedora-30"),
+        call("sd-viewer-buster-template"),
+        call("sd-app-buster-template"),
+        call("sd-log-buster-template"),
+        call("sd-devices-buster-template"),
+        call("sd-proxy-buster-template"),
+        call("whonix-gw-15"),
+        call("securedrop-workstation-buster"),
     ]
     error_calls = [
         call("Error while killing sys-firewall"),
@@ -707,7 +727,7 @@ def test_shutdown_and_start_vms_sysvm_fail(
     ]
     updater.shutdown_and_start_vms()
     mocked_call.assert_has_calls(sys_vm_kill_calls)
-    mocked_shutdown.assert_has_calls(app_vm_calls)
+    mocked_shutdown.assert_has_calls(template_vm_calls + app_vm_calls)
     app_vm_calls_reversed = list(reversed(app_vm_calls))
     mocked_start.assert_has_calls(sys_vm_start_calls + app_vm_calls_reversed)
     mocked_error.assert_has_calls(error_calls)


### PR DESCRIPTION
## Status

Ready for Review

## Description of Changes

Maybe fixes #498.

Should they call `sd-log` during shutdown sequence or otherwise, they may interfere with the reboot order and introduce failures. ALso move `sd-app` to beginning of shutdown sequence.

Since `sd-log` receives qubes-rpc calls from pretty much every AppVM and TemplateVM we provision. If that's the case, changed we've introduced in #487 could explain why we have been seeing this error more often, but also why it has been inconsistent across our installs: we do not control the state (powered on/off) of TemplateVMs. Should a template send logs to `sd-log` and triggering an out-of-order reboot. It would make sense to ensure any VM that logs to be shut down prior to sd-log, and start sd-log before all other VMs.

## Testing
