### PR TITLE
Removes migration flag from postinst

### DIFF
--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -131,8 +131,6 @@ find /srv/salt -maxdepth 1 -type f -iname '*.top' \
     | xargs -n1 basename \
     | sed -e 's/\.top$$//g' \
     | xargs qubesctl top.enable > /dev/null
-mkdir -p /tmp/sdw-migrations
-touch /tmp/sdw-migrations/mailcap-hardening
 
 %changelog
 * Wed Mar 10 2021 SecureDrop Team <securedrop@freedom.press> - 0.5.3


### PR DESCRIPTION


## Status

Ready for review  

## Description of Changes
Partially reverts 6cf625ce3f02dbce0b7516e2059b6c345a82956c.
Disables the automatic creation of a migrate-everything ask of the GUI
updater. We only want that migration to run once, so let's remove the
postinst task prior to the next prod release.

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

## Checklist

### If you have made code changes

- [ ] Linter (`make flake8`) passes in the development environment (this box may
      be left unchecked, as `flake8` also runs in CI)

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0` of a Qubes install

- [ ] This PR adds/removes files, and includes required updates to the packaging
      logic in `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`
