### PR TITLE
Add detailed logging to separate logfile

### DIFF
--- a/launcher/Makefile
+++ b/launcher/Makefile
@@ -8,7 +8,7 @@ bandit:
 
 .PHONY: test
 test:
-	pytest --cov-report term-missing --cov=sdw_notify --cov=sdw_updater_gui/ --cov=sdw_util -v tests/
+	python -m pytest --cov-report term-missing --cov=sdw_notify --cov=sdw_updater_gui/ --cov=sdw_util -v tests/
 
 black: ## Runs the black code formatter on the launcher code
 	black --check --line-length=100 .

--- a/launcher/sdw-launcher.py
+++ b/launcher/sdw-launcher.py
@@ -4,7 +4,6 @@ from sdw_util import Util
 from sdw_updater_gui import Updater
 from sdw_updater_gui.UpdaterApp import launch_securedrop_client
 from sdw_updater_gui.Updater import should_launch_updater
-import logging
 import sys
 import argparse
 
@@ -36,8 +35,9 @@ def launch_updater():
 
 
 def main(argv):
-    sdlog = logging.getLogger(__name__)
     Util.configure_logging(Updater.LOG_FILE)
+    Util.configure_logging(Updater.DETAIL_LOG_FILE, Updater.DETAIL_LOGGER_PREFIX, backup_count=10)
+    sdlog = Util.get_logger()
     lock_handle = Util.obtain_lock(Updater.LOCK_FILE)
     if lock_handle is None:
         # Preflight updater already running or problems accessing lockfile.

--- a/launcher/sdw_notify/Notify.py
+++ b/launcher/sdw_notify/Notify.py
@@ -2,12 +2,12 @@
 Utility library for warning the user that security updates have not been applied
 in some time.
 """
-import logging
 import os
 
 from datetime import datetime
+from sdw_util import Util
 
-sdlog = logging.getLogger(__name__)
+sdlog = Util.get_logger(module=__name__)
 
 # The directory where status files and logs are stored
 BASE_DIRECTORY = os.path.join(os.path.expanduser("~"), ".securedrop_launcher")

--- a/launcher/sdw_updater_gui/UpdaterApp.py
+++ b/launcher/sdw_updater_gui/UpdaterApp.py
@@ -2,7 +2,6 @@ from sdw_updater_gui import strings
 from sdw_updater_gui import Updater
 from sdw_updater_gui.Updater import UpdateStatus
 from sdw_util import Util
-import logging
 import subprocess
 import sys
 
@@ -16,7 +15,7 @@ else:
     from sdw_updater_gui.UpdaterAppUi import Ui_UpdaterDialog
 
 
-logger = logging.getLogger(__name__)
+logger = Util.get_logger(module=__name__)
 
 
 def launch_securedrop_client():

--- a/launcher/tests/test_util.py
+++ b/launcher/tests/test_util.py
@@ -289,3 +289,16 @@ def test_pick_bad_qt(
         "Util.OS_RELEASE_FILE", os.path.join(FIXTURES_PATH, "os-release-qubes-4.0")
     ), pytest.raises(ValueError):
         util.get_qt_version()
+
+
+def test_get_logger():
+    """
+    Test whether the logging utility functions returns namespaced loggers in
+    the `prefix.module` format.
+    """
+    test_prefix = "potato"
+    test_module = "salad"
+    logger = util.get_logger(prefix=test_prefix)
+    assert logger.name == test_prefix
+    logger = util.get_logger(prefix=test_prefix, module=test_module)
+    assert logger.name == "{}.{}".format(test_prefix, test_module)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #688

Makes our logging logic more flexible to configure multiple loggers that write to different logfiles, so `launcher.log` continues to be useful as a high level overview of all update events. Detailed information is written to `launcher-detail.log`, which is also rotated out after 10 copies.

To enable this additional logging, this PR switches the relevant subprocess calls from `check_call` to `check_output`. It distinguishes between success & error state, but logs in both cases.

## Testing

(Estimated wall time ~30 minutes, but mostly waiting.)

1. `make clone` this branch into `dom0` and `sudo dnf reinstall` (or `make staging` if you don't have a previously provisioned environment) the freshly built RPM from `rpm-build/RPMS/noarch`.
2. Remove or relocate the contents of `~/.securedrop_launcher/logs` so you can see the behavior with newly created log files.
3. In `dom0`, `mkdir /tmp/sdw-migrations && touch /tmp/sdw-migrations/potato`. This will force a full `sdw-admin --apply` run on the next update.
4. In `dom0`, run `/opt/securedrop/launcher/sdw-launcher.py --skip-delta 0`. This will force an updater run.
5. Look at the logs in `~/.securedrop_launcher/logs`
6. - [ ] Observe that `launcher-detail.log` contains output from `sudo qubesctl --show-output state.highstate` and from `sdw-admin --apply`
7. Modify the file `/srv/salt/update-xfce-settings` and insert an `echo XYZZY && exit 1` statement after the `set` statements. This is how we'll cause all Salt runs to error out.
8. Repeat steps 3 to 5.
9. - [ ] Observe that `launcher.log` contains error log entries pointing to `launcher-detail.log`
10. - [ ] Observe that `launcher-detail.log` contains error logs containing the full Salt output and the XYZZY magic word we had the script insert
11. Undo your modification from step 7 to restore the environment to a working state
  
## Checklist

- [x] Linter (`make flake8`) passes in the development environment (this box may
      be left unchecked, as `flake8` also runs in CI)
