### PR TITLE
Rename securedrop-admin to sdw-admin

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,7 @@ include dom0/*.j2
 include dom0/*.yml
 include dom0/*.conf
 include dom0/remove-tags
-include dom0/securedrop-admin
+include dom0/sdw-admin
 include dom0/securedrop-login
 include dom0/securedrop-launcher.desktop
 include dom0/securedrop-handle-upgrade

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ You can install the staging environment in two ways:
 
 - If you have an up-to-date clone of this repo with a valid configuration in `dom0`, you can use the `make staging` target to provision a staging environment. Prior to provisioning, `make staging` will set your `config.json` environment to `staging`. As part of the provisioning, your package repository configuration will be updated to use the latest test release of the RPM package, and the latest nightlies of the Debian packages.
 
-- If you want to install a staging environment from scratch in a manner similar to a production install (starting from an RPM, and using `securedrop-admin` for the installation), follow the process in the following sections.
+- If you want to install a staging environment from scratch in a manner similar to a production install (starting from an RPM, and using `sdw-admin` for the installation), follow the process in the following sections.
 
 #### Download and install securedrop-workstation-dom0-config package
 
@@ -267,7 +267,7 @@ Your workstation configuration will reside in `/usr/share/securedrop-workstation
 In a terminal in `dom0`, run the following commands:
 
 ```
-[dom0]$ securedrop-admin --apply
+[dom0]$ sdw-admin --apply
 ```
 
 ## Development

--- a/launcher/sdw_updater_gui/Updater.py
+++ b/launcher/sdw_updater_gui/Updater.py
@@ -303,7 +303,7 @@ def apply_dom0_state():
     """
     Applies the dom0 state to ensure dom0 and AppVMs are properly
     Configured. This will *not* enforce configuration inside the AppVMs.
-    Here, we call qubectl directly (instead of through securedrop-admin) to
+    Here, we call qubectl directly (instead of through sdw-admin) to
     ensure it is environment-specific.
     """
     sdlog.info("Applying dom0 state")

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -64,7 +64,7 @@ install -m 644 dom0/securedrop-login %{buildroot}/srv/salt/
 install -m 644 dom0/securedrop-launcher.desktop %{buildroot}/srv/salt/
 install -m 655 dom0/securedrop-handle-upgrade %{buildroot}/srv/salt/
 install -m 655 dom0/update-xfce-settings %{buildroot}/srv/salt/
-install -m 755 scripts/securedrop-admin.py %{buildroot}/%{_bindir}/securedrop-admin
+install -m 755 scripts/sdw-admin.py %{buildroot}/%{_bindir}/sdw-admin
 install -m 644 sd-app/* %{buildroot}/srv/salt/sd/sd-app/
 install -m 644 sd-proxy/* %{buildroot}/srv/salt/sd/sd-proxy/
 install -m 644 sd-whonix/* %{buildroot}/srv/salt/sd/sd-whonix/
@@ -87,7 +87,7 @@ install -m 644 launcher/sdw_util/*.py %{buildroot}/srv/salt/launcher/sdw_util/
 %doc README.md LICENSE
 %attr(755, root, root) /opt/securedrop/launcher/sdw-launcher.py
 %attr(755, root, root) /opt/securedrop/launcher/sdw-notify.py
-%attr(755, root, root) %{_bindir}/securedrop-admin
+%attr(755, root, root) %{_bindir}/sdw-admin
 %{python3_sitelib}/securedrop_workstation_dom0_config*
 %{_datadir}/%{name}
 /opt/securedrop/launcher/**/*.py

--- a/scripts/sdw-admin.py
+++ b/scripts/sdw-admin.py
@@ -54,7 +54,7 @@ def copy_config():
             ["sudo", "cp", os.path.join(SCRIPTS_PATH, "sd-journalist.sec"), SALT_PATH]
         )
     except subprocess.CalledProcessError:
-        raise SDAdminException("Error copying configuration")
+        raise SDWAdminException("Error copying configuration")
 
 
 def provision_all():
@@ -64,7 +64,7 @@ def provision_all():
     try:
         subprocess.check_call([os.path.join(SCRIPTS_PATH, "scripts/provision-all")])
     except subprocess.CalledProcessError:
-        raise SDAdminException("Error during provision-all")
+        raise SDWAdminException("Error during provision-all")
 
 
 def validate_config(path):
@@ -74,7 +74,7 @@ def validate_config(path):
     try:
         validator = SDWConfigValidator(path)  # noqa: F841
     except ValidationError:
-        raise SDAdminException("Error while validating configuration")
+        raise SDWAdminException("Error while validating configuration")
 
 
 def refresh_salt():
@@ -85,12 +85,12 @@ def refresh_salt():
     try:
         subprocess.check_call(["sudo", "rm", "-rf", "/var/cache/salt"])
     except subprocess.CalledProcessError:
-        raise SDAdminException("Error while clearing Salt cache")
+        raise SDWAdminException("Error while clearing Salt cache")
 
     try:
         subprocess.check_call(["sudo", "qubesctl", "saltutil.sync_all", "refresh=true"])
     except subprocess.CalledProcessError:
-        raise SDAdminException("Error while synchronizing Salt")
+        raise SDWAdminException("Error while synchronizing Salt")
 
 
 def perform_uninstall():
@@ -122,7 +122,7 @@ def perform_uninstall():
             ["sudo", "dnf", "-y", "-q", "remove", "securedrop-workstation-dom0-config"]
         )
     except subprocess.CalledProcessError:
-        raise SDAdminException("Error during uninstall")
+        raise SDWAdminException("Error during uninstall")
 
     print(
         "Instance secrets (Journalist Interface token and Submission private key) are still "
@@ -158,7 +158,7 @@ def main():
         sys.exit(0)
 
 
-class SDAdminException(Exception):
+class SDWAdminException(Exception):
     pass
 
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Resolves #586. Since `securedrop-admin` is only provisioned via RPM, no `make clean` changes should be required.

## Test plan

- Ensure you're running a SecureDrop Workstation `staging` or `prod` install created from an RPM.
- [ ] Observe that the `securedrop-admin` can be successfully run in `dom0`
- Check out this PR's branch in your dev env. 
- Bump the RPM version to 0.4.1 as illustrated in the detached commit f24804ae5f6ac156466f6072da715c975c02ba16 (you can use the `./update-version.sh` script in the base of this repo)
- Build a 0.4.1 RPM by running `make dom0-rpm` and copying that file to dom0.
- Install the 0.4.1 RPM with `sudo dnf install <filename>`
- [ ] Observe that `securedrop-admin ` can no longer be run in `dom0`
- [ ] Observe that you can now access the tool with `sdw-admin` in `dom0`
- [ ] Observe that `sdw-admin --validate` still functions as expected

### If you have made code changes

- [x] Linter (`make flake8`) passes in the development environment
- [ ] All tests (`make test`) pass in `dom0` of a Qubes install [no impact on test suite]
- [x] This PR adds/removes files, and includes required updates to the packaging logic in `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`
