### PR TITLE
Make our VMs internal, hiding their applications from the menu

### DIFF
--- a/securedrop_salt/sd-app.sls
+++ b/securedrop_salt/sd-app.sls
@@ -9,6 +9,9 @@
 # Imports "sdvars" for environment config
 {% from 'securedrop_salt/sd-default-config.sls' import sdvars with context %}
 
+# Check environment
+{% import_json "securedrop_salt/config.json" as d %}
+
 include:
   - securedrop_salt.sd-workstation-template
   - securedrop_salt.sd-upgrade-templates
@@ -26,6 +29,10 @@ sd-app:
         - sd-client
         - sd-workstation
     - features:
+    {% if d.environment == "prod" %}
+      - set:
+        - internal: 1
+    {% endif %}
       - enable:
         - service.paxctld
         - service.securedrop-mime-handling
@@ -33,8 +40,6 @@ sd-app:
         - vm-config.SD_MIME_HANDLING: sd-app
     - require:
       - qvm: sd-small-{{ sdvars.distribution }}-template
-
-{% import_json "securedrop_salt/config.json" as d %}
 
 sd-app-config:
   qvm.features:

--- a/securedrop_salt/sd-gpg.sls
+++ b/securedrop_salt/sd-gpg.sls
@@ -12,6 +12,9 @@
 # Imports "sdvars" for environment config
 {% from 'securedrop_salt/sd-default-config.sls' import sdvars with context %}
 
+# Check environment
+{% import_json "securedrop_salt/config.json" as d %}
+
 include:
   - securedrop_salt.sd-workstation-template
   - securedrop_salt.sd-upgrade-templates
@@ -29,6 +32,10 @@ sd-gpg:
     - features:
       - enable:
         - service.securedrop-logging-disabled
+    {% if d.environment == "prod" %}
+      - set:
+        - internal: 1
+    {% endif %}
     - tags:
       - add:
         - sd-workstation

--- a/securedrop_salt/sd-log.sls
+++ b/securedrop_salt/sd-log.sls
@@ -10,6 +10,9 @@
 # Imports "sdvars" for environment config
 {% from 'securedrop_salt/sd-default-config.sls' import sdvars with context %}
 
+# Check environment
+{% import_json "securedrop_salt/config.json" as d %}
+
 include:
   - securedrop_salt.sd-workstation-template
   - securedrop_salt.sd-upgrade-templates
@@ -28,6 +31,10 @@ sd-log:
       - add:
         - sd-workstation
     - features:
+    {% if d.environment == "prod" %}
+      - set:
+        - internal: 1
+    {% endif %}
       - enable:
         - service.paxctld
         - service.redis
@@ -35,8 +42,6 @@ sd-log:
         - service.securedrop-log-server
     - require:
       - qvm: sd-small-{{ sdvars.distribution }}-template
-
-{% import_json "securedrop_salt/config.json" as d %}
 
 # The private volume size should be set in config.json
 sd-log-private-volume-size:

--- a/securedrop_salt/sd-proxy.sls
+++ b/securedrop_salt/sd-proxy.sls
@@ -13,6 +13,7 @@
 include:
   - securedrop_salt.sd-whonix
   - securedrop_salt.sd-upgrade-templates
+  - securedrop_salt.sd-workstation-template
 
 sd-proxy-dvm:
   qvm.vm:
@@ -68,3 +69,5 @@ sd-proxy-config:
     - name: sd-proxy
     - set:
         - vm-config.SD_PROXY_ORIGIN: http://{{ d.hidserv.hostname }}
+    - require:
+      - qvm: sd-proxy-create-named-dispvm

--- a/securedrop_salt/sd-proxy.sls
+++ b/securedrop_salt/sd-proxy.sls
@@ -8,6 +8,7 @@
 
 # Imports "sdvars" for environment config
 {% from 'securedrop_salt/sd-default-config.sls' import sdvars with context %}
+{% import_json "securedrop_salt/config.json" as d %}
 
 include:
   - securedrop_salt.sd-whonix
@@ -23,6 +24,11 @@ sd-proxy-dvm:
       - netvm: sd-whonix
       - template_for_dispvms: True
       - default_dispvm: ""
+  {% if d.environment == "prod" %}
+    - features:
+      - set:
+        - internal: 1
+  {% endif %}
     - tags:
       - add:
         - sd-workstation
@@ -47,14 +53,15 @@ sd-proxy-create-named-dispvm:
         - service.securedrop-mime-handling
       - set:
           - vm-config.SD_MIME_HANDLING: default
+      {% if d.environment == "prod" %}
+          - internal: 1
+      {% endif %}
     - tags:
       - add:
         - sd-workstation
         - sd-{{ sdvars.distribution }}
     - require:
       - qvm: sd-proxy-dvm
-
-{% import_json "securedrop_salt/config.json" as d %}
 
 sd-proxy-config:
   qvm.features:

--- a/securedrop_salt/sd-viewer.sls
+++ b/securedrop_salt/sd-viewer.sls
@@ -14,6 +14,9 @@
 # Imports "sdvars" for environment config
 {% from 'securedrop_salt/sd-default-config.sls' import sdvars with context %}
 
+# Check environment
+{% import_json "securedrop_salt/config.json" as d %}
+
 include:
   - securedrop_salt.sd-workstation-template
   - securedrop_salt.sd-upgrade-templates
@@ -35,6 +38,10 @@ sd-viewer:
         - sd-viewer-vm
         - sd-{{ sdvars.distribution }}
     - features:
+    {% if d.environment == "prod" %}
+      - set:
+        - internal: 1
+    {% endif %}
       - enable:
         - service.paxctld
         - service.securedrop-mime-handling


### PR DESCRIPTION
## Description of Changes

We want our users to interact with the system through the client, which is started via the updater, rather than directly with a VM which would be the normal Qubes way. This should make the menu a bit less noisy as well.

The omission of `sd-whonix` is intentional, as it contains a couple of Tor related GUI tools that users might need access to and have no other way to get to.

**Todo:** add tests.

## Testing

- [ ] After running `sdw-admin --apply` / `make dev`, all of our VMs with the exception of `sd-whonix` and `sd-devices` are hidden from the Qubes menu.
- [ ] Tests in `dom0` pass