### PR TITLE
Launch correct SecureDrop Client .desktop application

### DIFF
--- a/launcher/sdw_updater_gui/UpdaterApp.py
+++ b/launcher/sdw_updater_gui/UpdaterApp.py
@@ -18,7 +18,7 @@ def launch_securedrop_client():
     """
     try:
         logger.info("Launching SecureDrop client")
-        subprocess.Popen(["qvm-run", "sd-app", "gtk-launch securedrop-client"])
+        subprocess.Popen(["qvm-run", "sd-app", "gtk-launch press.freedom.SecureDropClient"])
     except subprocess.CalledProcessError as e:
         logger.error("Error while launching SecureDrop client")
         logger.error(str(e))


### PR DESCRIPTION
## Description of Changes

Due to a file name change in [securedrop-client#1600](https://github.com/freedomofpress/securedrop-client/pull/1600) and [securedrop-client#1601](https://github.com/freedomofpress/securedrop-client/pull/1601), the client wouldn't get launched because the `securedrop-client.desktop` does not exist any longer. 

Towards #843.

## Testing

- [ ] Using the `dev` environment in `config.json`, the SecureDrop Client gets launched after using the launcher on the desktop
