### PR TITLE
Use poweroff + polling instead of qvm-kill for forced shutdowns

### DIFF
--- a/launcher/sdw_updater_gui/Updater.py
+++ b/launcher/sdw_updater_gui/Updater.py
@@ -495,7 +495,10 @@ def _force_shutdown_vm(vm):
     try:
         qubes.domains[vm].run("poweroff", user="root")
     except subprocess.CalledProcessError as e:
-        # Exit codes 1 and 143 may occur with successful shutdown; log others
+        # Exit codes 1 and 143 occur with successful shutdown (signifying
+        # the termination of the qrexec connection or a system process).
+        # poweroff does not provide a return code until the system is fully
+        # shut down; we never see exit code 0 from dom0.
         if e.returncode != 1 and e.returncode != 143:
             sdlog.error(
                 "Error shutting down VM '{}'. "

--- a/launcher/sdw_updater_gui/Updater.py
+++ b/launcher/sdw_updater_gui/Updater.py
@@ -514,7 +514,7 @@ def _wait_for_is_running(vm, expected, timeout=60, interval=0.2):
     timeout is reached.
 
     Return value:
-    - True if the VM reached the expeted state
+    - True if the VM reached the expected state
     - False if it did not
     """
     start_time = time.time()


### PR DESCRIPTION
## Status

Towards #498

## Test plan

### Preparatory steps

1. Check out this branch in your dev VM.
2. *(Recommended to stay sane, but not required)* Apply [this patch](https://gist.github.com/eloquence/200baed5444490428ce3662434a2ac34) to your `Updater.py` (`patch Updater.py instant_karma.patch`) in order to skip most of the update run, since this PR only impacts the shut-down-and-reboot sequence.
3. Apply the changes in this PR to the launcher versions in `/opt/securedrop/launcher` and `/srv/salt/launcher` (if only the `/opt` copy is overwritten, the updater itself will replace it on the next run).
4. `tail -f ~/.securedrop_launcher/launcher.log` to follow along as you test.

### Testing 

1. Run  `/opt/securedrop/launcher/sdw-launcher.py --skip-delta 0`. This forces an updater run.
2. - [ ] Observe that system VMs (`sys-usb`, `sys-firewall`, `sys-net`) are powered off and back on.
3. - [ ] Observe that the updater completes its run without an error including #498 (:crossed_fingers:).
4. - [ ] Observe that SecureDrop VMs and system VMs are up and running at the end of the run.
5. - [ ] Observe that the logs correctly report the forced shutdown and restart of system VMs.
6. Rinse and repeat a few times.
7. - [ ] Bonus points: Adjust the timeout value in https://github.com/freedomofpress/securedrop-workstation/pull/534/files#diff-ad9e526e0e4fea47e3196b3e293a4d50R511 to something ridiculous like `0.1` and observe if you can _now_ repro #498 (it is expected that you'll now see it again). Caveat that the file needs to again be patched in two places (`/opt` and `srv/`) for repeat runs.

## Checklist
- [x] No packaging implications
- [ ] `make test` in `dom0` not run yet (but should not be impacted; launcher has its own test suite)