### PR TITLE
Make DBUS session check more resilient

### DIFF
--- a/dom0/update-xfce-settings
+++ b/dom0/update-xfce-settings
@@ -13,6 +13,11 @@ set -e
 set -u
 set -o pipefail
 
+if [[ $EUID -eq 0 ]]; then
+   echo "This script should not be run as root; it must be run as a user with an active login session."
+   exit 1
+fi
+
 TASK=${1:-none}
 ICONSIZE=64
 
@@ -23,10 +28,7 @@ fi
 
 # This script requires a valid DBUS session to work. When run non-interactively,
 # we assume that a sesssion is running for the current user.
-if [ -z "${DBUS_SESSION_BUS_ADDRESS:-}" ]; then
-   export DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/$(id -u)/bus"
-fi
-
+export DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/$(id -u $USER)/bus"
 
 if [[ $TASK == "disable-unsafe-power-management" ]]; then
   echo "update-xfce-settings: Disabling unsafe power management options for user $USER"


### PR DESCRIPTION
We should always ensure that the DBUS session is set to the logged in user, who should not be root.

Towards #668 

## Status

Ready for review

## Test plan

1. Configure your environment to `staging`
2. Check out this branch in `dom0` via `make clone`
3. Build a staging env via `make staging`
4. - [ ] Observe that `update-xfce-settings` runs successfully
5. Attempt to run the `update-xfce-settings` script as root
6. - [ ] Observe that you can't