### PR TITLE
Removes package updates from sd-log AppVM config

### DIFF
--- a/dom0/sd-logging-setup.sls
+++ b/dom0/sd-logging-setup.sls
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 
+{% if "template" in grains['id'] or grains['id'] in ["securedrop-workstation-buster", "whonix-gw-15"] %}
 include:
   - fpf-apt-test-repo
 
-{% if "template" in grains['id'] or grains['id'] in ["securedrop-workstation-buster", "whonix-gw-15"] %}
 # Install securedrop-log package in TemplateVMs only
 install-securedrop-log-package:
   pkg.installed:


### PR DESCRIPTION

## Status

Ready for review
## Description of Changes

Refs #514 

Changes proposed in this pull request:

The logging config must ensure that the necessary FPF apt repos are in
place, but the repo configs should only be applied for TemplateVMs. For
netless AppVMs, the call will fail if updates are available.


## Testing
First, make sure you can repro the failure scenario described in https://github.com/freedomofpress/securedrop-workstation/issues/514#issuecomment-614306466 Then, in a dev environment:

```
make clone
make clean
make all
make test
```

and observe all tests passing. Further research required for testing clean prod/staging installs. I've not done that yet.


## Checklist

### If you have made code changes

- [ ] Linter (`make flake8`) passes in the development environment (this box may
      be left unchecked, as `flake8` also runs in CI)

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0` of a Qubes install

- [ ] This PR adds/removes files, and includes required updates to the packaging
      logic in `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`
