### PR TITLE
Add test compatibility for 4.1 setups

### DIFF
--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -36,6 +36,14 @@ class SD_VM_Tests(unittest.TestCase):
         assert kernel_version.endswith("-grsec-workstation")
         assert kernel_version == EXPECTED_KERNEL_VERSION
 
+        # QubesOS 4.1 stopped requiring u2mfn.ko for HVMs, the packages won't build the respective
+        # kernel module anymore
+        # This portion of the test assumes that 4.1 is always used with templates that use
+        # repositories for 4.1 (in our case, bullseye based templates)
+        with open("/etc/qubes-release") as qubes_release:
+            if "R4.1" in qubes_release.read():
+                return
+
         u2mfn_filepath = "/usr/lib/modules/{}/updates/dkms/u2mfn.ko".format(EXPECTED_KERNEL_VERSION)
         # cmd will raise exception if file not found
         stdout, stderr = vm.run("sudo test -f {}".format(u2mfn_filepath))


### PR DESCRIPTION
## Description of Changes

`u2mfn.ko` was a necessary kernel module in Qubes R4.0 HVMs, this requirement has been dropped in Qubes R4.1. Our tests should only check for the presence of the module when when templates/AppVMs use R4.0 repositories, as the module won't be dynamically generated in templates/AppVMs using R4.1 repositories

This change will also allow tests to support upcoming bullseye templates.

Fixes #771 

## Testing

### Qubes R4.1, fresh install:
* [x] `make tests` pass (in line with current expected failures in `main` branch)

### Qubes R4.1, in-place upgrade while SDW was installed:
* [ ] `make tests` pass (in line with current expected failures in `main` branch)

### Qubes R4.0, any install
* [ ] `make tests` pass