### PR TITLE
Switch test from `lsof` to `lslocks` to unbreak CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,6 @@ jobs:
             virtualenv .venv
             source .venv/bin/activate
             pip install --require-hashes -r dev-requirements.txt
-            sudo apt install lsof
             make test && make bandit
 
 workflows:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #657

As noted on the issue, running `lsof` in CircleCI results in output discrepancies with local runs, even when the same job is run [locally against the same container image using the CircleCI CLI](https://circleci.com/docs/2.0/local-cli/#run-a-job-in-a-container-on-your-machine). This was not always the case, so there may have been an upstream configuration change beyond our control.

`lslocks` is somewhat more predictable, though as this [job run result](https://app.circleci.com/pipelines/github/freedomofpress/securedrop-workstation/328/workflows/c1d8c688-992e-469b-bab5-37e864664469/jobs/3545) illustrates, the `lslocks` output when run in a CircleCI container does not include the filename. 

The tests as written here pass locally and in CI. As a small bonus, the command is already available in the container we're currently using.

## Checklist
- [x] Linter (`make flake8`) passes in the development environment