### PR TITLE
Rely on systemd services for securedrop-log's provisioning

### DIFF
--- a/dom0/sd-gpg.sls
+++ b/dom0/sd-gpg.sls
@@ -26,6 +26,9 @@ sd-gpg:
       - template: sd-small-{{ sdvars.distribution }}-template
       - netvm: ""
       - autostart: true
+    - features:
+      - enable:
+        - service.securedrop-logging-disabled
     - tags:
       - add:
         - sd-workstation

--- a/dom0/sd-log.sls
+++ b/dom0/sd-log.sls
@@ -31,7 +31,8 @@ sd-log:
       - enable:
         - service.paxctld
         - service.redis
-        - service.securedrop-log
+        - service.securedrop-logging-disabled
+        - service.securedrop-log-server
     - require:
       - qvm: sd-small-{{ sdvars.distribution }}-template
 

--- a/dom0/sd-logging-setup.sls
+++ b/dom0/sd-logging-setup.sls
@@ -14,12 +14,6 @@ install-securedrop-log-package:
     - require:
       - sls: fpf-apt-repo
 
-# configure all VMs to send to sd-log - excluded on a per-VM basis below via /rw
-configure-rsyslog-for-sd:
-  file.managed:
-    - name: /etc/sd-rsyslog.conf
-    - source: "salt://sd-rsyslog.conf.j2"
-
 {% endif %}
 
 {% if grains['id'] == "sd-small-{}-template".format(grains['oscodename']) %}
@@ -28,47 +22,5 @@ install-redis-for-sd-log-template:
     - pkgs:
       - redis-server
       - redis
-
-{% elif grains['id'] == "sd-log" %}
-# Only for the "sd-log" AppVM, configure /rw/config to disable
-# custom log config, and also start the necessary services.
-sd-log-remove-rsyslog-qubes-plugin:
-  file.blockreplace:
-    - name: /rw/config/rc.local
-    - append_if_not_found: True
-    - marker_start: "### BEGIN securedrop-workstation ###"
-    - marker_end: "### END securedrop-workstation ###"
-    - content: |
-        # Removes sdlog.conf file for rsyslog
-        rm -f /etc/rsyslog.d/sdlog.conf
-        systemctl restart rsyslog
-        systemctl start redis
-        systemctl start securedrop-log
-        exit 0
-  cmd.run:
-    - name: /rw/config/rc.local
-    - require:
-      - file: sd-log-remove-rsyslog-qubes-plugin
-remove-sd-rsyslog-config-for-logserver:
-  file.absent:
-    - name: /etc/rsyslog.d/sdlog.conf
-
-{% elif grains['id'] == "sd-gpg" %}
-# For sd-gpg, we disable logging altogether, since access
-# to the keyring will be logged in sd-app
-sd-gpg-remove-rsyslog-qubes-plugin:
-  file.blockreplace:
-    - name: /rw/config/rc.local
-    - append_if_not_found: True
-    - marker_start: "### BEGIN securedrop-workstation ###"
-    - marker_end: "### END securedrop-workstation ###"
-    - content: |
-        # Removes sdlog.conf file for rsyslog
-        rm -f /etc/rsyslog.d/sdlog.conf
-        systemctl restart rsyslog
-  cmd.run:
-    - name: /rw/config/rc.local
-    - require:
-      - file: sd-gpg-remove-rsyslog-qubes-plugin
 
 {% endif %}

--- a/dom0/sd-rsyslog.conf.j2
+++ b/dom0/sd-rsyslog.conf.j2
@@ -1,2 +1,0 @@
-[sd-rsyslog]
-remotevm = sd-log

--- a/dom0/sd-workstation.top
+++ b/dom0/sd-workstation.top
@@ -34,7 +34,6 @@ base:
     - sd-viewer-files
   sd-gpg:
     - sd-gpg-files
-    - sd-logging-setup
   sd-app:
     - sd-mime-handling
   sd-whonix:

--- a/dom0/sd-workstation.top
+++ b/dom0/sd-workstation.top
@@ -42,8 +42,6 @@ base:
   'sd-fedora-39-dvm,sys-usb':
     - match: list
     - sd-usb-autoattach-add
-  sd-log:
-    - sd-logging-setup
   sd-viewer:
     - sd-mime-handling
   sd-devices-dvm:

--- a/files/provision-all
+++ b/files/provision-all
@@ -26,7 +26,7 @@ sudo qubesctl --show-output state.highstate
 
 echo ".........................................................................."
 echo "Set up logging VMs early"
-sudo qubesctl --show-output --skip-dom0 --targets sd-log,sd-small-bookworm-template state.highstate
+sudo qubesctl --show-output --skip-dom0 --targets sd-small-bookworm-template state.highstate
 
 # Reboot sd-log so it's ready to receive logs from other VMs about to be configured
 qvm-shutdown --wait sd-log && qvm-start sd-log

--- a/tests/base.py
+++ b/tests/base.py
@@ -114,6 +114,16 @@ class SD_VM_Local_Test(unittest.TestCase):
 
         return True
 
+    def _service_is_active(self, service):
+        try:
+            results = self._run(f"sudo systemctl is-active {service}")
+        except subprocess.CalledProcessError as e:
+            if e.returncode == 3:
+                return False  # exit code 3 == inactive
+            else:
+                raise e
+        return results == "active"
+
     def assertFilesMatch(self, remote_path, local_path):
         remote_content = self._get_file_contents(remote_path)
 
@@ -167,6 +177,9 @@ class SD_VM_Local_Test(unittest.TestCase):
         """
         Make sure rsyslog is configured to send in data to sd-log vm.
         """
+        # Logging is not disabled
+        self.assertFalse(self._fileExists("/var/run/qubes-service/securedrop-logging-disabled"))
+
         self.assertTrue(self._package_is_installed("securedrop-log"))
         self.assertTrue(self._fileExists("/usr/sbin/sd-rsyslog"))
         self.assertTrue(self._fileExists("/etc/rsyslog.d/sdlog.conf"))

--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -79,6 +79,7 @@ class SD_GPG_Tests(SD_VM_Local_Test):
     def test_logging_disabled(self):
         # Logging to sd-log should be disabled on sd-gpg
         self.assertFalse(self._fileExists("/etc/rsyslog.d/sdlog.conf"))
+        self.assertTrue(self._fileExists("/var/run/qubes-service/securedrop-logging-disabled"))
 
 
 def load_tests(loader, tests, pattern):

--- a/tests/test_log_vm.py
+++ b/tests/test_log_vm.py
@@ -16,19 +16,17 @@ class SD_Log_Tests(SD_VM_Local_Test):
         self.assertTrue(self._package_is_installed("redis-server"))
 
     def test_log_utility_installed(self):
-        self.assertTrue(self._fileExists("/usr/sbin/securedrop-log"))
+        self.assertTrue(self._fileExists("/usr/sbin/securedrop-log-saver"))
         self.assertTrue(self._fileExists("/etc/qubes-rpc/securedrop.Log"))
 
     def test_sd_log_has_no_custom_rsyslog(self):
         self.assertFalse(self._fileExists("/etc/rsyslog.d/sdlog.conf"))
 
     def test_sd_log_service_running(self):
-        results = self._run("sudo systemctl is-active securedrop-log")
-        assert results == "active"
+        self.assertTrue(self._service_is_active("securedrop-log-server"))
 
     def test_redis_service_running(self):
-        results = self._run("sudo systemctl is-active redis")
-        assert results == "active"
+        self.assertTrue(self._service_is_active("redis"))
 
     def test_logs_are_flowing(self):
         cmd_output = self._run("ls -1 /home/user/QubesIncomingLogs")


### PR DESCRIPTION
## Description of Changes

With https://github.com/freedomofpress/securedrop-log/pull/34 and https://github.com/freedomofpress/securedrop-debian-packaging/pull/396, the relevant services/configurations are triggered by conditional systemd services, allow us to cut down on provisioning complexity.

Fixes: https://github.com/freedomofpress/securedrop-workstation/issues/1033

## Testing

This change depends on another PR: https://github.com/freedomofpress/securedrop-client/pull/1677

Once these PRs are merged, this PR can be tested with nightlies.

TK.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing pilot instances
2. New installs

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`
