### PR TITLE
Fix Fedora template installation failures

### DIFF
--- a/dom0/sd-sys-vms.sls
+++ b/dom0/sd-sys-vms.sls
@@ -12,11 +12,10 @@ include:
 {% set sd_supported_fedora_version = 'fedora-35' %}
 
 
-# Install latest templates required for SDW VMs.
-dom0-install-fedora-template:
-  cmd.run:
-    - name: >
-        qvm-template install {{ sd_supported_fedora_version }}
+# Ensure the latest templates required for SDW VMs are installed.
+dom0-fedora-template-is-installed:
+  qvm.template_installed:
+    - name: {{ sd_supported_fedora_version }}
 
 # Update the mgmt VM before updating the new Fedora VM. The order is required
 # and listed in the release notes for F32 & F33.


### PR DESCRIPTION
## Description

Fixes #797

## Implementation

As far as I can tell, providing the name of the template to `qvm.template_installed` is enough. (See example code in the commit message.)

## Test plan

- Install Qubes OS R4.1 if needed
- Install the `fedora-35` template if necessary
- [ ] Apply this Salt state and confirm that it succeeds (`make dev`? - or you preferred way of applying the Workstation Salt states)