### PR TITLE
Use proper name to describe salt state installing config.json on sd-app

### DIFF
--- a/dom0/sd-app-config.sls
+++ b/dom0/sd-app-config.sls
@@ -13,7 +13,7 @@
 
 {% import_json "sd/config.json" as d %}
 
-install-securedrop-proxy-yaml-config:
+install-securedrop-client-config-json:
   file.managed:
     - name: /home/user/.securedrop_client/config.json
     - source: salt://sd/sd-app/config.json.j2


### PR DESCRIPTION
## Description of Changes

This just changes the name to be accurate, but it's more for developer convenience as it's never referenced by name

Fixes #767

## Testing

No, the change is far too trivial :grinning: 