### PR TITLE
Converts F30 -> F31 in dev env

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ As of March 2020, the production environment is in beta. The staging environment
 
 **IMPORTANT: THE STAGING ENVIRONMENT SHOULD NEVER BE USED FOR PRODUCTION PURPOSES. IT SHOULD BE USED ON TEST MACHINES ONLY.**
 
-#### Update `dom0`, `fedora-30`, `whonix-gw-15` and `whonix-ws-15` templates
+#### Update `dom0`, `fedora-31`, `whonix-gw-15` and `whonix-ws-15` templates
 Updates to these VMs will be provided by the installer and updater, but to ensure they are up to date prior to install, it will be easier to debug, should something go wrong.
 
 Before proceeding to updates, we must ensure that `sys-whonix` can bootstrap to the Tor network. In the Qubes menu, navigate to `sys-whonix` and click on `Anon Connection Wizard` and click `Next` and ensure the Tor Bootstrap process completes successfully.
@@ -422,8 +422,8 @@ Your export devices should be labeled, and used for nothing else.
 
 ### Transferring files via OnionShare
 
-1. Create an `sd-onionshare-template` VM based on `fedora-30`:
-   1. Click on the Qubes menu in the upper left, select "Template: Fedora 30", click on "fedora-30: Qube Settings", and click on **Clone Qube**
+1. Create an `sd-onionshare-template` VM based on `fedora-31`:
+   1. Click on the Qubes menu in the upper left, select "Template: Fedora 31", click on "fedora-31: Qube Settings", and click on **Clone Qube**
    2. Name the cloned qube `sd-onionshare-template`
    3. In the Qubes menu on the top-left, select "Template: sd-onionshare-template" and click on "sd-onionshare-template: Terminal"
    4. Install OnionShare: `sudo dnf install onionshare`

--- a/dom0/sd-clean-all.sls
+++ b/dom0/sd-clean-all.sls
@@ -5,7 +5,7 @@
 
 set-fedora-as-default-dispvm:
   cmd.run:
-    - name: qvm-check fedora-30-dvm && qubes-prefs default_dispvm fedora-30-dvm || qubes-prefs default_dispvm ''
+    - name: qvm-check fedora-31-dvm && qubes-prefs default_dispvm fedora-31-dvm || qubes-prefs default_dispvm ''
 
 {% set gui_user = salt['cmd.shell']('groupmems -l -g qubes') %}
 

--- a/dom0/sd-clean-default-dispvm.sls
+++ b/dom0/sd-clean-default-dispvm.sls
@@ -3,4 +3,4 @@
 
 set-fedora-as-default-dispvm:
   cmd.run:
-    - name: qvm-check fedora-30-dvm && qubes-prefs default_dispvm fedora-30-dvm || qubes-prefs default_dispvm ''
+    - name: qvm-check fedora-31-dvm && qubes-prefs default_dispvm fedora-31-dvm || qubes-prefs default_dispvm ''

--- a/dom0/sd-dom0-files.sls
+++ b/dom0/sd-dom0-files.sls
@@ -19,7 +19,7 @@ dom0-rpm-test-key:
   file.managed:
     # We write the pubkey to the repos config location, because the repos
     # config location is automatically sent to dom0's UpdateVM. Otherwise,
-    # we must place the GPG key inside the fedora-30 TemplateVM, then
+    # we must place the GPG key inside the fedora-31 TemplateVM, then
     # restart sys-firewall.
     - name: /etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation
     - source: "salt://sd/sd-workstation/{{ sdvars.signing_key_filename }}"

--- a/dom0/sd-sys-vms.sls
+++ b/dom0/sd-sys-vms.sls
@@ -5,11 +5,11 @@
 # an up-to-date version of Fedora, in order to receive security updates.
 
 include:
-  # Import the upstream Qubes-maintained default-dispvm to ensure fedora-30-dvm
+  # Import the upstream Qubes-maintained default-dispvm to ensure fedora-31-dvm
   # is created.
   - qvm.default-dispvm
 
-{% set sd_supported_fedora_version = 'fedora-30' %}
+{% set sd_supported_fedora_version = 'fedora-31' %}
 
 # Install latest templates required for SDW VMs.
 dom0-install-fedora-template:
@@ -19,7 +19,7 @@ dom0-install-fedora-template:
 
 # qvm.default-dispvm is not strictly required here, but we want it to be
 # updated as soon as possible to ensure make clean completes successfully, as
-# is sets the default_dispvm to fedora-30-dvm
+# is sets the default_dispvm to fedora-31-dvm
 set-fedora-default-template-version:
   cmd.run:
     - name: qubes-prefs default_template {{ sd_supported_fedora_version }}

--- a/launcher/sdw_updater_gui/Updater.py
+++ b/launcher/sdw_updater_gui/Updater.py
@@ -30,7 +30,7 @@ sdlog = logging.getLogger(__name__)
 # In the future, we could use qvm-prefs to extract this information.
 current_templates = {
     "dom0": "dom0",
-    "fedora": "fedora-30",
+    "fedora": "fedora-31",
     "sd-viewer": "sd-viewer-buster-template",
     "sd-app": "sd-app-buster-template",
     "sd-log": "sd-log-buster-template",

--- a/launcher/tests/test_updater.py
+++ b/launcher/tests/test_updater.py
@@ -688,7 +688,7 @@ def test_shutdown_and_start_vms(
         call("sys-usb"),
     ]
     template_vm_calls = [
-        call("fedora-30"),
+        call("fedora-31"),
         call("sd-viewer-buster-template"),
         call("sd-app-buster-template"),
         call("sd-log-buster-template"),
@@ -743,7 +743,7 @@ def test_shutdown_and_start_vms_sysvm_fail(
         call("sd-log"),
     ]
     template_vm_calls = [
-        call("fedora-30"),
+        call("fedora-31"),
         call("sd-viewer-buster-template"),
         call("sd-app-buster-template"),
         call("sd-log-buster-template"),

--- a/tests/test_qubes_vms.py
+++ b/tests/test_qubes_vms.py
@@ -3,7 +3,7 @@ import unittest
 from qubesadmin import Qubes
 
 
-CURRENT_FEDORA_VERSION = "30"
+CURRENT_FEDORA_VERSION = "31"
 CURRENT_WHONIX_VERSION = "15"
 
 

--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -141,8 +141,8 @@ class SD_VM_Platform_Tests(unittest.TestCase):
         """
         # Technically we want to know whether the sys-firewall, sys-net, and
         # sys-usb VMs have their updates installed. This test assumes those
-        # AppVMs are based on fedora-30.
-        vm_name = "fedora-30"
+        # AppVMs are based on fedora-31.
+        vm_name = "fedora-31"
         vm = self.app.domains[vm_name]
         self._ensure_packages_up_to_date(vm, fedora=True)
         vm.shutdown()
@@ -193,7 +193,7 @@ class SD_VM_Platform_Tests(unittest.TestCase):
             "sys-usb",
         ]
         for vm in sys_vms:
-            wanted_template = "fedora-30"
+            wanted_template = "fedora-31"
             found_template = self.app.domains[vm].template.name
             self.assertEqual(wanted_template, found_template)
 


### PR DESCRIPTION


## Status

Ready for review.

## Description of Changes

Refs #544 

Changes proposed in this pull request:

These changes ensure that fedora-31 is preferred everywhere. Running a
`make dev` will ensure that the handle-upgrade logic is run, restarting
the VMs as required. What's *not* included in this change is a method
for handling automated upgrades in staging/prod. In order to accomplish
unattended transition from f30 -> f31, we'll have to update the dom0
state management logic to "include" the handle-upgrade script.

## Testing

Make sure you use a `dev` environment (i.e. `config.json` shows "environment": "dev"). 

```
make clone
make all
make test
```

All tests should pass. On my machine, the only test that failed was the dnf update check, so after updating the packages in `fedora-31`, the test suite was passing completely. 

Also run `qvm-ls | grep fedora` and ensure that `sys-net`, `sys-usb`, and `sys-firewall` are all based on `fedora-31`. (The tests check this, but best to be sure.) I've not yet confirmed the usb export flow to be working, so validation on that front is required, as well. 

## Checklist

### If you have made code changes

- [ ] Linter (`make flake8`) passes in the development environment (this box may
      be left unchecked, as `flake8` also runs in CI)

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0` of a Qubes install

- [ ] This PR adds/removes files, and includes required updates to the packaging
      logic in `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`
