### PR TITLE
Use Fedora-35 template (Qubes 4.0 and 4.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ When developing on the Workstation, make sure to edit files in `sd-dev`, then co
 
 The staging environment differs from a production envionment in that it builds a local RPM, installs it in dom0, uses the dom0 package repository configuration for future updates of the RPM package from the https://yum-test.securedrop.org repository, and makes it so that you receive the latest nightlies of the workstation components, such as the SecureDrop Client.
 
-#### Update `dom0`, `fedora-34`, `whonix-gw-16` and `whonix-ws-16` templates
+#### Update `dom0`, `fedora-35`, `whonix-gw-16` and `whonix-ws-16` templates
 
 Updates to these VMs will be provided by the installer and updater, but to ensure they are up to date prior to install, it will be easier to debug, should something go wrong.
 

--- a/dom0/sd-clean-all.sls
+++ b/dom0/sd-clean-all.sls
@@ -5,7 +5,7 @@
 
 set-fedora-as-default-dispvm:
   cmd.run:
-    - name: qvm-check fedora-34-dvm && qubes-prefs default_dispvm fedora-34-dvm || qubes-prefs default_dispvm ''
+    - name: qvm-check fedora-35-dvm && qubes-prefs default_dispvm fedora-35-dvm || qubes-prefs default_dispvm ''
 
 {% set gui_user = salt['cmd.shell']('groupmems -l -g qubes') %}
 

--- a/dom0/sd-clean-default-dispvm.sls
+++ b/dom0/sd-clean-default-dispvm.sls
@@ -3,4 +3,4 @@
 
 set-fedora-as-default-dispvm:
   cmd.run:
-    - name: qvm-check fedora-34-dvm && qubes-prefs default_dispvm fedora-34-dvm || qubes-prefs default_dispvm ''
+    - name: qvm-check fedora-35-dvm && qubes-prefs default_dispvm fedora-35-dvm || qubes-prefs default_dispvm ''

--- a/dom0/sd-sys-vms.sls
+++ b/dom0/sd-sys-vms.sls
@@ -9,7 +9,7 @@ include:
   # DispVM is created
   - qvm.default-dispvm
 
-{% set sd_supported_fedora_version = 'fedora-34' %}
+{% set sd_supported_fedora_version = 'fedora-35' %}
 
 
 # Install latest templates required for SDW VMs.
@@ -17,7 +17,7 @@ dom0-install-fedora-template:
 {% if grains['osrelease'] == '4.1' %}
   cmd.run:
     - name: >
-        qvm-template install fedora-34
+        qvm-template install fedora-35
 {% else %}
   pkg.installed:
     - pkgs:

--- a/launcher/sdw_updater_gui/Updater.py
+++ b/launcher/sdw_updater_gui/Updater.py
@@ -38,7 +38,7 @@ detail_log = Util.get_logger(prefix=DETAIL_LOGGER_PREFIX, module=__name__)
 # as well as their associated TemplateVMs.
 # In the future, we could use qvm-prefs to extract this information.
 current_vms = {
-    "fedora": "fedora-34",
+    "fedora": "fedora-35",
     "sd-viewer": "sd-large-buster-template",
     "sd-app": "sd-small-buster-template",
     "sd-log": "sd-small-buster-template",

--- a/launcher/tests/test_updater.py
+++ b/launcher/tests/test_updater.py
@@ -490,7 +490,7 @@ def test_shutdown_and_start_vms(
         call("sys-usb"),
     ]
     template_vm_calls = [
-        call("fedora-34"),
+        call("fedora-35"),
         call("sd-large-buster-template"),
         call("sd-small-buster-template"),
         call("whonix-gw-16"),
@@ -536,7 +536,7 @@ def test_shutdown_and_start_vms_sysvm_fail(
         call("sd-log"),
     ]
     template_vm_calls = [
-        call("fedora-34"),
+        call("fedora-35"),
         call("sd-large-buster-template"),
         call("sd-small-buster-template"),
         call("whonix-gw-16"),

--- a/tests/base.py
+++ b/tests/base.py
@@ -7,7 +7,7 @@ from qubesadmin import Qubes
 
 # Reusable constant for DRY import across tests
 WANTED_VMS = ["sd-gpg", "sd-log", "sd-proxy", "sd-app", "sd-viewer", "sd-whonix", "sd-devices"]
-CURRENT_FEDORA_VERSION = "34"
+CURRENT_FEDORA_VERSION = "35"
 CURRENT_FEDORA_TEMPLATE = "fedora-" + CURRENT_FEDORA_VERSION
 CURRENT_WHONIX_VERSION = "16"
 


### PR DESCRIPTION
## Status

On hold until f35 template moves out of testing repo (see https://github.com/QubesOS/qubes-issues/issues/6969)

## Description of Changes

Fixes #763.

Changes proposed in this pull request:
Switch base template for system vms (sys-net, sys-usb, sys-firewall) to Fedora 35 for both Qubes 4.0 and 4.1.

## Testing
**Testing before template lands in main Qubes template repo:**
- Install f35 template via `sudo qubes-dom0-update --enablerepo=qubes-templates-itl-testing qubes-template-fedora-35` 
- Check out this branch in your dev vm
- `make clone` then `sdw-admin --apply`
- [ ] System templates are switched to fedora-35
- [ ] `make test` passes in dom0 (:exclamation: I'm not sure this is possible right now, I think there are preexisting test failures, at least that I'm seeing - will update)
- [ ] Basic functionality (network connectivity, attaching/detaching devices via sys-usb) is working
- [ ] New Fedora-35 DVM is created and displays in appmenu; other fedora dispvms can still be opened
- [ ] `default-mgmt-dvm` is fedora-35, as are templates for sys-net, sys-usb, sys-firewall

**Testing after template lands:**
- Skip the first step, run through test plan

**Clean install testing (after template lands)**
- Clean installs on 4.0 and 4.1 are successful and base template is fedora-35 after `sdw-admin --apply` has been run 

**Installation Notes**:
- On both new installs and upgrades will likely run into a PCI error with `sys-net` that will require you to set the `no-strict-reset` option in order for sys-net to boot successfully. In my case, I had to set this option and then reboot my machine, then rerun `sdw-admin --apply`.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing pilot instances (**May need to communicate PCI workaround via support channels**)
2. New installs

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [x] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation