### PR TITLE
Honor oldstable repo config for Debian 10 Buster

### DIFF
--- a/dom0/fpf-apt-repo.sls
+++ b/dom0/fpf-apt-repo.sls
@@ -2,16 +2,30 @@
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 #
 
-# Import the Qubes-maintained Salt logic for upgrading VM packages.
-# Intelligently handles both Debian & Fedora VMs. For reference, see:
+# Don't start with the Qubes-maintained Salt logic for upgrading VM packages:
 #
 #   dom0:/srv/formulas/base/update-formula/update/qubes-vm.sls
 #
-include:
-  - update.qubes-vm
+# We want to make sure that certain maintenance tasks like cleaning out
+# old packages and updating apt lists are handled first, otherwise
+# the subsequent tasks will fail. For reference
+# include:
+#  - update.qubes-vm
 #  - sd-default-config
 
 {% from 'sd-default-config.sls' import sdvars with context %}
+
+# Debian Buster was changed from 'stable' to 'oldstable' on 2021-08,
+# so honor that change in the apt sources.
+update-apt-cache-with-stable-change:
+  cmd.run:
+    - name: apt-get update --allow-releaseinfo-change
+
+autoremove-old-packages:
+  cmd.run:
+    - name: apt-get autoremove -y
+    - require:
+      - cmd: update-apt-cache-with-stable-change
 
 # That's right, we need to install a package in order to
 # configure a repo to install another package
@@ -19,10 +33,10 @@ install-python-apt-for-repo-config:
   pkg.installed:
     - pkgs:
       - python-apt
+      - python3-apt
     - require:
-      # Require that the Qubes update state has run first. Doing so
-      # will ensure that apt is sufficiently patched prior to installing.
-      - sls: update.qubes-vm
+      - cmd: update-apt-cache-with-stable-change
+      - cmd: autoremove-old-packages
 
 configure-fpf-apt-repo:
   pkgrepo.managed:
@@ -32,6 +46,15 @@ configure-fpf-apt-repo:
     - clean_file: True # squash file to ensure there are no duplicates
     - require:
       - pkg: install-python-apt-for-repo-config
+
+upgrade-all-packages:
+  pkg.uptodate:
+    # Update apt lists again, since they were updated before FPF repo was added.
+    - refresh: True
+    - dist_upgrade: True
+    - require:
+      - pkgrepo: configure-fpf-apt-repo
+      - cmd: update-apt-cache-with-stable-change
 
 # This will install the production keyring package. This package will delete
 # the prod key from the default keyring in /etc/apt/trusted.gpg but will

--- a/dom0/fpf-apt-repo.sls
+++ b/dom0/fpf-apt-repo.sls
@@ -24,7 +24,7 @@ install-python-apt-for-repo-config:
       # will ensure that apt is sufficiently patched prior to installing.
       - sls: update.qubes-vm
 
-configure-apt-test-apt-repo:
+configure-fpf-apt-repo:
   pkgrepo.managed:
     - name: "deb [arch=amd64] {{ sdvars.apt_repo_url }} {{ grains['oscodename'] }} main"
     - file: /etc/apt/sources.list.d/securedrop_workstation.list
@@ -41,4 +41,4 @@ install-securedrop-keyring-package:
     - pkgs:
       - securedrop-keyring
     - require:
-      - pkgrepo: configure-apt-test-apt-repo
+      - pkgrepo: configure-fpf-apt-repo

--- a/dom0/sd-app-files.sls
+++ b/dom0/sd-app-files.sls
@@ -9,7 +9,7 @@
 #
 ##
 include:
-  - fpf-apt-test-repo
+  - fpf-apt-repo
   - sd-logging-setup
 
 # FPF repo is setup in "securedrop-workstation" template
@@ -18,4 +18,4 @@ install-securedrop-client-package:
     - pkgs:
       - securedrop-client
     - require:
-      - sls: fpf-apt-test-repo
+      - sls: fpf-apt-repo

--- a/dom0/sd-devices-files.sls
+++ b/dom0/sd-devices-files.sls
@@ -9,7 +9,7 @@
 #
 ##
 include:
-  - fpf-apt-test-repo
+  - fpf-apt-repo
   - sd-logging-setup
 
 # Libreoffice needs to be installed here to convert to pdf to allow printing
@@ -26,4 +26,4 @@ sd-devices-install-package:
   pkg.installed:
     - name: securedrop-export
     - require:
-      - sls: fpf-apt-test-repo
+      - sls: fpf-apt-repo

--- a/dom0/sd-logging-setup.sls
+++ b/dom0/sd-logging-setup.sls
@@ -3,7 +3,7 @@
 
 {% if grains['id'] in ["securedrop-workstation-buster", "sd-small-buster-template", "sd-large-buster-template", "whonix-gw-15"] %}
 include:
-  - fpf-apt-test-repo
+  - fpf-apt-repo
 
 # Install securedrop-log package in TemplateVMs only
 install-securedrop-log-package:
@@ -11,7 +11,7 @@ install-securedrop-log-package:
     - pkgs:
       - securedrop-log
     - require:
-      - sls: fpf-apt-test-repo
+      - sls: fpf-apt-repo
 
 # configure all VMs to send to sd-log - excluded on a per-VM basis below via /rw
 configure-rsyslog-for-sd:

--- a/dom0/sd-proxy-template-files.sls
+++ b/dom0/sd-proxy-template-files.sls
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 include:
-  - fpf-apt-test-repo
+  - fpf-apt-repo
   - sd-logging-setup
 
 # Depends on FPF-controlled apt repo, already present
@@ -11,7 +11,7 @@ install-securedrop-proxy-package:
     - pkgs:
       - securedrop-proxy
     - require:
-      - sls: fpf-apt-test-repo
+      - sls: fpf-apt-repo
 
 # Remove the legacy config file location
 remove-legacy-sd-proxy-config:

--- a/dom0/sd-viewer-files.sls
+++ b/dom0/sd-viewer-files.sls
@@ -11,7 +11,7 @@
 ##
 
 include:
-  - fpf-apt-test-repo
+  - fpf-apt-repo
   - sd-logging-setup
 
 sd-viewer-install-metapackage:
@@ -19,7 +19,7 @@ sd-viewer-install-metapackage:
     - pkgs:
       - securedrop-workstation-viewer
     - require:
-      - sls: fpf-apt-test-repo
+      - sls: fpf-apt-repo
 
 sd-viewer-install-libreoffice:
   pkg.installed:

--- a/dom0/sd-workstation-template-files.sls
+++ b/dom0/sd-workstation-template-files.sls
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 include:
-  - fpf-apt-test-repo
+  - fpf-apt-repo
 
 sd-workstation-template-install-kernel-config-packages:
   pkg.installed:
@@ -9,7 +9,7 @@ sd-workstation-template-install-kernel-config-packages:
       - securedrop-workstation-config
       - securedrop-workstation-grsec
     - require:
-      - sls: fpf-apt-test-repo
+      - sls: fpf-apt-repo
 
 # Ensure that paxctld starts immediately. For AppVMs,
 # use qvm.features.enabled = ["paxctld"] to ensure service start.

--- a/launcher/sdw_updater_gui/Updater.py
+++ b/launcher/sdw_updater_gui/Updater.py
@@ -183,7 +183,7 @@ def _apply_updates_vm(vm):
     sdlog.info("Updating {}".format(vm))
     try:
         subprocess.check_call(
-            ["sudo", "qubesctl", "--skip-dom0", "--targets", vm, "state.sls", "update.qubes-vm"]
+            ["sudo", "qubesctl", "--skip-dom0", "--targets", vm, "state.sls", "fpf-apt-repo"]
         )
     except subprocess.CalledProcessError as e:
         sdlog.error(

--- a/launcher/tests/test_updater.py
+++ b/launcher/tests/test_updater.py
@@ -318,7 +318,7 @@ def test_apply_updates_vms(mocked_info, mocked_error, mocked_call, vm):
         assert result == UpdateStatus.UPDATES_OK
 
         mocked_call.assert_called_once_with(
-            ["sudo", "qubesctl", "--skip-dom0", "--targets", vm, "state.sls", "update.qubes-vm"]
+            ["sudo", "qubesctl", "--skip-dom0", "--targets", vm, "state.sls", "fpf-apt-repo"]
         )
         assert not mocked_error.called
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Unbreaks clean installs by respecting the renaming of Debian Buster apt sources to "oldstable" by upstream Debian. Additionally, cleans up some of the apt repo config to resolve some long-standing issues. 

* Closes #721
* Closes #651
* Closes #572 

## Testing

It's critical to remove the TemplateVM RPM prior to confirming resolution. That's the "dnf remove" action below. Because the template RPM will need to be re-downloaded, expect ~600MB download to dom0. 

```
make clone && make clean
sudo dnf remove qubes-template-securedrop-workstation-buster # necessary because make clean doesn't remove TemplateVM
sudo dnf clean all
make dev
```
If you see no errors and the provisiong completes successfully, then the issue is resolved. 

## Deployment

So far, testing shows that the updater runs are not affected, so existing installs do not appear to be at risk. I don't quite understand why that is, unfortunately, other than the age of the apt lists in use. 