### PR TITLE
Safely shut down sys-usb; tweak logging

### DIFF
--- a/launcher/tests/test_updater.py
+++ b/launcher/tests/test_updater.py
@@ -676,12 +676,16 @@ def test_shutdown_and_start_vms(
     sys_vm_kill_calls = [
         call(["qvm-kill", "sys-firewall"], stderr=-1),
         call(["qvm-kill", "sys-net"], stderr=-1),
-        call(["qvm-kill", "sys-usb"], stderr=-1),
+    ]
+    sys_vm_shutdown_calls = [
+        call("sys-usb"),
+        call("sys-whonix"),
     ]
     sys_vm_start_calls = [
-        call("sys-usb"),
         call("sys-net"),
         call("sys-firewall"),
+        call("sys-whonix"),
+        call("sys-usb"),
     ]
     template_vm_calls = [
         call("fedora-30"),
@@ -696,14 +700,15 @@ def test_shutdown_and_start_vms(
     app_vm_calls = [
         call("sd-app"),
         call("sd-proxy"),
-        call("sys-whonix"),
         call("sd-whonix"),
         call("sd-gpg"),
         call("sd-log"),
     ]
     updater.shutdown_and_start_vms()
     mocked_output.assert_has_calls(sys_vm_kill_calls)
-    mocked_shutdown.assert_has_calls(template_vm_calls + app_vm_calls)
+    mocked_shutdown.assert_has_calls(
+        template_vm_calls + app_vm_calls + sys_vm_shutdown_calls
+    )
     app_vm_calls_reversed = list(reversed(app_vm_calls))
     mocked_start.assert_has_calls(sys_vm_start_calls + app_vm_calls_reversed)
     assert not mocked_error.called
@@ -723,17 +728,16 @@ def test_shutdown_and_start_vms_sysvm_fail(
     sys_vm_kill_calls = [
         call(["qvm-kill", "sys-firewall"], stderr=-1),
         call(["qvm-kill", "sys-net"], stderr=-1),
-        call(["qvm-kill", "sys-usb"], stderr=-1),
     ]
     sys_vm_start_calls = [
-        call("sys-usb"),
         call("sys-net"),
         call("sys-firewall"),
+        call("sys-whonix"),
+        call("sys-usb"),
     ]
     app_vm_calls = [
         call("sd-app"),
         call("sd-proxy"),
-        call("sys-whonix"),
         call("sd-whonix"),
         call("sd-gpg"),
         call("sd-log"),
@@ -749,13 +753,10 @@ def test_shutdown_and_start_vms_sysvm_fail(
         call("securedrop-workstation-buster"),
     ]
     error_calls = [
-        call("Error while killing sys-firewall"),
+        call("Error while killing system VM: sys-firewall"),
         call("Command 'check_output' returned non-zero exit status 1."),
         call("None"),
-        call("Error while killing sys-net"),
-        call("Command 'check_output' returned non-zero exit status 1."),
-        call("None"),
-        call("Error while killing sys-usb"),
+        call("Error while killing system VM: sys-net"),
         call("Command 'check_output' returned non-zero exit status 1."),
         call("None"),
     ]


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Resolves #531. Makes logging slightly more verbose to help diagnose issues with specific VMs.

`sys-whonix` is now treated as a "safe to shut down" system VM along with `sys-usb` (`sd-whonix` does not depend on it running).

## Testing


### Preparatory steps
(All testing should be done with an existing Qubes install at least at `0.2.4-rpm` - dev, prod or staging should make no difference)

1. Apply the changes in this PR to the launcher versions in `/opt/securedrop/launcher` and `/srv/salt/launcher` (if only the `/opt` copy is overwritten, the updater itself will replace it on the next run).
2. Downgrade `zlib` (`dnf downgrade zlib`) in `fedora-30` to ensure a realistic update scenario. Power off `fedora-30`.

### Scenario: fedora-30 update

1. Run  `/opt/securedrop/launcher/sdw-launcher.py --skip-delta 0`. This forces an updater run.
2. - [ ] Observe that the update completes successfully and that the `zlib` package in `fedora-30` is now at the latest version
3. - [ ] Observe that no unexpected errors are logged in `~/.securedrop_launcher/logs/launcher.log`
4. - [ ] Observe that `sys-usb` is running as expected and that the `sd-devices` workflow (automatic attachment of a LUKS-encrypted USB block device or USB printer to `sd-devices`) still works.

You may still encounter #498 due to the continued use of `qvm-kill`.

## Checklist

- [ ] Linter (`make flake8`) passes in the development environment (this box may
      be left unchecked, as `flake8` also runs in CI)
- [ ] All tests (`make test`) pass in `dom0` of a Qubes install (N/A, updater has its own test suite which passes)
- [x] No package updates required