### PR TITLE
Don't run apt state for Fedora; remove postinst migration flag

### DIFF
--- a/launcher/sdw_updater_gui/Updater.py
+++ b/launcher/sdw_updater_gui/Updater.py
@@ -181,9 +181,16 @@ def _apply_updates_vm(vm):
     will require a reboot after the upgrade.
     """
     sdlog.info("Updating {}".format(vm))
+
+    # We run custom Salt logic for Debian-based TemplateVMs
+    if vm.startswith("fedora"):
+        salt_state = "update.qubes-vm"
+    else:
+        salt_state = "fpf-apt-repo"
+
     try:
         subprocess.check_call(
-            ["sudo", "qubesctl", "--skip-dom0", "--targets", vm, "state.sls", "fpf-apt-repo"]
+            ["sudo", "qubesctl", "--skip-dom0", "--targets", vm, "state.sls", salt_state]
         )
     except subprocess.CalledProcessError as e:
         sdlog.error(

--- a/launcher/tests/test_updater.py
+++ b/launcher/tests/test_updater.py
@@ -317,8 +317,13 @@ def test_apply_updates_vms(mocked_info, mocked_error, mocked_call, vm):
         result = updater._apply_updates_vm(vm)
         assert result == UpdateStatus.UPDATES_OK
 
+        if vm.startswith("fedora"):
+            expected_salt_state = "update.qubes-vm"
+        else:
+            expected_salt_state = "fpf-apt-repo"
+
         mocked_call.assert_called_once_with(
-            ["sudo", "qubesctl", "--skip-dom0", "--targets", vm, "state.sls", "fpf-apt-repo"]
+            ["sudo", "qubesctl", "--skip-dom0", "--targets", vm, "state.sls", expected_salt_state]
         )
         assert not mocked_error.called
 

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -131,8 +131,6 @@ find /srv/salt -maxdepth 1 -type f -iname '*.top' \
     | xargs -n1 basename \
     | sed -e 's/\.top$$//g' \
     | xargs qubesctl top.enable > /dev/null
-mkdir -p /tmp/sdw-migrations
-touch /tmp/sdw-migrations/mimetype-dispvms
 
 %changelog
 * Wed Jun 9 2021 SecureDrop Team <securedrop@freedom.press> - 0.5.5


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #724

- #722 broke fedora-33 updates because it treats Fedora-based templates like Debian-based ones. This PR distinguishes (naively based on the template name) between Debian-based and Fedora-based templates. 
- This PR also removes the postinst flag to enforce a migration, since no migration will be required as part of the next release, and it adds ~20-30 minutes to an initial update run.

## Testing

1. Update your SecureDrop workstation checkout in your dev VM to this PR's branch
2. `make clone` in `dom0`
3. `make dev` to provision a development environment
4. Run the updater (if necessary, force a run with `/opt/securedrop/launcher/sdw-launcher.py --skip-delta 0`).
5. - [ ] Observe that updates complete without errors
6. - [ ] Observe that `fedora-33` is updated successfully (inspect `launcher.log` in `~/.securedrop_launcher` for errors, and observe that `sudo dnf update` in `fedora-33` reports "Nothing to do")