### PR TITLE
Updated config validation to compare fingerprint against the provided key

### DIFF
--- a/scripts/validate_config.py
+++ b/scripts/validate_config.py
@@ -6,6 +6,7 @@ Checks for
 import json
 import re
 import os
+import sys
 import subprocess
 import tempfile
 from qubesadmin import Qubes
@@ -102,6 +103,14 @@ class SDWConfigValidator(object):
     def confirm_submission_privkey_fingerprint(self):
         assert "submission_key_fpr" in self.config
         assert re.match("^[a-fA-F0-9]{40}$", self.config["submission_key_fpr"])
+        gpg_cmd = ["gpg2", "--show-keys", self.secret_key_filepath]
+        try:
+            out = subprocess.check_output(gpg_cmd).decode(sys.stdout.encoding)
+            match = "      {}".format(self.config["submission_key_fpr"])
+            assert re.search(match, out), "Configured fingerprint does not match key!"
+
+        except subprocess.CalledProcessError as e:
+            assert False, "Fingerprint validation failed with error: {}".format(e.output)
 
     def read_config_file(self):
         with open(self.config_filepath, "r") as f:

--- a/scripts/validate_config.py
+++ b/scripts/validate_config.py
@@ -105,12 +105,14 @@ class SDWConfigValidator(object):
         assert re.match("^[a-fA-F0-9]{40}$", self.config["submission_key_fpr"])
         gpg_cmd = ["gpg2", "--show-keys", self.secret_key_filepath]
         try:
-            out = subprocess.check_output(gpg_cmd).decode(sys.stdout.encoding)
+            out = subprocess.check_output(gpg_cmd, stderr=subprocess.STDOUT).decode(
+                sys.stdout.encoding
+            )
             match = "      {}".format(self.config["submission_key_fpr"])
             assert re.search(match, out), "Configured fingerprint does not match key!"
 
         except subprocess.CalledProcessError as e:
-            assert False, "Fingerprint validation failed with error: {}".format(e.output)
+            assert False, "Key validation failed: {}".format(e.output.decode(sys.stdout.encoding))
 
     def read_config_file(self):
         with open(self.config_filepath, "r") as f:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #779 .

Adds a validation check for the fpr in config.json, comparing it to the fpr of `sd-journalist.sec`.

## Testing
in a dev env on this branch:
- modify `config.json`, changing `submission_key_fpr` value to a syntactically valid (40 hex char) GPG fingerprint that does not match the one for the `sd-journalist.sec` key in use
- [ ] run `make dev` and confirm that you see a validation error indicating that the fingerprints don't match
- fix `config.json` by changing back to the correct fingerprint
- [ ] run make dev and confirm that validation succeeds, the install proceeds, and replies work in the client.

## Deployment

Any special considerations for deployment? Consider both:

This change will not retroactively fix fingerprints in broken installs. Users will need to fix config.json manually and run `sdw-admin --apply` to correct any config errors.
