### PR TITLE
Adds config test for required kernel modules

### DIFF
--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -36,6 +36,12 @@ class SD_VM_Tests(unittest.TestCase):
         assert kernel_version.endswith("-grsec-workstation")
         assert kernel_version == EXPECTED_KERNEL_VERSION
 
+        u2mfn_filepath = "/usr/lib/modules/{}/updates/dkms/u2mfn.ko".format(EXPECTED_KERNEL_VERSION)
+        # cmd will raise exception if file not found
+        stdout, stderr = vm.run("sudo test -f {}".format(u2mfn_filepath))
+        assert stdout == b""
+        assert stderr == b""
+
     def _check_service_running(self, vm, service):
         """
         Ensures a given service is running inside a given VM.


### PR DESCRIPTION
## Status
Ready for review.

## Description of Changes

These changes add new config tests for VM state, ensuring that the u2mfn kernel module, required for graphical environments in Qubes, was built accurately. Without these tests, the graphical display problems reported in https://github.com/freedomofpress/securedrop-workstation/issues/590 wouild not result in a test suite failure. Now the tests should fail accordingly. 


## Testing

See detailed test plan in https://github.com/freedomofpress/securedrop-debian-packaging/pull/189 to validate the logic changes in the new metapackage. For reviewing this PR, a fully passing `make test` is sufficient. Note that you may see a failing test such as https://github.com/freedomofpress/securedrop-workstation/issues/583 , which is unrelated.

Additionally, it's probably worth confirming that removing the filepath `/usr/lib/modules/4.14.186-grsec-workstation/updates/dkms/u2mfn.ko` from a TemplateVM causes the new test to fail, although be aware that removing that file will break the GUI as described in https://github.com/freedomofpress/securedrop-workstation/issues/590

## Checklist

### If you have made code changes

- [ ] Linter (`make flake8`) passes in the development environment (this box may
      be left unchecked, as `flake8` also runs in CI)

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0` of a Qubes install

- [ ] This PR adds/removes files, and includes required updates to the packaging
      logic in `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`
