### PR TITLE
Handle mimetypes for sd-app, sd-viewer and sd-devices in private volume

### DIFF
--- a/dom0/sd-mime-handling.sls
+++ b/dom0/sd-mime-handling.sls
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+##
+# sd-mime-handling
+# =====================
+#
+# Overrides mimetype handling for certain VMs. Instead of relying on the
+# /usr/share/applications (system volume), we instead use /home/user/.local/share/
+# (private volume). The various mimeapps.list files linked are provided by the
+# securedrop-workstation-config package in /opt/, and are symlinked here in their
+# respective AppVMs.
+##
+
+{% if grains['id'] in ["sd-viewer", "sd-app", "sd-devices-dvm"] %}
+
+sd-private-volume-mimeapps-handling:
+  file.symlink:
+    - name: /home/user/.local/share/applications/mimeapps.list
+    - target: /opt/sdw/mimeapps.list.{{ grains['id'] }}
+    - makedirs: True
+
+{% endif %}

--- a/dom0/sd-workstation.top
+++ b/dom0/sd-workstation.top
@@ -31,6 +31,7 @@ base:
     - sd-proxy-template-files
   sd-app:
     - sd-app-config
+    - sd-mime-handling
   sd-viewer-buster-template:
     - sd-viewer-files
   sd-app-buster-template:
@@ -49,6 +50,10 @@ base:
     - sd-logging-setup
   sd-log:
     - sd-logging-setup
+  sd-viewer:
+    - sd-mime-handling
+  sd-devices-dvm:
+    - sd-mime-handling
 
   # "Placeholder" config to trigger TemplateVM boots,
   # so upgrades can be applied automatically via cron.


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

Fixes #603 


## Testing

### The changes to the `securedrop-workstation-config` do not adversely impact mime handling
- On the `main` branch of this repo
- Build `securedrop-workstation-config` package with changes from https://github.com/freedomofpress/securedrop-debian-packaging/pull/190
```
PKG_VERSION=0.1.4 make securedrop-workstation-config
```
- Copy the built deb to sd-workstation folder in the clone of this repo/branch for testing
```
cp /home/user/debbuild/packaging/securedrop-workstation-config_0.1.4+buster_all.deb sd-workstation/
```
- Apply the following diff to ensure this version of the package is installed in all VMs:
```
diff --git a/dom0/fpf-apt-test-repo.sls b/dom0/fpf-apt-test-repo.sls
index 6299198..1ef3f75 100644
--- a/dom0/fpf-apt-test-repo.sls
+++ b/dom0/fpf-apt-test-repo.sls
@@ -42,3 +42,11 @@ install-securedrop-keyring-package:
       - securedrop-keyring
     - require:
       - pkgrepo: configure-apt-test-apt-repo
+
+test-updated-securedrop-config-package:
+   file.managed:
+     - name: /opt/securedrop-config.deb
+     - source: salt://sd/sd-workstation/securedrop-workstation-config_0.1.4+buster_all.deb
+     - mode: 644
+   cmd.run:
+     - name: apt install -y /opt/securedrop-config.deb
```
- `make clone`, `make all`, and `make test`
- [ ] `make all` completes successfully
- [ ] `make test` completes successfully 

### Using the changes introduced here, private volume mime handling
- On this branch `603-private-volumes-mimetypes`
- Build `securedrop-workstation-config` package with changes from https://github.com/freedomofpress/securedrop-debian-packaging/pull/190
```
PKG_VERSION=0.1.4 make securedrop-workstation-config
```
- Copy the built deb to sd-workstation folder in the clone of this repo/branch for testing
```
cp /home/user/debbuild/packaging/securedrop-workstation-config_0.1.4+buster_all.deb sd-workstation/
```
- Apply the following diff to ensure this version of the package is installed in all VMs:
```
diff --git a/dom0/fpf-apt-test-repo.sls b/dom0/fpf-apt-test-repo.sls
index 6299198..1ef3f75 100644
--- a/dom0/fpf-apt-test-repo.sls
+++ b/dom0/fpf-apt-test-repo.sls
@@ -42,3 +42,11 @@ install-securedrop-keyring-package:
       - securedrop-keyring
     - require:
       - pkgrepo: configure-apt-test-apt-repo
+
+test-updated-securedrop-config-package:
+   file.managed:
+     - name: /opt/securedrop-config.deb
+     - source: salt://sd/sd-workstation/securedrop-workstation-config_0.1.4+buster_all.deb
+     - mode: 644
+   cmd.run:
+     - name: apt install -y /opt/securedrop-config.deb
```
- `make clone`, `make all`, and `make test`
- [ ] `make all` completes successfully
- [ ] `make test` completes successfully 
- [ ] manual test of mime precedence: in `sd-app`: `cp /opt/sdw/mimeapps.list.sd-viewer /usr/share/applications/mimeapps.list`: xdg-open a file should still open in a DispVM. `rm ~/.local/share/applications/mimeapps.list` should cause `xdg-open` to open files in sd-app. Recreating the symlink resolves.
 

## Checklist

### If you have made code changes

- [x] Linter (`make flake8`) passes in the development environment (this box may
      be left unchecked, as `flake8` also runs in CI)

### If you have made changes to the provisioning logic

- [x] All tests (`make test`) pass in `dom0` of a Qubes install

- [x] This PR adds/removes files, and includes required updates to the packaging
      logic in `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`
