### PR TITLE
Use correct VM name for mimetype handling

### DIFF
--- a/dom0/sd-mime-handling.sls
+++ b/dom0/sd-mime-handling.sls
@@ -20,7 +20,8 @@ sd-private-volume-mimeapps-config-dir:
     - makedirs: True
     - mode: "0755"
 
-{% if grains['id'] in ["sd-viewer", "sd-app", "sd-devices-dvm"] %}
+{% set vm_name = salt['cmd.shell']('qubesdb-read /name') %}
+{% if vm_name in ["sd-viewer", "sd-app", "sd-devices-dvm"] %}
 
 sd-private-volume-mimeapps-handling:
   file.symlink:


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Intended to address #705. 

We've observed inconsistent symlinking based on "grains.id", which resolve to the VM hostname in all cases. Let's instead call out to `qubesdb-read /name`, which sidesteps all Salt machinery, and polls for the VM name via the configuration API.

## Testing

1. Set up a _prod_ install, fully updated
2. Make sure you can reproduce a failing DispVM setup, as described in #705. For example, run `ln -sf /opt/sdw/mimeapps.list.sd-default ~/.local/share/applications/mimeapps.list` inside `sd-viewer` to break it. You should confirm inside SecureDrop Client that DispVMs fail to open submissions.
3. Run `make clone` to fetch these changes into dom0
4. Manually install the freshly fetched rpm package with `sudo dnf reinstall <rpm>`
5. Run `sdw-admin --apply` to do a full state run. 
6. Re-test the DispVM setup. Is it fixed?
