### PR TITLE
Update to support/migrate to Fedora 36 templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ When developing on the Workstation, make sure to edit files in `sd-dev`, then co
 
 The staging environment differs from a production envionment in that it builds a local RPM, installs it in dom0, uses the dom0 package repository configuration for future updates of the RPM package from the https://yum-test.securedrop.org repository, and makes it so that you receive the latest nightlies of the workstation components, such as the SecureDrop Client.
 
-#### Update `dom0`, `fedora-35`, `whonix-gw-16` and `whonix-ws-16` templates
+#### Update `dom0`, `fedora-36`, `whonix-gw-16` and `whonix-ws-16` templates
 
 Updates to these VMs will be provided by the installer and updater, but to ensure they are up to date prior to install, it will be easier to debug, should something go wrong.
 

--- a/dom0/sd-clean-all.sls
+++ b/dom0/sd-clean-all.sls
@@ -5,7 +5,7 @@
 
 set-fedora-as-default-dispvm:
   cmd.run:
-    - name: qvm-check fedora-35-dvm && qubes-prefs default_dispvm fedora-35-dvm || qubes-prefs default_dispvm ''
+    - name: qvm-check fedora-36-dvm && qubes-prefs default_dispvm fedora-36-dvm || qubes-prefs default_dispvm ''
 
 {% set gui_user = salt['cmd.shell']('groupmems -l -g qubes') %}
 
@@ -23,7 +23,7 @@ restore-sys-usb-dispvm-halt-wait:
 restore-sys-usb-dispvm:
   qvm.prefs:
     - name: sys-usb
-    - template: fedora-35-dvm
+    - template: fedora-36-dvm
     - require:
       - cmd: restore-sys-usb-dispvm-halt-wait
       - cmd: set-fedora-as-default-dispvm

--- a/dom0/sd-clean-default-dispvm.sls
+++ b/dom0/sd-clean-default-dispvm.sls
@@ -3,4 +3,4 @@
 
 set-fedora-as-default-dispvm:
   cmd.run:
-    - name: qvm-check fedora-35-dvm && qubes-prefs default_dispvm fedora-35-dvm || qubes-prefs default_dispvm ''
+    - name: qvm-check fedora-36-dvm && qubes-prefs default_dispvm fedora-36-dvm || qubes-prefs default_dispvm ''

--- a/dom0/sd-sys-vms.sls
+++ b/dom0/sd-sys-vms.sls
@@ -9,7 +9,7 @@ include:
   # DispVM is created
   - qvm.default-dispvm
 
-{% set sd_supported_fedora_version = 'fedora-35' %}
+{% set sd_supported_fedora_version = 'fedora-36' %}
 
 
 # Install latest templates required for SDW VMs.

--- a/launcher/sdw_updater_gui/Updater.py
+++ b/launcher/sdw_updater_gui/Updater.py
@@ -40,7 +40,7 @@ detail_log = Util.get_logger(prefix=DETAIL_LOGGER_PREFIX, module=__name__)
 # as well as their associated TemplateVMs.
 # In the future, we could use qvm-prefs to extract this information.
 current_vms = {
-    "fedora": "fedora-35",
+    "fedora": "fedora-36",
     "sd-viewer": "sd-large-{}-template".format(DEBIAN_VERSION),
     "sd-app": "sd-small-{}-template".format(DEBIAN_VERSION),
     "sd-log": "sd-small-{}-template".format(DEBIAN_VERSION),

--- a/launcher/tests/test_updater.py
+++ b/launcher/tests/test_updater.py
@@ -492,7 +492,7 @@ def test_shutdown_and_start_vms(
         call("sys-usb"),
     ]
     template_vm_calls = [
-        call("fedora-35"),
+        call("fedora-36"),
         call("sd-large-{}-template".format(DEBIAN_VERSION)),
         call("sd-small-{}-template".format(DEBIAN_VERSION)),
         call("whonix-gw-16"),
@@ -538,7 +538,7 @@ def test_shutdown_and_start_vms_sysvm_fail(
         call("sd-log"),
     ]
     template_vm_calls = [
-        call("fedora-35"),
+        call("fedora-36"),
         call("sd-large-{}-template".format(DEBIAN_VERSION)),
         call("sd-small-{}-template".format(DEBIAN_VERSION)),
         call("whonix-gw-16"),

--- a/tests/base.py
+++ b/tests/base.py
@@ -7,7 +7,7 @@ from qubesadmin import Qubes
 
 # Reusable constant for DRY import across tests
 WANTED_VMS = ["sd-gpg", "sd-log", "sd-proxy", "sd-app", "sd-viewer", "sd-whonix", "sd-devices"]
-CURRENT_FEDORA_VERSION = "35"
+CURRENT_FEDORA_VERSION = "36"
 CURRENT_FEDORA_TEMPLATE = "fedora-" + CURRENT_FEDORA_VERSION
 CURRENT_WHONIX_VERSION = "16"
 


### PR DESCRIPTION
## Description of Changes

Fixes #801

Update supported Fedora version to 36.

## Testing

- [ ] There are no references to Fedora 35 left in the repository
- `make dev` or `make clone` then `sdw-admin --apply`
- [ ] `sd-fedora-dvm` exists and is based on `fedora-36`
- [ ] `make test` passes in dom0

### Only relevant on 4.1

- [ ] New Fedora-36 DVM is created and displays in appmenu; other fedora dispvms can still be opened
- [ ] `default-mgmt-dvm` is `fedora-36`, as are templates for sys-net, sys-usb, sys-firewall

## Checklist

- [x] I would appreciate help with the documentation