### PR TITLE
Lints updater code for flake8 F523

### DIFF
--- a/launcher/sdw_updater_gui/Updater.py
+++ b/launcher/sdw_updater_gui/Updater.py
@@ -502,25 +502,13 @@ def should_launch_updater(interval):
                     sdlog.info("Required reboot pending, launching updater")
                     return True
             elif status["status"] == UpdateStatus.UPDATES_REQUIRED.value:
-                sdlog.info(
-                    "Updates are required, launching updater.".format(
-                        str(status["status"])
-                    )
-                )
+                sdlog.info("Updates are required, launching updater.")
                 return True
             elif status["status"] == UpdateStatus.UPDATES_FAILED.value:
-                sdlog.info(
-                    "Preceding update failed, launching updater.".format(
-                        str(status["status"])
-                    )
-                )
+                sdlog.info("Preceding update failed, launching updater.")
                 return True
             else:
-                sdlog.info(
-                    "Update status is unknown, launching updater.".format(
-                        str(status["status"])
-                    )
-                )
+                sdlog.info("Update status is unknown, launching updater.")
                 return True
     else:
         sdlog.info("Update status not available, launching updater.")


### PR DESCRIPTION
## Status

Ready for review  

## Description of Changes

F523 is use of str.format without the required a properly structured fmt
string. See https://flake8.pycqa.org/en/latest/user/error-codes.html


## Testing
1. First, reproduce the issue: `make flake8` on clean master fails
2. Then confirm `make flake8` on this branch passes

In my testing, technically 2 failed due to the presence of old source dirs for prior versions of the RPM package, which contained older source code. Still, this'll satisfy CI. 

## Checklist

### If you have made code changes

- [ ] Linter (`make flake8`) passes in the development environment (this box may
      be left unchecked, as `flake8` also runs in CI)

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0` of a Qubes install

- [ ] This PR adds/removes files, and includes required updates to the packaging
      logic in `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`
