### PR TITLE
updated expected kernel version test value to 4.14.186

### DIFF
--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -5,7 +5,7 @@ from qubesadmin import Qubes
 from base import WANTED_VMS
 
 
-EXPECTED_KERNEL_VERSION = "4.14.169-grsec-workstation"
+EXPECTED_KERNEL_VERSION = "4.14.186-grsec-workstation"
 
 
 class SD_VM_Tests(unittest.TestCase):


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Towards #546 .

Updates buster kernel version in tests from 4.14.169 to 4.14.186

- Kernel config changes: https://github.com/freedomofpress/ansible-role-grsecurity-build/pull/58
- Metapackage changes: https://github.com/freedomofpress/securedrop-debian-packaging/pull/174

## Testing

- Install workstation using this branch
- [ ] `make test` tests fail due to version mismatch
- Update kernel to  4.14.186 in `securedrop-workstation-buster` using packages from https://github.com/freedomofpress/securedrop-dev-packages-lfs/pull/42
- run `make clean` and `make all` to rebuild workstation
- [ ] `make test` tests that check kernel version now pass

## Checklist

### If you have made code changes

- [ ] Linter (`make flake8`) passes in the development environment (this box may
      be left unchecked, as `flake8` also runs in CI)

### If you have made changes to the provisioning logic

- [x] All tests (`make test`) pass in `dom0` of a Qubes install

- [ ] This PR adds/removes files, and includes required updates to the packaging
      logic in `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`
