### PR TITLE
Add option to launch updater from sdw-notify script

### DIFF
--- a/dom0/sd-dom0-crontab.sls
+++ b/dom0/sd-dom0-crontab.sls
@@ -17,4 +17,4 @@ dom0-crontab-update-notify:
     - marker_start: "### BEGIN securedrop-workstation ###"
     - marker_end: "### END securedrop-workstation ###"
     - content: |
-        0 * * * * {{gui_user}} DISPLAY=:0 /opt/securedrop/launcher/sdw-notify.py
+        0 */2 * * * {{gui_user}} DISPLAY=:0 /opt/securedrop/launcher/sdw-notify.py

--- a/launcher/sdw-notify.py
+++ b/launcher/sdw-notify.py
@@ -4,18 +4,19 @@ Displays a warning to the user if the workstation has been running continuously
 for too long without checking for security updates. Writes output to a logfile,
 not stdout. All settings are in Notify utility module.
 """
-
 import sys
-
-from sdw_notify import Notify
-from sdw_updater_gui import Updater
+from sdw_notify import Notify, NotifyApp
+from sdw_updater_gui import Updater, UpdaterApp
 from sdw_util import Util
 
 if Util.get_qt_version() == 5:
     print("Using Qt5 (experimental)")
-    from PyQt5.QtWidgets import QApplication, QMessageBox
+    from PyQt5.QtWidgets import QApplication
 else:
-    from PyQt4.QtGui import QApplication, QMessageBox
+    from PyQt4.QtGui import QApplication
+
+Util.configure_logging(Notify.LOG_FILE)
+log = Util.get_logger(Notify.LOG_FILE)
 
 
 def main():
@@ -24,8 +25,6 @@ def main():
     the preflight updater is running, and certain checks suggest that the
     system has not been updated for a specified period
     """
-
-    Util.configure_logging(Notify.LOG_FILE)
 
     if Util.is_conflicting_process_running(Notify.CONFLICTING_PROCESSES):
         # Conflicting system process may be running in dom0. Logged.
@@ -52,19 +51,41 @@ def main():
 def show_update_warning():
     """
     Show a graphical warning reminding the user to check for security updates
-    using the preflight updater.
-    """
-    app = QApplication([])  # noqa: F841
+    using the Preflight Updater.
 
-    QMessageBox.warning(
-        None,
-        "Security check recommended",
-        "This computer has not been checked for security updates recently. "
-        "We recommend that you launch or restart the SecureDrop app to "
-        "check for security updates.",
-        QMessageBox.Ok,
-        QMessageBox.Ok,
-    )
+    If the user opts to check for updates, launch the Preflight Updater.
+    If the user opts to defer, they will be reminded again the next time the
+    notify script runs.
+    """
+
+    app = QApplication([])  # noqa: F841
+    dialog = NotifyApp.NotifyDialog(Util.is_sdapp_halted())
+    result = dialog.run()
+
+    # Check results of Notify Dialog and launch the Preflight Updater if user
+    # has opted to check for updates.
+    if result == NotifyApp.NotifyStatus.CHECK_UPDATES:
+        log.info("Launching Preflight Updater")
+        updater = UpdaterApp.UpdaterApp()
+        updater.show()
+        sys.exit(app.exec_())
+    elif result == NotifyApp.NotifyStatus.DEFER_UPDATES:
+        # Currently, `DEFER_UPDATES` is a no-op, because the deferral period is
+        # simply the period before the next run of the notify script (defined in
+        # `securedrop-workstation/dom0/sd-dom0-crontab.sls`).
+        log.info(
+            "User has deferred update check. sdw-notify will run "
+            "again at the next scheduled interval."
+        )
+        sys.exit(0)
+    else:
+        # NotifyApp.NotifyStatus.ERROR_UNKNOWN, meaning the dialog returned an
+        # unexpected state. The error is logged in NotifyDialog.run().
+        log.info(
+            "Unexpected result from NotifyDialog. sdw-notify will run "
+            "again at the next scheduled interval."
+        )
+        sys.exit(result)
 
 
 if __name__ == "__main__":

--- a/launcher/sdw_notify/NotifyApp.py
+++ b/launcher/sdw_notify/NotifyApp.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""
+Notification dialog that appears when user has not applied security updates
+recently. Prompts user to check for updates or defer reminder.
+"""
+from enum import Enum
+from sdw_util import Util
+from sdw_notify import Notify, strings
+
+if Util.get_qt_version() == 5:
+    print("Using Qt5 (experimental)")
+    from PyQt5.QtWidgets import QMessageBox
+else:
+    from PyQt4.QtGui import QMessageBox
+
+sdlog = Util.get_logger(Notify.LOG_FILE)
+
+
+class NotifyStatus(Enum):
+    """
+    Supported exit states from Notify dialog.
+    """
+
+    CHECK_UPDATES = "0"
+    DEFER_UPDATES = "1"
+    ERROR_UNKNOWN = "2"
+
+
+class NotifyDialog(QMessageBox):
+    """
+    Shows notification advising user that they have not checked for updates
+    recently, and offering option to check now or defer the check.
+
+    Constructor takes a boolean parameter, `is_sdapp_stopped`, which determines
+    whether a longer error message indicating the updater's impact on a
+    currently-running client session will be shown.
+    """
+
+    def __init__(self, is_sdapp_stopped: bool):
+        super().__init__()
+        self._is_sdapp_stopped = is_sdapp_stopped
+        self._ui()
+
+    def _ui(self):
+        self.setWindowTitle(strings.headline_notify_updates)
+        self.setIcon(QMessageBox.Warning)
+        self.setStandardButtons(QMessageBox.No | QMessageBox.Ok)
+        self.setDefaultButton(QMessageBox.Ok)
+        self.setEscapeButton(QMessageBox.No)
+        button_check_now = self.button(QMessageBox.Ok)
+        button_check_now.setText(strings.button_check_for_updates)
+        button_defer = self.button(QMessageBox.No)
+        button_defer.setText(strings.button_defer_check)
+
+        if self._is_sdapp_stopped:
+            self.setText(strings.description_notify_updates)
+        else:
+            self.setText(strings.description_notify_updates_sdapp_running)
+
+    def run(self) -> NotifyStatus:
+        """
+        Launch dialog and return user selection.
+        """
+        result = self.exec_()
+
+        if result == QMessageBox.Ok:
+            sdlog.info(
+                "NotfyDialog returned {}, user has opted to check for updates".format(result)
+            )
+            return NotifyStatus.CHECK_UPDATES
+        elif result == QMessageBox.No:
+            sdlog.info("NotfyDialog returned {}, user has opted to defer updates".format(result))
+            return NotifyStatus.DEFER_UPDATES
+        else:
+            # Should not occur, as this dialog which can only return
+            # one of two states.
+            sdlog.error(
+                "NotfyDialog returned unexpected value {}; consult "
+                "QMessageBox API for more information".format(result)
+            )
+            return NotifyStatus.ERROR_UNKNOWN

--- a/launcher/sdw_notify/strings.py
+++ b/launcher/sdw_notify/strings.py
@@ -1,0 +1,17 @@
+headline_notify_updates = "Security check recommended"
+
+description_notify_updates = (
+    "<p>The computer has not checked for security updates recently.</p>"
+    "<p>Would you like to check for updates now?</p>"
+)
+
+description_notify_updates_sdapp_running = (
+    "<p>The computer has not checked for security updates recently.</p>"
+    "<p><strong>Warning:</strong> Checking for updates "
+    "will interrupt your session and restart the application.</p>"
+    "<p>Would you like to check for updates now?</p>"
+)
+
+button_check_for_updates = "Check for updates"
+
+button_defer_check = "Remind me later"

--- a/launcher/sdw_util/Util.py
+++ b/launcher/sdw_util/Util.py
@@ -187,3 +187,26 @@ def strip_ansi_colors(str):
     Strip ANSI colors from command output
     """
     return re.sub(r"\u001b\[.*?[@-~]", "", str)
+
+
+def is_sdapp_halted() -> bool:
+    """
+    Helper fuction that returns True if `sd-app` VM is in a halted state
+    and False if state is running, paused, or cannot be determined.
+
+    Runs only if Qubes environment detected; otherwise returns False.
+    """
+
+    if not get_qubes_version():
+        sdlog.error("QubesOS not detected, is_sdapp_halted will return False")
+        return False
+
+    try:
+        output_bytes = subprocess.check_output(["qvm-ls", "sd-app"])
+        output_str = output_bytes.decode("utf-8")
+        return "Halted" in output_str
+
+    except subprocess.CalledProcessError as e:
+        sdlog.error("Failed to return sd-app VM status via qvm-ls")
+        sdlog.error(str(e))
+        return False


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #595 

Move Notify dialog into separate file and allow user to launch Preflight updater directly from the Notify dialog. 

Also separates out constants from Notify.py and Updater.py into a constants file (`sdw_util/Const.py`). Towards goals of a) reducing mocking of class or module internals during testing, b) reducing dependency surface/moving towards separation of UI and logic components. I've refactored Notify.py but not Updater.py to use the constants file. If this approach works for people then in a subsequent PR I'll also make some similar changes to Updater.py. 

Misc: 
- I've stuck to the [edit for clarity] camel case naming convention going on here (NotifyApp.py), but I'd be happy to switch to more typical Python naming conventions, possibly in another PR so as to keep things clean. 

- As discussed in sdw developer hangout, a separate PR will be made to begin adding UI tests for all the launcher/notifier components.

### Changes proposed in this pull request:

- Replace simple notification ("ok") with option to launch updater from sdw-notify script, or to defer reminder (deferral period is until the next time the cron job runs)
- Change cron job that runs notifier to run every 2 hours instead of hourly  

## Testing

Check out this branch in your sd dev vm.

**Manual testing**
Copy this branch to dom0 via `make clone`, then `make dev`. 

Ensure `sd-app` VM is shut down. 
Edit the file in `dom0` called `~/.securedrop_launcher/sdw-last-updated` to change the date to a date >= 5 days ago.
Run `python3 /opt/securedrop/launcher/sdw-notify.py`:
- [ ] Notification appears with prompt to check for updates. 
- [ ] No "**Warning:**" text is present in the notification
- [ ] The default selected button option is "Check for updates".
- [ ] Clicking "Remind me later" (or pressing the Esc key) closes the dialog window. Note the time.

Start `sd-app` vm via `qvm-start sd-app` in `dom0`. Wait for the notify prompt to reappear.  
- [ ] The notify prompt appears again after a delay of t < 2 hours (The reminder runs every 2 hours on the even hours. The delay will depend on what time the user dismissed the dialog). 
- [ ] This time, the "**Warning:**" text is present in the notification
- [ ] Clicking "Check for updates" launches the Preflight Updater.  
- [ ] The Preflight Updater can run updates successfully. 
- [ ] No GTK warnings or other errors are generated or printed to the `dom0` console when the Preflight Updater is launched.

**Automated testing**
- [ ] All tests pass

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing pilot instances
2. New installs

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation