### PR TITLE
Replace salt/jinja execution modules

### DIFF
--- a/dom0/sd-app-mime-handling.sls
+++ b/dom0/sd-app-mime-handling.sls
@@ -1,0 +1,6 @@
+include:
+  - sd-mime-handling
+
+{% from 'sd-mimeapps-macro.sls' import link_mimeapps with context %}
+
+{{ link_mimeapps('sd-app') }}

--- a/dom0/sd-devices-mime-handling.sls
+++ b/dom0/sd-devices-mime-handling.sls
@@ -1,0 +1,6 @@
+include:
+  - sd-mime-handling
+
+{% from 'sd-mimeapps-macro.sls' import link_mimeapps with context %}
+
+{{ link_mimeapps('sd-devices-dvm') }}

--- a/dom0/sd-mime-handling.sls
+++ b/dom0/sd-mime-handling.sls
@@ -8,8 +8,8 @@
 # Overrides mimetype handling for certain VMs. Instead of relying on the
 # /usr/share/applications (system volume), we instead use /home/user/.local/share/
 # (private volume). The various mimeapps.list files linked are provided by the
-# securedrop-workstation-config package in /opt/, and are symlinked here in their
-# respective AppVMs.
+# securedrop-workstation-config package in /opt/, and are symlinked in their
+# respective AppVMs by calling the mimeapps-macro with the correct symlink target.
 ##
 
 sd-private-volume-mimeapps-config-dir:
@@ -19,31 +19,6 @@ sd-private-volume-mimeapps-config-dir:
     - group: user
     - makedirs: True
     - mode: "0755"
-
-{% set vm_name = salt['cmd.shell']('qubesdb-read /name') %}
-{% if vm_name in ["sd-viewer", "sd-app", "sd-devices-dvm"] %}
-
-sd-private-volume-mimeapps-handling:
-  file.symlink:
-    - name: /home/user/.local/share/applications/mimeapps.list
-    - target: /opt/sdw/mimeapps.list.{{ vm_name }}
-    - user: user
-    - group: user
-    - require:
-      - file: sd-private-volume-mimeapps-config-dir
-
-{% else %}
-
-sd-private-volume-mimeapps-handling:
-  file.symlink:
-    - name: /home/user/.local/share/applications/mimeapps.list
-    - target: /opt/sdw/mimeapps.list.default
-    - user: user
-    - group: user
-    - require:
-      - file: sd-private-volume-mimeapps-config-dir
-
-{% endif %}
 
 sd-private-volume-mailcap-handling:
   file.symlink:

--- a/dom0/sd-mimeapps-macro.sls
+++ b/dom0/sd-mimeapps-macro.sls
@@ -1,0 +1,12 @@
+{% macro link_mimeapps(target) %}
+
+sd-private-volume-mimeapps-handling:
+  file.symlink:
+    - name: /home/user/.local/share/applications/mimeapps.list
+    - target: /opt/sdw/mimeapps.list.{{ target }}
+    - user: user
+    - group: user
+    - require:
+      - file: sd-private-volume-mimeapps-config-dir
+
+{% endmacro %}

--- a/dom0/sd-proxy-mime-handling.sls
+++ b/dom0/sd-proxy-mime-handling.sls
@@ -1,0 +1,6 @@
+include:
+  - sd-mime-handling
+
+{% from 'sd-mimeapps-macro.sls' import link_mimeapps with context %}
+
+{{ link_mimeapps('default') }}

--- a/dom0/sd-usb-autoattach-add.sls
+++ b/dom0/sd-usb-autoattach-add.sls
@@ -6,15 +6,6 @@
 # USB devices to sd-devices.
 ##
 
-# If sys-usb is disposable, we have already set up sd-fedora-dvm to make our
-# modifications in, so we only want to modify sys-usb if it is a regular AppVM
-
-{% set apply = True %}
-{% if grains['id'] == 'sys-usb' and salt['pillar.get']('qvm:sys-usb:disposable', true) %}
-  {% set apply = False %}
-{% endif %}
-
-{% if apply %}
 sd-udev-rules:
   file.managed:
     - name: /rw/config/sd/etc/udev/rules.d/99-sd-devices.rules
@@ -48,4 +39,3 @@ sd-attach-export-device:
     - user: root
     - group: root
     - mode: 0555
-{% endif %}

--- a/dom0/sd-viewer-mime-handling.sls
+++ b/dom0/sd-viewer-mime-handling.sls
@@ -1,0 +1,6 @@
+include:
+  - sd-mime-handling
+
+{% from 'sd-mimeapps-macro.sls' import link_mimeapps with context %}
+
+{{ link_mimeapps('sd-viewer') }}

--- a/dom0/sd-workstation.top
+++ b/dom0/sd-workstation.top
@@ -41,8 +41,7 @@ base:
   securedrop-workstation-bullseye:
     - sd-workstation-template-files
     - sd-logging-setup
-  'sd-fedora-dvm,sys-usb':
-    - match: list
+  sd-fedora-dvm:
     - sd-usb-autoattach-add
   sd-log:
     - sd-logging-setup

--- a/dom0/sd-workstation.top
+++ b/dom0/sd-workstation.top
@@ -35,7 +35,7 @@ base:
     - sd-logging-setup
   sd-app:
     - sd-app-config
-    - sd-mime-handling
+    - sd-app-mime-handling
   sd-whonix:
     - sd-whonix-hidserv-key
   securedrop-workstation-bullseye:
@@ -46,12 +46,12 @@ base:
   sd-log:
     - sd-logging-setup
   sd-viewer:
-    - sd-mime-handling
+    - sd-viewer-mime-handling
   sd-devices-dvm:
-    - sd-mime-handling
+    - sd-devices-mime-handling
   sd-proxy:
     - sd-proxy-files
-    - sd-mime-handling
+    - sd-proxy-mime-handling
 
   # "Placeholder" config to trigger TemplateVM boots,
   # so upgrades can be applied automatically via cron.

--- a/scripts/provision-all
+++ b/scripts/provision-all
@@ -30,9 +30,7 @@ all_sdw_vms_target="$(qvm-ls --tags sd-workstation --raw-list | perl -npE 's/\n/
 echo "Provision all SecureDrop Workstation VMs with service-specific configs"
 sudo qubesctl --show-output --max-concurrency "$max_concurrency" --skip-dom0 --targets "$all_sdw_vms_target" state.highstate
 
-echo "Add SecureDrop export device handling to sys-usb"
-# If sd-fedora-dvm exists it's because salt determined that sys-usb was disposable
-qvm-check --quiet sd-fedora-dvm 2> /dev/null && \
-  sudo qubesctl --show-output --skip-dom0 --targets sd-fedora-dvm state.highstate && \
-  qvm-shutdown --wait sys-usb && qvm-start sys-usb || \
-  sudo qubesctl --show-output --skip-dom0 --targets sys-usb state.highstate
+echo "Add SecureDrop export device handling to template for sys-usb"
+# Only disposable sys-usb is supported, so add export handling to sys-usb template
+sudo qubesctl --show-output --skip-dom0 --targets sd-fedora-dvm state.highstate && \
+qvm-shutdown --wait sys-usb && qvm-start sys-usb


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #826

Changes proposed in this pull request:

Avoid use of jinja/salt execution modules in default-mgmt-dvm. (Upstream: https://github.com/saltstack/salt/issues/62636).
 
Notes:
- Use of execution modules (for example, `salt['cmd.get']`) is unchanged in dom0, since Salt version there is more stable and is unaffected by this issue.
- The approach I took with @eaon initially relied on writing a custom grain to set the hostname; however, it's likely subject to the same bugginess as the original implementation with `grains['id']`, which we changed in favour of the execution module in 2021. The approach I've taken now involves separate sls files targeting each vm, but to keep things DRY they all use the same underlying macro.  It's a little bit clunky (cause there are small extra files), but it probably means we can boost our `max_concurrency` again (see https://github.com/freedomofpress/securedrop-workstation/issues/710), which the custom grains approach would not let us do. 
- We may not need this entire PR if the upstream fix gets merged soon.

## Testing

- [ ] Ensure you can repro the bug in #826 or the upstream bug on your target machine if you haven't done so already.
- [ ] Ensure provisioning works correctly: check out this branch then `make clean`, `make clone`, `make dev`
- [ ] Provisioning completes successfully. USB autoattach udev rules are present in `/etc/udev/rules.d/99-sd-devices.rules` on sd-fedora-dvm, and mimeapps.list symlink is correct in sd-app (sd-app), sd-devices-dvm (sd-devices-dvm), sd-proxy (default), sd-viewer (sd-viewer).
- [ ] `make test` passes on dom0

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing pilot instances
2. New installs

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`  **todo**

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`  **todo**
