### PR TITLE
4.1 support: `sys-usb` DispVM compatibility and `sd-log` qrexec loopback denial notification suppression

### DIFF
--- a/dom0/sd-clean-all.sls
+++ b/dom0/sd-clean-all.sls
@@ -9,8 +9,43 @@ set-fedora-as-default-dispvm:
 
 {% set gui_user = salt['cmd.shell']('groupmems -l -g qubes') %}
 
+{% if grains['osrelease'] == '4.1' and salt['pillar.get']('qvm:sys-usb:disposable', true) %}
+restore-sys-usb-dispvm-halt:
+  qvm.kill:
+    - name: sys-usb
+
+restore-sys-usb-dispvm-halt-wait:
+  cmd.run:
+    - name: sleep 5
+    - require:
+      - qvm: restore-sys-usb-dispvm-halt
+
+restore-sys-usb-dispvm:
+  qvm.prefs:
+    - name: sys-usb
+    - template: fedora-35-dvm
+    - require:
+      - cmd: restore-sys-usb-dispvm-halt-wait
+      - cmd: set-fedora-as-default-dispvm
+
+restore-sys-usb-dispvm-start:
+  qvm.start:
+    - name: sys-usb
+    - require:
+      - qvm: restore-sys-usb-dispvm
+
+# autoattach modifications are only present in sd-fedora-dvm
+# so no more sd-usb-autoattach-remove necessary
+remove-sd-fedora-dispvm:
+  qvm.absent:
+    - name: sd-fedora-dvm
+    - require:
+      - qvm: restore-sys-usb-dispvm
+{% else %}
+# If sys-usb is not disposable, clean up after ourselves
 include:
   - sd-usb-autoattach-remove
+{% endif %}
 
 # Reset desktop icon size to its original value
 dom0-reset-icon-size-xfce:

--- a/dom0/sd-dom0-qvm-rpc.sls
+++ b/dom0/sd-dom0-qvm-rpc.sls
@@ -193,6 +193,8 @@ dom0-rpc-qubes.r5-format-deny:
   file.managed:
     - name: /etc/qubes/policy.d/70-securedrop-workstation.policy
     - contents: |
+        securedrop.Log          *           @anyvm @anyvm deny
+
         qubes.FeaturesRequest   *           @anyvm @tag:sd-workstation deny
         qubes.FeaturesRequest   *           @tag:sd-workstation @anyvm deny
 
@@ -221,6 +223,10 @@ dom0-rpc-qubes.r5-format-ask-allow:
   file.managed:
     - name: /etc/qubes/policy.d/60-securedrop-workstation.policy
     - contents: |
+        # required to suppress unsupported loopback error notifications
+        securedrop.Log          *           sd-log sd-log deny notify=no
+        securedrop.Log          *           @tag:sd-workstation sd-log allow
+
         qubes.Filecopy          *           sd-log @default ask
         qubes.Filecopy          *           sd-log @tag:sd-receive-logs ask
         qubes.Filecopy          *           sd-proxy @tag:sd-client allow

--- a/dom0/sd-log.sls
+++ b/dom0/sd-log.sls
@@ -31,6 +31,7 @@ sd-log:
     - require:
       - qvm: sd-small-buster-template
 
+{% if grains['osrelease'] == '4.0' %}
 # Allow any SecureDrop VM to log to the centralized log VM
 sd-log-dom0-securedrop.Log:
   file.prepend:
@@ -38,6 +39,15 @@ sd-log-dom0-securedrop.Log:
     - text: |
         @tag:sd-workstation sd-log allow
         @anyvm @anyvm deny
+{% elif grains['osrelease'] == '4.1' %}
+# In 4.1 this policy is handled in the more central app policy
+# files added by sd-dom0-qvm-rpc.sls, no need to keep this
+# around in 4.0 if we migrated
+sd-log-dom0-remove-old-securedrop.Log-policy:
+  file.absent:
+    - names:
+      - /etc/qubes-rpc/policy/securedrop.Log
+{% endif %}
 
 {% import_json "sd/config.json" as d %}
 

--- a/dom0/sd-workstation.top
+++ b/dom0/sd-workstation.top
@@ -41,7 +41,14 @@ base:
   securedrop-workstation-buster:
     - sd-workstation-template-files
     - sd-logging-setup
+# Depending on whether sys-usb is disposable or not, we want to
+# modify different qubes. If sd-fedora-dvm will only be
+# created by sd-sys-vms.sls if sys-usb is disposable.
+{% if grains['osrelease'] == '4.1' and salt['pillar.get']('qvm:sys-usb:disposable', true) %}
+  sd-fedora-dvm:
+{% else %}
   sys-usb:
+{% endif %}
     - sd-usb-autoattach-add
   sd-log:
     - sd-logging-setup

--- a/scripts/provision-all
+++ b/scripts/provision-all
@@ -30,4 +30,8 @@ echo "Provision all SecureDrop Workstation VMs with service-specific configs"
 sudo qubesctl --show-output --max-concurrency "$max_concurrency" --skip-dom0 --targets "$all_sdw_vms_target" state.highstate
 
 echo "Add SecureDrop export device handling to sys-usb"
-sudo qubesctl --show-output --skip-dom0 --targets sys-usb state.highstate
+# If sd-fedora-dvm exists it's because salt determined that sys-usb was disposable
+qvm-check --quiet sd-fedora-dvm 2> /dev/null && \
+  sudo qubesctl --show-output --skip-dom0 --targets sd-fedora-dvm state.highstate && \
+  qvm-shutdown --wait sys-usb && qvm-start sys-usb || \
+  sudo qubesctl --show-output --skip-dom0 --targets sys-usb state.highstate

--- a/tests/test_qubes_vms.py
+++ b/tests/test_qubes_vms.py
@@ -23,14 +23,22 @@ class SD_Qubes_VM_Tests(unittest.TestCase):
         """
         sys_vms = ["sys-firewall", "sys-net", "sys-usb", "default-mgmt-dvm"]
         sys_vms_maybe_disp = ["sys-firewall", "sys-usb"]
+        sys_vms_custom_disp = ["sys-usb"]
 
         for sys_vm in sys_vms:
             vm = self.app.domains[sys_vm]
-            wanted_template = CURRENT_FEDORA_TEMPLATE
+            wanted_templates = [CURRENT_FEDORA_TEMPLATE]
             if get_qubes_version() == "4.1" and sys_vm in sys_vms_maybe_disp:
-                wanted_template += "-dvm"
-            self.assertEqual(
-                vm.template.name, wanted_template, "Unexpected template for {}".format(sys_vm)
+                if sys_vm in sys_vms_custom_disp:
+                    wanted_templates.append("sd-fedora-dvm")
+                else:
+                    wanted_templates.append(CURRENT_FEDORA_TEMPLATE + "-dvm")
+
+            self.assertTrue(
+                vm.template.name in wanted_templates,
+                "Unexpected template for {}\n".format(sys_vm)
+                + "Current: {}\n".format(vm.template.name)
+                + "Expected: {}".format(", ".join(wanted_templates)),
             )
 
     def test_current_whonix_vms(self):

--- a/tests/vars/qubes-rpc-41.yml
+++ b/tests/vars/qubes-rpc-41.yml
@@ -52,11 +52,6 @@
 
     $anyvm	dom0	allow
 
-- policy: securedrop.Log
-  starts_with: |-
-    @tag:sd-workstation sd-log allow
-    @anyvm @anyvm deny
-
 - policy: securedrop.Proxy
   starts_with: |-
     sd-app sd-proxy allow
@@ -98,6 +93,10 @@
 
 - policy: /etc/qubes/policy.d/60-securedrop-workstation.policy
   starts_with: |-
+    # required to suppress unsupported loopback error notifications
+    securedrop.Log          *           sd-log sd-log deny notify=no
+    securedrop.Log          *           @tag:sd-workstation sd-log allow
+
     qubes.Filecopy          *           sd-log @default ask
     qubes.Filecopy          *           sd-log @tag:sd-receive-logs ask
     qubes.Filecopy          *           sd-proxy @tag:sd-client allow
@@ -108,6 +107,8 @@
 
 - policy: /etc/qubes/policy.d/70-securedrop-workstation.policy
   starts_with: |-
+    securedrop.Log          *           @anyvm @anyvm deny
+
     qubes.FeaturesRequest   *           @anyvm @tag:sd-workstation deny
     qubes.FeaturesRequest   *           @tag:sd-workstation @anyvm deny
 


### PR DESCRIPTION
## Description of Changes

Fake "stacked" PR waiting for #751 being merged first. Towards #600.

The Qubes OS 4.1 default configuration makes the `sys-usb` qube
disposable, which interferes with our udev rule to automatically attach
flash devices to `sd-devices`. This change clones the `fedora-34-dvm`
qube as `sd-fedora-dvm`, where we henceforth add the necessary
modifications, so `sys-usb` stays disposable, but with our modifications
sticking around permanently.
    
In 4.1 policy denials trigger a notification visible to the user -
qexec loopback isn't supported in 4.0 either, but they're silent.
Suppressing these notifications is only supported in the new policy
format, so `securedrop.Log` rules are now there.

Fixes #755 

## Testing

* QubesOS version:
 * If 4.1, `sys-usb` is a DispVM:
* Workstation environment:
* Server environment:

### dom0

- [ ] During the initial `sdw-admin --apply` run, there are no error notifications along the lines of #755
- [ ] `sdw-admin --apply` successfully terminates
- [ ] All tests (`make test`) pass (prerequisite: https://github.com/freedomofpress/securedrop-debian-packaging/issues/312 is fixed)

### Updater (4.1 only)

- [ ] During the update, no error notifications along the lines of #755 are shown

### Client

- [ ] When a USB flash drive is connected to the machine, it is automatically attached to `sd-devices` (which boots if it is not running)
- [ ] Export UX works as expected (see [export instructions in Workstation Acceptance Tests(https://github.com/freedomofpress/securedrop-workstation/wiki/Workstation-Acceptance-Tests#export)])

## Deployment

For new 4.1 installs both `sys-usb` DispVMs (default configuration) and AppVMs are supported, though I think we should [advertise the default configuration in the docs](https://github.com/freedomofpress/securedrop-workstation/pull/764#issuecomment-1112350309).

If migrated 4.0 installs keep modifications to their `sys-usb` AppVM during/after upgrade, the salt states should also continue to work as expected on 4.1.

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`
