### PR TITLE
Remove misleading Docker requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The development environment is just like the [Staging Environment](#staging-envi
 
 #### Download, Configure, Copy to `dom0`
 
-Decide on a VM to use for development. We recommend creating a standalone VM called `sd-dev` by following [these instructions](https://docs.securedrop.org/en/stable/development/setup_development.html#qubes). You must install Docker in that VM in order to build a development environment using the standard workflow.
+Decide on a VM to use for development. We recommend creating a standalone VM called `sd-dev` by following [these instructions](https://docs.securedrop.org/en/stable/development/setup_development.html#qubes).
 
 Clone this repo to your preferred location on that VM.
 


### PR DESCRIPTION
## Status

Ready for review 
## Description of Changes

Docker _was_ required to build RPMs until #666. It no longer is. While it can be useful if folks want to use the Docker-based _server_ environment, said environment is not actually helpful in getting a SecureDrop Workstation up and running (you need an `.onion` for that), which is what this README is focused on. So, on balance, it seems most prudent to simply remove this sentence to avoid confusion.