### PR TITLE
Fix profile.d tests for sd-app

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,10 +9,8 @@ class SD_App_Tests(SD_VM_Local_Test):
         self.vm_name = "sd-app"
         super(SD_App_Tests, self).setUp()
 
-    def test_decrypt_sd_user_profile(self):
-        contents = self._get_file_contents("/etc/profile.d/sd-app-qubes-gpg-domain.sh")
-        expected_content = 'export QUBES_GPG_DOMAIN="sd-gpg"\n'
-        self.assertEqual(contents, expected_content)
+    def test_gpg_domain_configured(self):
+        self.qubes_gpg_domain_configured(self.vm_name)
 
     def test_open_in_dvm_desktop(self):
         contents = self._get_file_contents("/usr/share/applications/open-in-dvm.desktop")

--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -52,6 +52,9 @@ class SD_GPG_Tests(SD_VM_Local_Test):
         # Logging to sd-log should be disabled on sd-gpg
         self.assertFalse(self._fileExists("/etc/rsyslog.d/sdlog.conf"))
 
+    def test_gpg_domain_configured(self):
+        self.qubes_gpg_domain_configured(self.vm_name)
+
 
 def load_tests(loader, tests, pattern):
     suite = unittest.TestLoader().loadTestsFromTestCase(SD_GPG_Tests)

--- a/tests/test_log_vm.py
+++ b/tests/test_log_vm.py
@@ -49,6 +49,9 @@ class SD_Log_Tests(SD_VM_Local_Test):
         # Confirm we don't have 'host' entries from Whonix VMs
         self.assertFalse("host" in log_dirs)
 
+    def test_gpg_domain_configured(self):
+        self.qubes_gpg_domain_configured(self.vm_name)
+
 
 def load_tests(loader, tests, pattern):
     suite = unittest.TestLoader().loadTestsFromTestCase(SD_Log_Tests)

--- a/tests/test_proxy_vm.py
+++ b/tests/test_proxy_vm.py
@@ -52,6 +52,9 @@ class SD_Proxy_Tests(SD_VM_Local_Test):
                     actual_app = self._run("xdg-mime query default {}".format(mime_type))
                     self.assertEqual(actual_app, expected_app)
 
+    def test_gpg_domain_configured(self):
+        self.qubes_gpg_domain_configured(self.vm_name)
+
 
 def load_tests(loader, tests, pattern):
     suite = unittest.TestLoader().loadTestsFromTestCase(SD_Proxy_Tests)

--- a/tests/test_sd_devices.py
+++ b/tests/test_sd_devices.py
@@ -45,6 +45,9 @@ class SD_Devices_Tests(SD_VM_Local_Test):
         for line in expected_contents:
             self.assertTrue(line in contents)
 
+    def test_gpg_domain_configured(self):
+        self.qubes_gpg_domain_configured(self.vm_name)
+
 
 def load_tests(loader, tests, pattern):
     suite = unittest.TestLoader().loadTestsFromTestCase(SD_Devices_Tests)

--- a/tests/test_sd_whonix.py
+++ b/tests/test_sd_whonix.py
@@ -74,6 +74,9 @@ class SD_Whonix_Tests(SD_VM_Local_Test):
             "Whonix GW torrc contains duplicate %include lines",
         )
 
+    def test_gpg_domain_configured(self):
+        self.qubes_gpg_domain_configured(self.vm_name)
+
 
 def load_tests(loader, tests, pattern):
     suite = unittest.TestLoader().loadTestsFromTestCase(SD_Whonix_Tests)

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -36,6 +36,9 @@ class SD_Viewer_Tests(SD_VM_Local_Test):
                     actual_app = self._run("xdg-mime query default {}".format(mime_type))
                     self.assertEqual(actual_app, expected_app)
 
+    def test_gpg_domain_configured(self):
+        self.qubes_gpg_domain_configured(self.vm_name)
+
 
 def load_tests(loader, tests, pattern):
     suite = unittest.TestLoader().loadTestsFromTestCase(SD_Viewer_Tests)


### PR DESCRIPTION
## Status

Ready for review
This PR should be reviewed at the same time as https://github.com/freedomofpress/securedrop-client/pull/1159 and https://github.com/freedomofpress/securedrop-debian-packaging/pull/202. 

## Description of Changes

Fixes #621
`QUBES_GPG_DOMAIN` is conditionally set based on the running VM in order to support template consolidation. See https://github.com/freedomofpress/securedrop-client/issues/1141

This will also help testing both client and packaging PRs that resolve these test failures.

## Testing

Build a client package based on the following branches/PRs:
- client: https://github.com/freedomofpress/securedrop-client/pull/1159
- packaging: https://github.com/freedomofpress/securedrop-debian-packaging/pull/202
- [ ] Client builds successfully

Apply the diff below to install the sd-app package locally instead of through apt server
```
diff --git a/dom0/sd-app-files.sls b/dom0/sd-app-files.sls
index 9828d4e..55b3b18 100644
--- a/dom0/sd-app-files.sls
+++ b/dom0/sd-app-files.sls
@@ -14,8 +14,9 @@ include:
 
 # FPF repo is setup in "securedrop-workstation" template
 install-securedrop-client-package:
-  pkg.installed:
-    - pkgs:
-      - securedrop-client
-    - require:
-      - sls: fpf-apt-test-repo
+  file.managed:
+   - name: /opt/securedrop-client.deb
+   - source: salt://sd/sd-workstation/securedrop-client_0.2.1+buster_all.deb
+   - mode: 644
+  cmd.run:
+   - name: apt install --allow-downgrades -y /opt/securedrop-client.deb
```
- [ ] `make dev` should complete successfully
- [ ] `make test` should complete successfully  (except sd-app being up-to-date, this is because the client version needs to be bumped)
## Checklist

### If you have made changes to the provisioning logic

- [x] All tests (`make test`) pass in `dom0` of a Qubes install (except the upgrades for sd-app (the client version needs to be bumped)