### PR TITLE
Have `./qa-switch.sh nightly` switch to the nightlies apt component

### DIFF
--- a/utils/qa-switch.sh
+++ b/utils/qa-switch.sh
@@ -10,6 +10,12 @@ if [[ $(id -u) -ne 0 ]] ; then echo "Please run as root" ; exit 1 ; fi
 
 cp -R `dirname "$0"`/qa-switch/ /srv/salt/
 
+if [[ "$1" == "nightly" ]]; then
+    version="buster-nightly"
+else
+    version="buster"
+endif
+
 cd /srv/salt
 echo Updating dom0...
 qubesctl --show-output --targets dom0 state.apply qa-switch.dom0
@@ -17,7 +23,7 @@ qubesctl --show-output --targets dom0 state.apply qa-switch.dom0
 export template_list="sd-app-buster-template sd-devices-buster-template sd-log-buster-template sd-proxy-buster-template sd-viewer-buster-template securedrop-workstation-buster whonix-gw-16"
 
 echo Updating Debian-based templates:
-for t in $template_list; do echo Updating $t...; qubesctl --show-output --skip-dom0 --targets $t state.apply qa-switch.buster; done
+for t in $template_list; do echo Updating $t...; qubesctl --show-output --skip-dom0 --targets $t state.apply qa-switch.$version; done
 
 echo Replacing prod config YAML...
 

--- a/utils/qa-switch/buster-nightly.sls
+++ b/utils/qa-switch/buster-nightly.sls
@@ -1,11 +1,11 @@
 remove-prod-apt-repo:
   pkgrepo.absent:
     - name: "deb [arch=amd64] https://apt.freedom.press buster main"
-    - name: "deb [arch=amd64] https://apt-test.freedom.press buster nightlies"
+    - name: "deb [arch=amd64] https://apt-test.freedom.press buster main"
 
 add-test-apt-repo:
   pkgrepo.managed:
-    - name: "deb [arch=amd64] https://apt-test.freedom.press buster main"
+    - name: "deb [arch=amd64] https://apt-test.freedom.press buster nightlies"
     - file: /etc/apt/sources.list.d/securedrop_workstation.list
     - key_url: "salt://sd/sd-workstation/apt-test-pubkey.asc"
     - clean_file: True


### PR DESCRIPTION
## Status

Work in progress

## Description of Changes

As discussed in <https://github.com/freedomofpress/securedrop-debian-packaging/issues/289>,
we want to move nightlies into their own component so they don't
interfere with manually created release candidate packages. This only
requires a different source.list line, so teach qa-switch how to
enable it.

## Testing

* [ ]Run `qa-switch.sh`, observe it maintains current behavior.
* [ ] Run `qa-switch.sh nightly`, observe it switches to nightly packages

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing pilot instances
2. New installs

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I would appreciate help with the documentation