### PR TITLE
Bump kernel version in tests to 4.14.241

### DIFF
--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -5,7 +5,7 @@ from qubesadmin import Qubes
 from base import WANTED_VMS
 
 
-EXPECTED_KERNEL_VERSION = "4.14.186-grsec-workstation"
+EXPECTED_KERNEL_VERSION = "4.14.241-grsec-workstation"
 
 
 class SD_VM_Tests(unittest.TestCase):


### PR DESCRIPTION
## Status
Ready for review

## Description of Changes

Matches recent version bump, currently being tested via apt-test.

Towards https://github.com/freedomofpress/securedrop-workstation/issues/717


## Testing
- `make clone && make dev && make test`

## Deployment

Test-only, although these new kernels will be released to prod in the near future (after further testing, tracked in #717).