### PR TITLE
update bullseye templates

### DIFF
--- a/launcher/sdw_updater_gui/Updater.py
+++ b/launcher/sdw_updater_gui/Updater.py
@@ -39,13 +39,13 @@ detail_log = Util.get_logger(prefix=DETAIL_LOGGER_PREFIX, module=__name__)
 # In the future, we could use qvm-prefs to extract this information.
 current_vms = {
     "fedora": "fedora-35",
-    "sd-viewer": "sd-large-buster-template",
-    "sd-app": "sd-small-buster-template",
-    "sd-log": "sd-small-buster-template",
-    "sd-devices": "sd-large-buster-template",
-    "sd-proxy": "sd-small-buster-template",
+    "sd-viewer": "sd-large-bullseye-template",
+    "sd-app": "sd-small-bullseye-template",
+    "sd-log": "sd-small-bullseye-template",
+    "sd-devices": "sd-large-bullseye-template",
+    "sd-proxy": "sd-small-bullseye-template",
     "sd-whonix": "whonix-gw-16",
-    "sd-gpg": "sd-small-buster-template",
+    "sd-gpg": "sd-small-bullseye-template",
 }
 
 current_templates = set([val for key, val in current_vms.items() if key != "dom0"])


### PR DESCRIPTION
Signed-off-by: Allie Crevier <allie@freedom.press>

## Status

~Ready for review~ (still need to update launcher tests)

## Description of Changes

Fixes https://github.com/freedomofpress/securedrop-workstation/issues/787

Changes proposed in this pull request:

Ensure that we update bullseye templates. We're no longer planning to make updates for Qubes 4.0, but if we have to make a hot fix before we end support on August 5th, we will have to release from the `qubes-4.0` branch.

## Testing

On Qubes 4.1...
- [ ] Run the updater and confirm that the templates were updated to the latest nightlies 

## Deployment

See deployment plan in #600.

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation