### PR TITLE
Add deprecation warning if v2 config detected

### DIFF
--- a/scripts/validate_config.py
+++ b/scripts/validate_config.py
@@ -59,15 +59,25 @@ class SDWConfigValidator(object):
 
     def confirm_onion_config_valid(self):
         """
-        We support both v2 and v3 Onion Services, so if the values
-        in config file match either format, good enough.
+        We support both v2 and v3 onion services, so if the values
+        in the config file match either format, the configuration is considered
+        valid. A deprecation warning is shown if v2 services are in use.
         """
+        v2_config = False
         try:
             self.confirm_onion_v3_url()
             self.confirm_onion_v3_auth()
         except AssertionError:
             self.confirm_onion_v2_url()
             self.confirm_onion_v2_auth()
+            v2_config = True
+
+        if v2_config:
+            print(
+                "WARNING: v2 onion service configuration found.\n"
+                "Support for v2 onion services will be removed from SecureDrop in February 2021.\n"
+                "Migration guide: https://securedrop.org/v2-onion-eol/"
+            )
 
     def confirm_onion_v3_url(self):
         assert "hidserv" in self.config


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #585. The warning is added to the validator, so it will also be displayed on the `make validate` target or manual invocation of the validation script.

## Test plan

- Clone this branch to `dom0`.
- Ensure you have a valid v3 config under `/usr/share/securedrop-workstation-dom0-config`.
- Run `python3 scripts/securedrop-admin.py --validate`
- [ ] Observe that the configuration still validates without errors or warnings.
- Make a breaking modification to the .onion configuration (back up config as needed) and re-validate. For example, you could use an address of the wrong length.
- [ ] Observe that validation errors still get reported as exceptions
- Change the config to a correctly formatted v2 address.
- [ ] Observe that the configuration now validates successfully, but a deprecation warning is shown.

## Checklist

- [x] Linter (`make flake8`) passes in the development environment 
- [x] No packaging changes
- [ ] All tests (`make test`) pass in `dom0` of a Qubes install [no current tests for this logic]