### PR TITLE
Remove special casing for sd-whonix

### DIFF
--- a/dom0/sd-clean-whonix.sls
+++ b/dom0/sd-clean-whonix.sls
@@ -14,7 +14,6 @@ remove-securedrop-log-package-from-whonix:
 sd-cleanup-whonix-gw-15:
   cmd.run:
     - names:
-      - sudo rm -f /etc/rsyslog.d/sdlog.conf
       - sudo rm -f /etc/apt/sources.list.d/securedrop_workstation.list
       - sudo systemctl restart rsyslog
       - sudo apt-key del 4ED79CC3362D7D12837046024A3BE4A92211B03C

--- a/tests/base.py
+++ b/tests/base.py
@@ -105,11 +105,9 @@ class SD_VM_Local_Test(unittest.TestCase):
 
         return True
 
-    def logging_configured(self, vmname=False):
+    def logging_configured(self):
         """
         Make sure rsyslog is configured to send in data to sd-log vm.
-        Takes an optional 'vmname' argument, in case hostname
-        returned by system is an insufficient identifier, e.g. Whonix.
         """
         self.assertTrue(self._package_is_installed("securedrop-log"))
         self.assertTrue(self._fileExists("/usr/sbin/sd-rsyslog"))
@@ -120,10 +118,6 @@ class SD_VM_Local_Test(unittest.TestCase):
         static_content = """[sd-rsyslog]
 remotevm = sd-log
 """
-        # A hardcoded vmname should only be present if required,
-        # since securedrop-log will default to value of `hostname`.
-        if vmname:
-            static_content += "localvm = {}\n".format(self.vm_name)
         self.assertEqual(file_content, static_content)
         # Check for evidence of misconfigured logging in syslog,
         # fail if matching events found

--- a/tests/test_sd_whonix.py
+++ b/tests/test_sd_whonix.py
@@ -55,7 +55,7 @@ class SD_Whonix_Tests(SD_VM_Local_Test):
         assert self._fileExists(self.whonix_apt_list)
 
     def test_logging_configured(self):
-        self.logging_configured(vmname=True)
+        self.logging_configured()
 
     def test_sd_whonix_verify_tor_config(self):
         # User must be debian-tor for v3 Onion, due to restrictive


### PR DESCRIPTION
Part of #583

## Description

Removes Salt logic for custom handling of `whonix-gw-15` integration with `sd-log` and instead treats it like any other TemplateVM.

Removes the `vmname` testing from `dom0` tests. The functionality remains in `securedrop-log`, but is only likely to be used during development.

## Status

Ready for review. 

## Test plan

### Prerequisites 
- The changes in https://github.com/freedomofpress/securedrop-log/pull/18 have been merged and have landed in the latest nightly on https://apt-test.freedom.press/pool/main/s/securedrop-log/
- You have a working staging environment built from latest `main` of `securedrop-workstation`.

### Instructions
1. Remove  `~/QubesIncomingLogs/host` directory on `sd-log` if it exists from previous runs
2. `make clone` from this branch.
3. `make staging` with a valid config. This will apply the Salt states from this PR.
4. Ensure the `sd-whonix` VM, the `sd-app` VM, and the `sd-log` VM are all booted.
- [ ] On `sd-whonix`: Observe that `/rw/config/rc.local` no longer contains any customizations
- [ ] On `sd-whonix`: Observe that `/rw/config/sdlog.conf` no longer exists.
- [ ] On `sd-log`: Observe that no files exist under `host` in `~/QubesIncomingLogs`
- [ ] On `sd-log`: Observe that logs are correctly ingested under `sd-whonix`.
- [ ] On `sd-log`: Observe that logs are correctly ingested under `sd-app`.
5. `make clean` in `dom0`.
- [ ] On `whonix-gw-15`: Observe that `/etc/rsyslog.d/sdlog.conf` has been removed
