### PR TITLE
Change to "install QubesOS 4.0.4"

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The project is currently in a closed beta, and we do not recommend installing it
 
 ### Install Qubes
 
-Before trying to use this project, install [Qubes 4.0.3](https://www.qubes-os.org/downloads/) on your development machine. Accept the default VM configuration during the install process.
+Before trying to use this project, install [Qubes 4.0.4](https://www.qubes-os.org/downloads/) on your development machine. Accept the default VM configuration during the install process.
 
 After installing Qubes, you must update both dom0 and the base templates to include the latest versions of apt packages. Open a terminal in `dom0` by clicking on the Qubes menu top-right of the screen and left-clicking on Terminal Emulator and run:
 


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes
Changed "Before trying to use this project, install Qubes 4.0.3 on your development machine." to "Before trying to use this project, install Qubes 4.0.4 on your development machine."
Qubes OS has a new point-release. 4.0.3 is not easily downloadable anymore.

## Testing

N/A

## Checklist

### If you have made code changes

N/A

### If you have made changes to the provisioning logic

N/A
