### PR TITLE
Check for network connection before running preflight updater

### DIFF
--- a/launcher/sdw-launcher.py
+++ b/launcher/sdw-launcher.py
@@ -20,16 +20,17 @@ DEFAULT_INTERVAL = 28800  # 8hr default for update interval
 def parse_argv(argv):
     parser = argparse.ArgumentParser()
     parser.add_argument("--skip-delta", type=int)
+    parser.add_argument("--skip-netcheck", action="store_true")
     return parser.parse_args(argv)
 
 
-def launch_updater():
+def launch_updater(should_skip_netcheck: bool = False):
     """
-    Start the updater GUI
+    Start the updater GUI.
     """
 
     app = QApplication(sys.argv)
-    form = UpdaterApp()
+    form = UpdaterApp(should_skip_netcheck)
     form.show()
     sys.exit(app.exec_())
 
@@ -58,7 +59,7 @@ def main(argv):
     interval = int(args.skip_delta)
 
     if should_launch_updater(interval):
-        launch_updater()
+        launch_updater(args.skip_netcheck)
     else:
         launch_securedrop_client()
 

--- a/launcher/sdw_updater_gui/strings.py
+++ b/launcher/sdw_updater_gui/strings.py
@@ -39,3 +39,9 @@ description_status_rebooting = ""
 
 headline_status_error_reboot = "Error rebooting Workstation"
 description_error_reboot = "<p>Please contact your administrator.</p>"
+
+headline_error_network = "Network Unavailable"
+description_error_network = (
+    "<p>A network error was encountered while attempting to update.</p>"
+    "<p>Please check network settings and try again.</p>"
+)

--- a/launcher/tests/test_updaterapp.py
+++ b/launcher/tests/test_updaterapp.py
@@ -1,0 +1,144 @@
+import os
+import pytest
+import subprocess
+from unittest import TestCase
+from unittest import mock
+from unittest.mock import call
+from importlib.machinery import SourceFileLoader
+
+# Set at commandline to allow for testing of PyQt4 or PyQt5
+# (PyQt4 support will be dropped when Qubes 4.0 is no longer supported)
+PYQT_ENV = "SDW_UPDATER_QT"
+
+if os.environ.get(PYQT_ENV) == "5":
+    from PyQt5.QtWidgets import QApplication, QDialog
+    from PyQt5.QtCore import QThread, pyqtSignal, pyqtSlot
+    from sdw_updater_gui.UpdaterAppUiQt5 import Ui_UpdaterDialog
+else:
+    from PyQt4.QtGui import QApplication, QDialog
+    from PyQt4.QtCore import QThread, pyqtSignal, pyqtSlot
+    from sdw_updater_gui.UpdaterAppUi import Ui_UpdaterDialog
+
+relpath_updaterapp_script = "../sdw_updater_gui/UpdaterApp.py"
+path_to_script = os.path.join(os.path.dirname(os.path.abspath(__file__)), relpath_updaterapp_script)
+updater_app = SourceFileLoader("UpdaterApp", path_to_script).load_module()
+
+relpath_strings_script = "../sdw_updater_gui/strings.py"
+path_to_script = os.path.join(os.path.dirname(os.path.abspath(__file__)), relpath_strings_script)
+strings = SourceFileLoader("strings", path_to_script).load_module()
+
+
+class TestUpdaterApp(TestCase):
+    _app = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls._app = QApplication([])  # noqa: F841
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._app.quit()
+
+    @mock.patch("UpdaterApp.Util.get_qubes_version", return_value="4.0")
+    @mock.patch("UpdaterApp.subprocess.check_output", return_value=b"none")
+    def test_netcheck_no_network_should_fail(self, mocked_output, mocked_qubes_version):
+        """
+        When the host machine has no network connectivity
+        Then the error is logged
+         And netcheck returns False
+        """
+        assert not updater_app._is_netcheck_successful()
+
+    @mock.patch("Util.get_qubes_version", return_value=None)
+    @mock.patch("UpdaterApp.logger.error")
+    def test_netcheck_no_qubes_should_fail_with_error(self, mocked_error, mocked_qubes_version):
+        """
+        When the network connectivity check is run outside of Qubes
+        Then the check should return not succeed
+         And an error should be logged
+        """
+        assert not updater_app._is_netcheck_successful()
+        assert mocked_error.called
+
+    @mock.patch("subprocess.check_output", return_value=b"full")
+    @mock.patch("UpdaterApp.Util.get_qubes_version", return_value="4.0")
+    def test_netcheck_should_succeed(self, mocked_qubes_version, mocked_output):
+        """
+        When the network connectivity check is run in Qubes
+         And nmcli detects a connection
+        Then the network check should succeed
+        """
+        assert updater_app._is_netcheck_successful()
+
+    @mock.patch("UpdaterApp.Util.get_qubes_version", return_value="4.0")
+    @mock.patch("UpdaterApp.logger.error")
+    @mock.patch("subprocess.check_output", return_value=b"none")
+    def test_updater_app_with_no_connectivity_should_error(
+        self, mocked_output, mocked_error, mocked_qubes_version
+    ):
+        """
+        When the netcheck method is run
+         And the network check is unsuccessful
+        Then the network error view should be visible
+        """
+        updater_app_dialog = updater_app.UpdaterApp()
+        updater_app_dialog._check_network_and_update()
+        assert self._is_network_fail_view(updater_app_dialog)
+
+    @mock.patch("UpdaterApp.Util.get_qubes_version", return_value="4.0")
+    @mock.patch("subprocess.check_output", return_value=b"full")
+    @mock.patch("UpdaterApp.logger.info")
+    @mock.patch("UpdaterApp.UpgradeThread")
+    def test_updater_app_with_connectivity_should_succeed(
+        self, mocked_thread, mocked_logger, mocked_output, mocked_qubes_version
+    ):
+        """
+        When the netcheck is run
+         And the network check is successful
+        Then the Preflight Updater should begin to check for updates
+         And the progress view should be visible
+        """
+        updater_app_dialog = updater_app.UpdaterApp()
+        updater_app_dialog._check_network_and_update()
+        assert self._is_progress_view(updater_app_dialog)
+
+    @mock.patch("UpdaterApp.UpgradeThread")
+    def test_updater_app_with_override(self, mocked_thread):
+        """
+        When the netcheck is overridden (skipped)
+         And there is no network connectivity
+        Then `apply updates` should still be called
+         And the progress bar should be visible
+        """
+        updater_app_dialog = updater_app.UpdaterApp(should_skip_netcheck=True)
+        updater_app_dialog._check_network_and_update()
+        assert self._is_progress_view(updater_app_dialog)
+
+    def _is_progress_view(self, dialog: updater_app.UpdaterApp) -> bool:
+        """
+        Helper method to test assumptions about Dialog UI state.
+        """
+        return (
+            dialog.progressBar.isVisible()
+            and not dialog.applyUpdatesButton.isVisible()
+            and dialog.cancelButton.isVisible()
+            and not dialog.cancelButton.isEnabled()
+            and dialog.proposedActionDescription.text()
+            == strings.description_status_applying_updates
+        )
+
+    def _is_network_fail_view(self, dialog: updater_app.UpdaterApp) -> bool:
+        """
+        Helper method to test assumptions about Dialog UI state.
+        """
+        return (
+            not dialog.progressBar.isVisible()
+            and not dialog.applyUpdatesButton.isVisible()
+            and dialog.cancelButton.isVisible()
+            and dialog.cancelButton.isEnabled()
+            and dialog.proposedActionDescription.text() == strings.description_error_network
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #633 
Towards #649 

Changes proposed in this pull request:

- Add network connectivity check before running Preflight Updater, Only launch UpgradeThread if network check is successful. 
- If network check is unsuccessful, show an error message. 
-  Add override command-line option, `--skip-netcheck`, to bypass the network check and allow the Prelight Updater to run as usual (this is for development/testing purposes).
- Add tests for `UpdaterApp.py` to test the above functionality.

## Testing

**Manual testing in Qubes/dom0**

Check out this branch and `make clone` it into dom0. Disconnect your computer from the internet. 
- [ ] run `python3 /opt/securedrop/launcher/sdw-launcher.py` and click "Apply Updates." Observe an immediate network failure error message.
- [ ] Reconnect to the internet and rerun the launcher script. Ensure you can successfully run the preflight updater.
- [ ] Ensure the above steps work with both ethernet and wireless connections.   

**Manual testing outside of dom0**

- [ ] check out this branch, activate your virtual environment, and run `python3 /opt/securedrop/launcher/sdw-launcher.py`. When you attempt to apply updates you should see the "network failed" message (regardless of your network status).
- [ ] Now run `python3 /opt/securedrop/launcher/sdw-launcher.py --skip-netcheck` and you should be able to continue to the updater "run" (which will not actually run or apply updates since you're outside of dom0). The network error dialog view should not appear. The updater "run" will finish with a failure message. (Note: you will encounter error messages printed to the console relating to the failure to run some updater functionality outside of dom0: 
`sudo: qubes-dom0-update: command not found`, 
`sudo: qubesctl: command not found`, `Running 'echo '3' > /home/user/.securedrop_client/sdw-update-status' on sd-app \ sd-app: Failed to access 'default_user' property`)  
- [ ] Ensure the above steps work with both the PyQt4 and the PyQt5 environments. You will need to `export SDW_UPDATER_QT=4` for PyQt4 (and 5 for PyQt5) as per [these instructions](https://github.com/freedomofpress/securedrop-workstation/tree/d1e8c98cc099152c7e8957c97248258a5dec6df7/launcher#developer-environment).