### PR TITLE
Have dev default to nightlies, use qa-switch for release candidates

### DIFF
--- a/dom0/fpf-apt-repo.sls
+++ b/dom0/fpf-apt-repo.sls
@@ -39,7 +39,7 @@ install-python-apt-for-repo-config:
 
 configure-fpf-apt-repo:
   pkgrepo.managed:
-    - name: "deb [arch=amd64] {{ sdvars.apt_repo_url }} {{ grains['oscodename'] }} main"
+    - name: "deb [arch=amd64] {{ sdvars.apt_repo_url }} {{ grains['oscodename'] }} {{ sdvars.component }}"
     - file: /etc/apt/sources.list.d/securedrop_workstation.list
     - key_url: "salt://sd/sd-workstation/{{ sdvars.signing_key_filename }}"
     - clean_file: True # squash file to ensure there are no duplicates

--- a/dom0/sd-default-config.yml
+++ b/dom0/sd-default-config.yml
@@ -4,8 +4,10 @@ prod:
   dom0_yum_repo_url: "https://yum.securedrop.org/workstation/dom0/f25"
   apt_repo_url: "https://apt.freedom.press"
   signing_key_filename: "securedrop-release-signing-pubkey-2021.asc"
+  component: "main"
 # Development variables, suited for use during local development
 dev:
   dom0_yum_repo_url: "https://yum-test.securedrop.org/workstation/dom0/f25"
   apt_repo_url: "https://apt-test.freedom.press"
   signing_key_filename: "apt-test-pubkey.asc"
+  component: "nightlies"

--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -12,8 +12,8 @@ SUPPORTED_WHONIX_PLATFORMS = ["Debian GNU/Linux 11 (bullseye)"]
 
 
 apt_url = ""
-FPF_APT_SOURCES_STRETCH_DEV = "deb [arch=amd64] https://apt-test.freedom.press stretch main"
-FPF_APT_SOURCES_BUSTER_DEV = "deb [arch=amd64] https://apt-test.freedom.press buster main"
+FPF_APT_SOURCES_STRETCH_DEV = "deb [arch=amd64] https://apt-test.freedom.press stretch nightlies"
+FPF_APT_SOURCES_BUSTER_DEV = "deb [arch=amd64] https://apt-test.freedom.press buster nightlies"
 FPF_APT_SOURCES_STRETCH = "deb [arch=amd64] https://apt.freedom.press stretch main"
 FPF_APT_SOURCES_BUSTER = "deb [arch=amd64] https://apt.freedom.press buster main"
 APT_SOURCES_FILE = "/etc/apt/sources.list.d/securedrop_workstation.list"

--- a/utils/qa-switch.sh
+++ b/utils/qa-switch.sh
@@ -14,7 +14,7 @@ cd /srv/salt
 echo Updating dom0...
 qubesctl --show-output --targets dom0 state.apply qa-switch.dom0
 
-export template_list="sd-app-buster-template sd-devices-buster-template sd-log-buster-template sd-proxy-buster-template sd-viewer-buster-template securedrop-workstation-buster whonix-gw-16"
+export template_list="sd-large-buster-template sd-small-buster-template securedrop-workstation-buster whonix-gw-16"
 
 echo Updating Debian-based templates:
 for t in $template_list; do echo Updating $t...; qubesctl --show-output --skip-dom0 --targets $t state.apply qa-switch.buster; done

--- a/utils/qa-switch.sh
+++ b/utils/qa-switch.sh
@@ -14,10 +14,10 @@ cd /srv/salt
 echo Updating dom0...
 qubesctl --show-output --targets dom0 state.apply qa-switch.dom0
 
-export template_list="sd-large-buster-template sd-small-buster-template securedrop-workstation-buster whonix-gw-16"
+export template_list="sd-large-bullseye-template sd-small-bullseye-template securedrop-workstation-bullseye whonix-gw-16"
 
 echo Updating Debian-based templates:
-for t in $template_list; do echo Updating $t...; qubesctl --show-output --skip-dom0 --targets $t state.apply qa-switch.buster; done
+for t in $template_list; do echo Updating $t...; qubesctl --show-output --skip-dom0 --targets $t state.apply qa-switch.bullseye; done
 
 echo Replacing prod config YAML...
 

--- a/utils/qa-switch/bullseye.sls
+++ b/utils/qa-switch/bullseye.sls
@@ -1,10 +1,10 @@
 remove-prod-apt-repo:
   pkgrepo.absent:
-    - name: "deb [arch=amd64] https://apt.freedom.press buster nightlies"
+    - name: "deb [arch=amd64] https://apt.freedom.press bullseye nightlies"
 
 add-test-apt-repo:
   pkgrepo.managed:
-    - name: "deb [arch=amd64] https://apt-test.freedom.press buster main"
+    - name: "deb [arch=amd64] https://apt-test.freedom.press bullseye main"
     - file: /etc/apt/sources.list.d/securedrop_workstation.list
     - key_url: "salt://sd/sd-workstation/apt-test-pubkey.asc"
     - clean_file: True

--- a/utils/qa-switch/buster.sls
+++ b/utils/qa-switch/buster.sls
@@ -1,6 +1,6 @@
 remove-prod-apt-repo:
   pkgrepo.absent:
-    - name: "deb [arch=amd64] https://apt.freedom.press buster main"
+    - name: "deb [arch=amd64] https://apt.freedom.press buster nightlies"
 
 add-test-apt-repo:
   pkgrepo.managed:

--- a/utils/qa-switch/dom0.sls
+++ b/utils/qa-switch/dom0.sls
@@ -38,7 +38,7 @@ dom0-workstation-rpm-repo:
         gpgcheck=1
         gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation
         enabled=1
-        baseurl=https://yum-test.securedrop.org/workstation/dom0/f25
+        baseurl=https://yum-test.securedrop.org/workstation/dom0/f32
         name=SecureDrop Workstation Qubes dom0 repo
     - require:
       - file: dom0-rpm-test-key

--- a/utils/qa-switch/sd-qa-config.yml
+++ b/utils/qa-switch/sd-qa-config.yml
@@ -1,13 +1,13 @@
 ---
 # Production variables, for use with real-world installs
 prod:
-  dom0_yum_repo_url: "https://yum-test.securedrop.org/workstation/dom0/f25"
+  dom0_yum_repo_url: "https://yum-test.securedrop.org/workstation/dom0/f32"
   apt_repo_url: "https://apt-test.freedom.press"
   signing_key_filename: "apt-test-pubkey.asc"
   component: "main"
 # Development variables, suited for use during local development
 dev:
-  dom0_yum_repo_url: "https://yum-test.securedrop.org/workstation/dom0/f25"
+  dom0_yum_repo_url: "https://yum-test.securedrop.org/workstation/dom0/f32"
   apt_repo_url: "https://apt-test.freedom.press"
   signing_key_filename: "apt-test-pubkey.asc"
   component: "main"

--- a/utils/qa-switch/sd-qa-config.yml
+++ b/utils/qa-switch/sd-qa-config.yml
@@ -4,8 +4,10 @@ prod:
   dom0_yum_repo_url: "https://yum-test.securedrop.org/workstation/dom0/f25"
   apt_repo_url: "https://apt-test.freedom.press"
   signing_key_filename: "apt-test-pubkey.asc"
+  component: "main"
 # Development variables, suited for use during local development
 dev:
   dom0_yum_repo_url: "https://yum-test.securedrop.org/workstation/dom0/f25"
   apt_repo_url: "https://apt-test.freedom.press"
   signing_key_filename: "apt-test-pubkey.asc"
+  component: "main"

--- a/utils/qa-switch/top.sls
+++ b/utils/qa-switch/top.sls
@@ -5,29 +5,29 @@ base:
   dom0:
     - sd-dom0-switch
 
-  sd-log-buster-template:
-    - sd-buster-switch
-  sd-devices-buster-template:
-    - sd-buster-switch
+  sd-log-bullseye-template:
+    - sd-bullseye-switch
+  sd-devices-bullseye-template:
+    - sd-bullseye-switch
   sd-gpg:
-    - sd-buster-switch
-  sd-proxy-buster-template:
-    - sd-buster-switch
+    - sd-bullseye-switch
+  sd-proxy-bullseye-template:
+    - sd-bullseye-switch
   sd-app:
-    - sd-buster-switch
-  sd-viewer-buster-template:
-    - sd-buster-switch
-  sd-app-buster-template:
-    - sd-buster-switch
+    - sd-bullseye-switch
+  sd-viewer-bullseye-template:
+    - sd-bullseye-switch
+  sd-app-bullseye-template:
+    - sd-bullseye-switch
   sys-firewall:
-    - sd-buster-switch
+    - sd-bullseye-switch
   sd-whonix:
-    - sd-buster-switch
-  securedrop-workstation-buster:
-    - sd-buster-switch
+    - sd-bullseye-switch
+  securedrop-workstation-bullseye:
+    - sd-bullseye-switch
   sys-usb:
-    - sd-buster-switch
+    - sd-bullseye-switch
   whonix-gw-16:
-    - sd-buster-switch
+    - sd-bullseye-switch
   sd-log:
-    - sd-buster-switch
+    - sd-bullseye-switch


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

* `make dev` now installs with nightlies ("nightlies" component on apt-test)
* use `qa-switch.sh` to switch to release candidates ("main" component on apt-test)
* re-run `make dev` to switch back

This was done by pairing with @cfm.

## Testing

* Follow the steps outlined above. In between each step check `/etc/apt/sources.list.d/securedrop_workstation.list` to see the correct component is being used. (note that you might need to manually restart appVMs to see the templateVM change take effect)
* The first commit can be tested with buster or bullseye, while the second requires the bullseye template etc. to be available.

## Deployment

Any special considerations for deployment? Should be a no-op for prod instances.

## Checklist

- [ ] All tests (`make test`) pass in `dom0`
- [x] I would appreciate help with the documentation