### PR TITLE
Add error handling for full state runs; fix apply_dom0 error handling

### DIFF
--- a/launcher/sdw_updater_gui/UpdaterApp.py
+++ b/launcher/sdw_updater_gui/UpdaterApp.py
@@ -185,9 +185,8 @@ class UpgradeThread(QThread):
 
         # apply dom0 state
         self.progress_signal.emit(10)
-        result = Updater.apply_dom0_state()
         # add to results dict, if it fails it will show error message
-        results["apply_dom0"] = result.value
+        results["apply_dom0"] = Updater.apply_dom0_state()
 
         self.progress_signal.emit(15)
         # rerun full config if dom0 checks determined it's required,
@@ -195,7 +194,8 @@ class UpgradeThread(QThread):
         if Updater.migration_is_required():
             # Progress bar will freeze for ~15m during full state run
             self.progress_signal.emit(35)
-            Updater.run_full_install()
+            # add to results dict, if it fails it will show error message
+            results["apply_all"] = Updater.run_full_install()
             self.progress_signal.emit(75)
         else:
             upgrade_generator = Updater.apply_updates(progress_start=15, progress_end=75)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #668 (together with #684; will file separate issue for logging improvements)
Fixes #685

## Testing

### Fix for #668
1. Install an RPM from this branch (either via `make staging` or `dnf reinstall` of the built RPM after `make clone`)
2. Ensure a migration flag is present in `/tmp/sdw-migrations` (this will be the case after an RPM install until #667 is merged)
3. Modify your copy of  `/usr/share/securedrop-workstation-dom0-config/scripts/provision-all` to `exit 1` immediately
4. Run the updater with `/opt/securedrop/launcher/sdw-launcher.py --skip-delta 0`
5. - [ ] Observe that the updater ultimately reports an error
6. - [ ] Observe that the `apply_all` error is logged in `~/.securedrop_launcher/logs/launcher.log`
7. - [ ] Observe that the migration flag is still present (i.e. the updater will try again)
7. Undo your modification to  `/usr/share/securedrop-workstation-dom0-config/scripts/provision-all` 

### Fix for #685
1. Install an RPM from this branch (either via `make staging` or `dnf reinstall` of the built RPM after `make clone)
2. Remove `/tmp/sdw-migrations` if it exists
3. Modify your copy of `/srv/salt/update-xfce-settings` to `exit 1` immediately
4. Run the updater with `/opt/securedrop/launcher/sdw-launcher.py --skip-delta 0`
5. - [ ] Observe that the updater ultimately reports an error
6. - [ ] Observe that the `apply_dom0` error is logged in `~/.securedrop_launcher/logs/launcher.log`
7. Undo your modification to `/srv/salt/update-xfce-settings`
