### PR TITLE
Add cups service/feature to `sd-devices-dvm`

### DIFF
--- a/dom0/sd-devices.sls
+++ b/dom0/sd-devices.sls
@@ -30,6 +30,7 @@ sd-devices-dvm:
     - features:
       - enable:
         - service.paxctld
+        - service.cups
     - require:
       - qvm: sd-large-{{ sdvars.distribution }}-template
 


### PR DESCRIPTION
## Description of Changes

As of bullseye, Qubes requires the cups service/feature to be set in
dom0 for systemd to successfully start `cups.service` inside the DispVM.

`sd-devices` inherits this from `sd-devices-dvm`.

Fixes #794

Towards #600

## Testing

- Run `make dev`
- [ ] Run `qvm-features sd-devices-dvm` and `qvm-features sd-devices`, both of which show `service.cups     1`
- [ ] (Cross-reference) Test plan of https://github.com/freedomofpress/securedrop-export/pull/96 checks out and was merged

## Checklist

- [ ] All tests (`make test`) pass in `dom0`
- [x] I would appreciate help with the documentation