### PR TITLE
Switch to fedora-33 for sys-* VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ When developing on the Workstation, make sure to edit files in `sd-dev`, then co
 
 The staging environment is intended to provide an experience closer to a production environment. For example, it will alter power management settings on your laptop to prevent suspending it to disk, and make other changes that may not be desired during day-to-day development in Qubes.
 
-#### Update `dom0`, `fedora-32`, `whonix-gw-15` and `whonix-ws-15` templates
+#### Update `dom0`, `fedora-33`, `whonix-gw-15` and `whonix-ws-15` templates
 
 Updates to these VMs will be provided by the installer and updater, but to ensure they are up to date prior to install, it will be easier to debug, should something go wrong.
 

--- a/dom0/sd-clean-all.sls
+++ b/dom0/sd-clean-all.sls
@@ -5,7 +5,7 @@
 
 set-fedora-as-default-dispvm:
   cmd.run:
-    - name: qvm-check fedora-32-dvm && qubes-prefs default_dispvm fedora-32-dvm || qubes-prefs default_dispvm ''
+    - name: qvm-check fedora-33-dvm && qubes-prefs default_dispvm fedora-33-dvm || qubes-prefs default_dispvm ''
 
 {% set gui_user = salt['cmd.shell']('groupmems -l -g qubes') %}
 

--- a/dom0/sd-clean-default-dispvm.sls
+++ b/dom0/sd-clean-default-dispvm.sls
@@ -3,4 +3,4 @@
 
 set-fedora-as-default-dispvm:
   cmd.run:
-    - name: qvm-check fedora-32-dvm && qubes-prefs default_dispvm fedora-32-dvm || qubes-prefs default_dispvm ''
+    - name: qvm-check fedora-33-dvm && qubes-prefs default_dispvm fedora-33-dvm || qubes-prefs default_dispvm ''

--- a/dom0/sd-sys-vms.sls
+++ b/dom0/sd-sys-vms.sls
@@ -9,7 +9,7 @@ include:
   # DispVM is created
   - qvm.default-dispvm
 
-{% set sd_supported_fedora_version = 'fedora-32' %}
+{% set sd_supported_fedora_version = 'fedora-33' %}
 
 # Install latest templates required for SDW VMs.
 dom0-install-fedora-template:

--- a/launcher/sdw_updater_gui/Updater.py
+++ b/launcher/sdw_updater_gui/Updater.py
@@ -38,7 +38,7 @@ detail_log = Util.get_logger(prefix=DETAIL_LOGGER_PREFIX, module=__name__)
 # as well as their associated TemplateVMs.
 # In the future, we could use qvm-prefs to extract this information.
 current_vms = {
-    "fedora": "fedora-32",
+    "fedora": "fedora-33",
     "sd-viewer": "sd-large-buster-template",
     "sd-app": "sd-small-buster-template",
     "sd-log": "sd-small-buster-template",

--- a/launcher/tests/test_updater.py
+++ b/launcher/tests/test_updater.py
@@ -500,7 +500,7 @@ def test_shutdown_and_start_vms(
         call("sys-usb"),
     ]
     template_vm_calls = [
-        call("fedora-32"),
+        call("fedora-33"),
         call("sd-large-buster-template"),
         call("sd-small-buster-template"),
         call("whonix-gw-15"),
@@ -548,7 +548,7 @@ def test_shutdown_and_start_vms_sysvm_fail(
         call("sd-log"),
     ]
     template_vm_calls = [
-        call("fedora-32"),
+        call("fedora-33"),
         call("sd-large-buster-template"),
         call("sd-small-buster-template"),
         call("whonix-gw-15"),

--- a/scripts/build-dom0-rpm
+++ b/scripts/build-dom0-rpm
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Builds RPMs for installation in dom0. RPMs are fully reproducible.
-# Targets F25 & F32 for Qubes 4.0 and 4.1 support.
+# Targets fedora-25 & fedora-32 for Qubes 4.0 and 4.1 support.
 set -e
 set -u
 set -o pipefail
@@ -28,9 +28,9 @@ export SOURCE_DATE_EPOCH
 cp dist/*.tar.gz rpm-build/SOURCES/
 
 # Build for Qubes 4.0.x and 4.1.x, for which dom0 is based on
-# F25 and F32, respectively.
+# fedora-25 and fedora-32, respectively.
 for i in 25 32; do
-    # dom0 defaults to python3.5 in F25
+    # dom0 defaults to python3.5 in fedora-25
     python_version="python3.5"
     if [[ $i = 32 ]]; then
         python_version="python3.8"

--- a/scripts/prep-dev
+++ b/scripts/prep-dev
@@ -12,7 +12,7 @@ dom0_dev_dir="$HOME/securedrop-workstation"
 
 function find_latest_rpm() {
     # Look up which version of dom0 we're using.
-    # Qubes 4.0 is fc25, Qubes 4.1 will be fc32.
+    # Qubes 4.0 is fedora-25, Qubes 4.1 will be fedora-32.
     fedora_version="$(rpm --eval '%{fedora}')"
     find "${dom0_dev_dir}/rpm-build/RPMS/" -type f -iname "*fc${fedora_version}.noarch.rpm" -print0 | xargs -0 ls -t | head -n 1
 }

--- a/tests/base.py
+++ b/tests/base.py
@@ -7,7 +7,7 @@ from qubesadmin import Qubes
 
 # Reusable constant for DRY import across tests
 WANTED_VMS = ["sd-gpg", "sd-log", "sd-proxy", "sd-app", "sd-viewer", "sd-whonix", "sd-devices"]
-CURRENT_FEDORA_VERSION = "32"
+CURRENT_FEDORA_VERSION = "33"
 CURRENT_FEDORA_TEMPLATE = "fedora-" + CURRENT_FEDORA_VERSION
 CURRENT_WHONIX_VERSION = "15"
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #691 (co-authored with @conorsch).

## Test plan

### Update scenario

1. Provision a staging environment from current `main`, or enforce the state of an existing, up-to-date staging environment via `sdw-admin --apply`.
2. Ensure that you do not have a `fedora-33` template present on your system from prior runs or a manual update. If necessary, remove the template with `sudo dnf remove qubes-template-fedora-33`.
3. `make clone` this branch into `dom0` and `sudo dnf reinstall` the freshly built RPM from `rpm-build/RPMS/noarch`.
4. Run the updater with `/opt/securedrop/launcher/sdw-launcher.py --skip-delta 0`.
4. - [ ] Observe that the update completes successfully
5. - [ ] Observe that the `fedora-33` template is now installed
6. - [ ] Observe that  `qvm-ls | grep fedora` shows that sys-net, sys-usb, and sys-firewall are all based on `fedora-33`. 
7. - [ ] Observe that  `qvm-prefs default-mgmt-dvm template` shows `fedora-33`
8. - [ ] Observe that `dom0` tests are passing (ensure that `config.json` and `sd-journalist.sec` are present).

### Fresh install scenario

1. Uninstall the SecureDrop Workstation via `sdw-admin --uninstall`
2. Ensure that you do not have a `fedora-33` template present on your system from prior runs or a manual update. If necessary, remove the template with `sudo dnf remove qubes-template-fedora-33`.
3. `make clone` this branch into `dom0` and run `make staging`
4. - [ ] Observe that the installation completes successfully
5. - [ ] Observe that the `fedora-33` template is now installed
6. - [ ] Observe that  `qvm-ls | grep fedora` shows that sys-net, sys-usb, and sys-firewall are all based on `fedora-33`. 
7. - [ ] Observe that  `qvm-prefs default-mgmt-dvm template` shows `fedora-33`
8. - [ ] Observe that `dom0` tests are passing (ensure that `config.json` and `sd-journalist.sec` are present).
