### PR TITLE
Fix subtargets for dom0 tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,19 +109,19 @@ test: assert-dom0 ## Runs all application tests (no integration tests yet)
 	python3 -m unittest discover -v tests
 
 test-base: assert-dom0 ## Runs tests for VMs layout
-	python3 -m unittest -v tests.test_vms_exist.SD_VM_Tests
+	python3 -m unittest discover -v tests -p test_vms_exist.py
 
 test-app: assert-dom0 ## Runs tests for SD APP VM config
-	python3 -m unittest -v tests.test_app.SD_App_Tests
+	python3 -m unittest discover -v tests -p test_app.py
 
 test-proxy: assert-dom0 ## Runs tests for SD Proxy VM
-	python3 -m unittest -v tests.test_proxy_vm
+	python3 -m unittest discover -v tests -p test_proxy_vm.py
 
 test-whonix: assert-dom0 ## Runs tests for SD Whonix VM
-	python3 -m unittest -v tests.test_sd_whonix
+	python3 -m unittest discover -v tests -p test_sd_whonix.py
 
 test-gpg: assert-dom0 ## Runs tests for SD GPG functionality
-	python3 -m unittest -v tests.test_gpg
+	python3 -m unittest discover -v tests -p test_gpg.py
 
 validate: assert-dom0 ## Checks for local requirements in dev env
 	@./scripts/validate_config.py


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #622

Use of the `discover` subcommand for test discovery ensures the "base" module is correctly imported.

## Testing

1. Run `make test-base` in `dom0` _without_ the changes in this PR
- [ ] Observe that you can reproduce #622
2. Run `make clone` against this branch, then run the individual subtargets for tests declared in the Makefile.
- [ ] Observe that all tests are now running as expected

## Checklist

- [x] All tests (`make test`) pass in `dom0` of a Qubes install
- [ ] This PR adds/removes files, and includes required updates to the packaging
      logic in `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`
