### PR TITLE
Update sd-viewer MIME type test for mp4 audio

### DIFF
--- a/tests/vars/sd-viewer.mimeapps
+++ b/tests/vars/sd-viewer.mimeapps
@@ -12,6 +12,7 @@ application/vnd.openxmlformats-officedocument.spreadsheetml.sheet=libreoffice-ba
 application/vnd.openxmlformats-officedocument.presentationml.presentation=libreoffice-base.desktop
 application/pdf=org.gnome.Evince.desktop
 application/x-desktop=org.gnome.gedit.desktop
+audio/mp4=audacious.desktop
 audio/mpeg=audacious.desktop
 audio/x-vorbis+ogg=audacious.desktop
 audio/x-wav=audacious.desktop


### PR DESCRIPTION
## Status

Ready for review, dependent on https://github.com/freedomofpress/securedrop-debian-packaging/pull/224 and should be reviewed together.

## Description of Changes

Resolves #664

## Test plan

- After testing https://github.com/freedomofpress/securedrop-debian-packaging/pull/224, update your `dom0` copy via `make clone-norpm` in `dom0`; ensure that `config.json` and private key are available
- Run `make test`
- [x] Observe that tests are still passing