### PR TITLE
fix days of the week for the last two changelog entries

### DIFF
--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -133,10 +133,10 @@ find /srv/salt -maxdepth 1 -type f -iname '*.top' \
     | xargs qubesctl top.enable > /dev/null
 
 %changelog
-* Thu Jul 5 2022 SecureDrop Team <securedrop@freedom.press> - 0.7.0
+* Tue Jul 5 2022 SecureDrop Team <securedrop@freedom.press> - 0.7.0
 - Fix support for Qubes 4.1
 
-* Thu Jun 8 2022 SecureDrop Team <securedrop@freedom.press> - 0.6.3
+* Wed Jun 8 2022 SecureDrop Team <securedrop@freedom.press> - 0.6.3
 - Add support for Qubes 4.1
 
 * Thu Jun 2 2022 SecureDrop Team <securedrop@freedom.press> - 0.6.2


### PR DESCRIPTION
## Status

Ready for review (this does not need to make it into the 0.7.0 release for the dom0 config package)

## Description of Changes

Towards https://github.com/freedomofpress/securedrop-workstation/issues/804

@rocodes's careful eye caught these date format warnings in my build logs: https://github.com/freedomofpress/build-logs/commit/103269a69c32fe4dba916d4a59758bb5f8f40ac1#diff-3c59eea4ec0bb982978f94473d08c0880337abfdbfbe09cba685ce52e4b8d6f8R349-R350, so I'm manually fixing them in this PR.

## Testing

1. Run `make dom0-rpm`
- [ ] Confirm that you no longer see the two warnings:
   ```
   warning: bogus date in %changelog: Thu Jul 5 2022 SecureDrop Team <securedrop@freedom.press> - 0.7.0
   warning: bogus date in %changelog: Thu Jun 8 2022 SecureDrop Team <securedrop@freedom.press> - 0.6.3
   ```