### PR TITLE
Logs more VM state info in updater

### DIFF
--- a/launcher/sdw_updater_gui/Updater.py
+++ b/launcher/sdw_updater_gui/Updater.py
@@ -430,10 +430,11 @@ def shutdown_and_start_vms():
     sdlog.info("Killing system fedora-based VMs for updates")
     for vm in sys_vms_in_order:
         try:
-            subprocess.check_call(["qvm-kill", vm])
+            subprocess.check_output(["qvm-kill", vm], stderr=subprocess.PIPE)
         except subprocess.CalledProcessError as e:
             sdlog.error("Error while killing {}".format(vm))
             sdlog.error(str(e))
+            sdlog.error(str(e.stderr))
 
     sdlog.info("Starting system fedora-based VMs after updates")
     for vm in reversed(sys_vms_in_order):
@@ -446,19 +447,23 @@ def shutdown_and_start_vms():
 
 def _safely_shutdown_vm(vm):
     try:
-        subprocess.check_call(["qvm-shutdown", "--wait", vm])
+        subprocess.check_output(["qvm-shutdown", "--wait", vm], stderr=subprocess.PIPE)
     except subprocess.CalledProcessError as e:
         sdlog.error("Failed to shut down {}".format(vm))
         sdlog.error(str(e))
+        sdlog.error(str(e.stderr))
         return UpdateStatus.UPDATES_FAILED
 
 
 def _safely_start_vm(vm):
     try:
-        subprocess.check_call(["qvm-start", "--skip-if-running", vm])
+        subprocess.check_output(
+            ["qvm-start", "--skip-if-running", vm], stderr=subprocess.PIPE
+        )
     except subprocess.CalledProcessError as e:
         sdlog.error("Error while starting {}".format(vm))
         sdlog.error(str(e))
+        sdlog.error(str(e.stderr))
 
 
 def should_launch_updater(interval):

--- a/launcher/sdw_updater_gui/Updater.py
+++ b/launcher/sdw_updater_gui/Updater.py
@@ -457,6 +457,10 @@ def _safely_shutdown_vm(vm):
 
 def _safely_start_vm(vm):
     try:
+        running_vms = subprocess.check_output(
+            ["qvm-ls", "--running", "--raw-list"], stderr=subprocess.PIPE
+        )
+        sdlog.info("VMs running before start of {}: {}".format(vm, running_vms))
         subprocess.check_output(
             ["qvm-start", "--skip-if-running", vm], stderr=subprocess.PIPE
         )


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #521. Refs #498 

Changes proposed in this pull request:

* graphical updater now logs running vms before issuing `qvm-start` commands
* graphical updater also logs stderr on failed `qvm-*` commands, although not quite as useful as we might hope, see https://github.com/freedomofpress/securedrop-workstation/issues/521#issuecomment-607577063

For comparison:

**Before:**
```
2020-03-27 13:01:30,410 - sdw_updater_gui.Updater:386(apply_dom0_state) INFO: Applying dom0 state
2020-03-27 13:01:30,415 - sdw_updater_gui.UpdaterApp:173(update_progress_bar) INFO: Signal: Progress 95%
2020-03-27 13:02:12,054 - sdw_updater_gui.Updater:389(apply_dom0_state) INFO: Dom0 state applied
2020-03-27 13:02:12,054 - sdw_updater_gui.Updater:410(shutdown_and_start_vms) INFO: Rebooting system fedora-based VMs
2020-03-27 13:04:00,453 - sdw_updater_gui.Updater:443(_safely_start_vm) ERROR: Error while starting sys-usb
2020-03-27 13:04:00,453 - sdw_updater_gui.Updater:444(_safely_start_vm) ERROR: Command '['qvm-start', '--skip-if-running', 'sys-usb']' returned non-zero exit status 1
2020-03-27 13:04:00,453 - sdw_updater_gui.Updater:422(shutdown_and_start_vms) INFO: Rebooting all vms for updates
2020-03-27 13:04:55,884 - sdw_updater_gui.Updater:443(_safely_start_vm) ERROR: Error while starting sd-proxy
2020-03-27 13:04:55,885 - sdw_updater_gui.Updater:444(_safely_start_vm) ERROR: Command '['qvm-start', '--skip-if-running', 'sd-proxy']' returned non-zero exit status 1
2020-03-27 13:06:05,919 - sdw_updater_gui.Updater:248(_write_updates_status_flag_to_disk) INFO: Setting update flag to 0 in sd-app
2020-03-27 13:06:06,447 - sdw_updater_gui.Updater:261(_write_updates_status_flag_to_disk) INFO: Setting update flag to 0 in dom0
2020-03-27 13:06:06,448 - sdw_updater_gui.Updater:216(_write_last_updated_flags_to_disk) INFO: Setting last updated to 2020-03-27 13:06:06 in sd-app
2020-03-27 13:06:06,727 - sdw_updater_gui.Updater:229(_write_last_updated_flags_to_disk) INFO: Setting last updated to 2020-03-27 13:06:06 in dom0
```

**After:**
```
2020-04-01 18:50:34,916 - sdw_updater_gui.Updater:386(apply_dom0_state) INFO: Applying dom0 state
2020-04-01 18:50:34,916 - sdw_updater_gui.UpdaterApp:173(update_progress_bar) INFO: Signal: Progress 95%
2020-04-01 18:51:16,796 - sdw_updater_gui.Updater:389(apply_dom0_state) INFO: Dom0 state applied
2020-04-01 18:51:16,796 - sdw_updater_gui.Updater:417(shutdown_and_start_vms) INFO: Shutting down SDW VMs for updates
2020-04-01 18:51:16,964 - sdw_updater_gui.Updater:444(_safely_shutdown_vm) ERROR: Failed to shut down sys-whonix
2020-04-01 18:51:16,965 - sdw_updater_gui.Updater:445(_safely_shutdown_vm) ERROR: Command '['qvm-shutdown', '--wait', 'sys-whonix']' returned non-zero exit status 1
2020-04-01 18:51:16,965 - sdw_updater_gui.Updater:446(_safely_shutdown_vm) ERROR: b'qvm-shutdown: error: Failed to shut down: sys-whonix\n'
2020-04-01 18:51:42,329 - sdw_updater_gui.Updater:422(shutdown_and_start_vms) INFO: Killing system fedora-based VMs for updates
2020-04-01 18:51:53,442 - sdw_updater_gui.Updater:431(shutdown_and_start_vms) INFO: Starting system fedora-based VMs after updates
2020-04-01 18:51:53,730 - sdw_updater_gui.Updater:455(_safely_start_vm) INFO: VMs running before start of sys-usb: b'anon-whonix\ndom0\nfpf-email\nfpf-infra\nfpf-signal\nfpf-vault\nfpf-vidchat\nfpf-vpn\nfpf-web\nsd-dev\nsd-devices\nsys-firewall-inner\nsys-whonix\n'
2020-04-01 18:52:08,822 - sdw_updater_gui.Updater:455(_safely_start_vm) INFO: VMs running before start of sys-net: b'anon-whonix\ndom0\nfpf-email\nfpf-infra\nfpf-signal\nfpf-vault\nfpf-vidchat\nfpf-vpn\nfpf-web\nsd-dev\nsd-devices\nsys-firewall-inner\nsys-usb\nsys-whonix\n'
2020-04-01 18:52:27,316 - sdw_updater_gui.Updater:455(_safely_start_vm) INFO: VMs running before start of sys-firewall: b'anon-whonix\ndom0\nfpf-email\nfpf-infra\nfpf-signal\nfpf-vault\nfpf-vidchat\nfpf-vpn\nfpf-web\nsd-dev\nsd-devices\nsys-firewall-inner\nsys-net\nsys-usb\nsys-whonix\n'
2020-04-01 18:52:37,586 - sdw_updater_gui.Updater:435(shutdown_and_start_vms) INFO: Starting SDW VMs after updates
2020-04-01 18:52:38,072 - sdw_updater_gui.Updater:455(_safely_start_vm) INFO: VMs running before start of sd-log: b'anon-whonix\ndom0\nfpf-email\nfpf-infra\nfpf-signal\nfpf-vault\nfpf-vidchat\nfpf-vpn\nfpf-web\nsd-dev\nsd-devices\nsys-firewall\nsys-firewall-inner\nsys-net\nsys-usb\nsys-whonix\n'
2020-04-01 18:53:07,760 - sdw_updater_gui.Updater:455(_safely_start_vm) INFO: VMs running before start of sd-gpg: b'anon-whonix\ndom0\nfpf-email\nfpf-infra\nfpf-signal\nfpf-vault\nfpf-vidchat\nfpf-vpn\nfpf-web\nsd-dev\nsd-devices\nsd-log\nsys-firewall\nsys-firewall-inner\nsys-net\nsys-usb\nsys-whonix\n'
2020-04-01 18:53:35,512 - sdw_updater_gui.Updater:455(_safely_start_vm) INFO: VMs running before start of sd-app: b'anon-whonix\ndom0\nfpf-email\nfpf-infra\nfpf-signal\nfpf-vault\nfpf-vidchat\nfpf-vpn\nfpf-web\nsd-dev\nsd-devices\nsd-gpg\nsd-log\nsys-firewall\nsys-firewall-inner\nsys-net\nsys-usb\nsys-whonix\n'
2020-04-01 18:54:03,973 - sdw_updater_gui.Updater:455(_safely_start_vm) INFO: VMs running before start of sd-whonix: b'anon-whonix\ndom0\nfpf-email\nfpf-infra\nfpf-signal\nfpf-vault\nfpf-vidchat\nfpf-vpn\nfpf-web\nsd-app\nsd-dev\nsd-devices\nsd-gpg\nsd-log\nsys-firewall\nsys-firewall-inner\nsys-net\nsys-usb\nsys-whonix\n'
2020-04-01 18:54:14,158 - sdw_updater_gui.Updater:455(_safely_start_vm) INFO: VMs running before start of sd-proxy: b'anon-whonix\ndom0\nfpf-email\nfpf-infra\nfpf-signal\nfpf-vault\nfpf-vidchat\nfpf-vpn\nfpf-web\nsd-app\nsd-dev\nsd-devices\nsd-gpg\nsd-log\nsd-whonix\nsys-firewall\nsys-firewall-inner\nsys-net\nsys-usb\nsys-whonix\n'
2020-04-01 18:54:43,306 - sdw_updater_gui.Updater:455(_safely_start_vm) INFO: VMs running before start of sys-whonix: b'anon-whonix\ndom0\nfpf-email\nfpf-infra\nfpf-signal\nfpf-vault\nfpf-vidchat\nfpf-vpn\nfpf-web\nsd-app\nsd-dev\nsd-devices\nsd-gpg\nsd-log\nsd-proxy\nsd-whonix\nsys-firewall\nsys-firewall-inner\nsys-net\nsys-usb\nsys-whonix\n'
2020-04-01 18:54:43,466 - sdw_updater_gui.Updater:248(_write_updates_status_flag_to_disk) INFO: Setting update flag to 0 in sd-app
2020-04-01 18:54:43,724 - sdw_updater_gui.Updater:261(_write_updates_status_flag_to_disk) INFO: Setting update flag to 0 in dom0
2020-04-01 18:54:43,725 - sdw_updater_gui.Updater:216(_write_last_updated_flags_to_disk) INFO: Setting last updated to 2020-04-01 18:54:43 in sd-app
2020-04-01 18:54:43,938 - sdw_updater_gui.Updater:229(_write_last_updated_flags_to_disk) INFO: Setting last updated to 2020-04-01 18:54:43 in dom0
```

## Testing
```
make clone
make prep-dom0
tail -f ~/.securedrop_client/logs/launcher.log
# then, in separate terminal:
/opt/securedrop/launcher/sdw-launcher.py --skip-delta 0
```

Confirm you see the more verbose logs, particularly the list of all running VMs.

## Checklist

### If you have made code changes

- [ ] Linter (`make flake8`) passes in the development environment (this box may
      be left unchecked, as `flake8` also runs in CI)

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0` of a Qubes install

- [ ] This PR adds/removes files, and includes required updates to the packaging
      logic in `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`
