### PR TITLE
ensure default config backed up by qa switcher script

### DIFF
--- a/dom0/sd-clean-all.sls
+++ b/dom0/sd-clean-all.sls
@@ -45,7 +45,9 @@ remove-dom0-sdw-config-files:
       - /etc/qubes-rpc/policy/securedrop.Proxy
       - /home/{{ gui_user }}/Desktop/securedrop-launcher.desktop
       - /home/{{ gui_user }}/.securedrop_launcher
-
+      - /srv/salt/qa-switch.tar.gz
+      - /srv/salt/qa-switch
+      - /srv/salt/consolidation-qa-switch.sh
 
 # Remove any custom RPC policy tags added to non-SecureDrop VMs by the user
 remove-rpc-policy-tags:

--- a/utils/qa-switch.sh
+++ b/utils/qa-switch.sh
@@ -17,11 +17,11 @@ qubesctl --show-output --targets dom0 state.apply qa-switch.dom0
 export template_list="sd-app-buster-template sd-devices-buster-template sd-log-buster-template sd-proxy-buster-template sd-viewer-buster-template securedrop-workstation-buster whonix-gw-15"
 
 echo Updating Debian-based templates:
-for t in $template_list; do echo Updating $t...; qubesctl --show-output --skip-dom0 --targets $t state.apply switch.buster; done
+for t in $template_list; do echo Updating $t...; qubesctl --show-output --skip-dom0 --targets $t state.apply qa-switch.buster; done
 
 echo Replacing prod config YAML...
 
-if [ ! -f "/srv/salt/qa-switcher/sd-default-config.yml.orig" ]; then
+if [ ! -f "/srv/salt/qa-switch/sd-default-config.yml.orig" ]; then
   cp sd-default-config.yml qa-switch/sd-default-config.yml.orig
 fi
 cp qa-switch/sd-qa-config.yml sd-default-config.yml


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Minor fix to switcher script - it wasn't backing up the default config and was using template-consolidation pool if old version of switcher script was present.

QA-only.