### PR TITLE
Updates VM tests for 2021 key expiry

### DIFF
--- a/tests/test_qubes_rpc.py
+++ b/tests/test_qubes_rpc.py
@@ -20,7 +20,7 @@ class SD_Qubes_Rpc_Tests(unittest.TestCase):
         for policy in self.expected:
             if not self._startsWith(policy["policy"], policy["starts_with"]):
                 fail = True
-        self.assertFalse(fail)
+        self.assertFalse(fail), "Policy does not match: " + policy["policy"]
 
     def _startsWith(self, filename, expectedPolicy):
         filePath = os.path.join(QUBES_POLICY_DIR, filename)


### PR DESCRIPTION

## Status

Ready for review

## Description of Changes

Now that the old signing key has expired, the message has changed somewhat: "expires" -> "expired". Also fixed an outdated dnf check to expect the gpg verification output. I updated the logic in the tests to be a bit friendlier to edit over time, such as using a multiline string rather than a list of stdout lines. 

Addresses the final checkbox for fixing the tests in https://github.com/freedomofpress/qubes-template-securedrop-workstation/issues/20


## Testing

```
make clone
make test
```

All tests should be passing. If you haven't run the updater recently, you may see some failed tests due to uninstalled nightlies. Apply those changes, and make sure you see 100% of tests passing. 

## Deployment
None, test-only.
