### PR TITLE
Uninstalls RPM in prep-dev script

### DIFF
--- a/scripts/prep-dev
+++ b/scripts/prep-dev
@@ -22,7 +22,7 @@ fi
 
 echo "Deploying Salt config..."
 echo "Uninstalling any previous RPM versions..."
-sudo dnf remove -y securedrop-worsktation-dom0-config || true
+sudo dnf remove -y securedrop-workstation-dom0-config || true
 echo "Installing RPM at $latest_rpm ..."
 sudo dnf install -y "$latest_rpm"
 

--- a/scripts/prep-dev
+++ b/scripts/prep-dev
@@ -21,6 +21,8 @@ if [[ -z "$latest_rpm" ]]; then
 fi
 
 echo "Deploying Salt config..."
+echo "Uninstalling any previous RPM versions..."
+sudo dnf remove -y securedrop-worsktation-dom0-config || true
 echo "Installing RPM at $latest_rpm ..."
 sudo dnf install -y "$latest_rpm"
 


### PR DESCRIPTION
#   Status

Ready for review  

## Description of Changes

Follow up to #587.

The `dnf install -y <local_file>` action will not reinstall a package
if the versions are the same. Since we expect package contents to
change, but not version strings, when running `make clone`, let's make
sure to uninstall the rpm package in dom0 so that the install action
always takes effect.

## Testing
First, let's observe the problem. The steps to reproduce assume that you've already got a version of `securedrop-workstation-config

1. In dev VM, check out main branch in this repo
1. In dom0, run `make clone && make prep-dev`. This is just to confirm that you've got a recent version of the rpm already present
1. In dom0, confirm file is absent: `sudo ls -1 /srv/salt/ | grep sd-test` shows nothing
1. In dev VM, run `touch dom0/sd-test.sls` to create a new file
1. In dom0, run `make clone && make prep-dev` 
1. In dom0, confirm file is still absent: `sudo ls -1 /srv/salt/ | grep sd-test` shows nothing

Now let's test the fix.

1. In dev VM, check out this feature branch
1. In dev VM, run `git status` and confirm `dom0/sd-test.sls` is still present locally (you don't need to commit it)
1. In dom0, confirm file is absent: `sudo ls -1 /srv/salt/ | grep sd-test` shows nothing
1. In dom0, run `make clone && make prep-dev` 
1. In dom0, confirm file is **present**: `sudo ls -1 /srv/salt/ | grep sd-test` shows "sd-test.sls"




## Checklist

### If you have made code changes

- [ ] Linter (`make flake8`) passes in the development environment (this box may
      be left unchecked, as `flake8` also runs in CI)

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0` of a Qubes install

- [ ] This PR adds/removes files, and includes required updates to the packaging
      logic in `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`
