### PR TITLE
Use Bullseye image for CI; don't run obsolete Qt4 tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   lint:
     docker:
-      - image: debian:buster
+      - image: debian:bullseye
     steps:
       - run: apt-get update && apt-get install -y sudo git make
       - checkout
@@ -18,7 +18,7 @@ jobs:
             make black
   buildrpm:
     docker:
-      - image: debian:buster
+      - image: debian:bullseye
     steps:
       - run: apt-get update && apt-get install -y sudo git make
       - checkout
@@ -26,7 +26,7 @@ jobs:
       - run: make dom0-rpm
   reprotest:
     docker:
-      - image: debian:buster
+      - image: debian:bullseye
     steps:
       - run: apt-get update && apt-get install -y sudo git make
       - checkout
@@ -40,21 +40,7 @@ jobs:
       - run: make reprotest-ci
   launcher-tests:
     docker:
-      - image: debian:buster
-    steps:
-      - run: apt-get update && apt-get install -y sudo git make
-      - checkout
-      - run:
-          name: Install Python requirements and run tests for launcher
-          command: |
-            make install-deps
-            sudo apt-get install -y python3-pyqt4
-            cd launcher/
-            make venv && source .venv/bin/activate
-            make check
-  launcher-tests-qt5:
-    docker:
-      - image: debian:buster
+      - image: debian:bullseye
     steps:
       - run: apt-get update && apt-get install -y sudo git make
       - checkout


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #819

- Runs tests in current stable release
- Removes Qt4 tests (we no longer need them and they won't run in Bullseye; cf. #817)

## Testing

- [ ] Confirm that CI is happy and test output looks sane