### PR TITLE
Bump supported Fedora release to 37

### DIFF
--- a/dom0/sd-clean-all.sls
+++ b/dom0/sd-clean-all.sls
@@ -34,11 +34,11 @@ restore-sys-usb-dispvm-start:
     - require:
       - qvm: restore-sys-usb-dispvm
 
-# autoattach modifications are only present in sd-fedora-dvm
+# autoattach modifications are only present in sd-fedora-37-dvm
 # so no more sd-usb-autoattach-remove necessary
 remove-sd-fedora-dispvm:
   qvm.absent:
-    - name: sd-fedora-dvm
+    - name: sd-fedora-37-dvm
     - require:
       - qvm: restore-sys-usb-dispvm
 {% else %}

--- a/dom0/sd-clean-all.sls
+++ b/dom0/sd-clean-all.sls
@@ -5,7 +5,7 @@
 
 set-fedora-as-default-dispvm:
   cmd.run:
-    - name: qvm-check fedora-36-dvm && qubes-prefs default_dispvm fedora-36-dvm || qubes-prefs default_dispvm ''
+    - name: qvm-check fedora-37-dvm && qubes-prefs default_dispvm fedora-37-dvm || qubes-prefs default_dispvm ''
 
 {% set gui_user = salt['cmd.shell']('groupmems -l -g qubes') %}
 
@@ -23,7 +23,7 @@ restore-sys-usb-dispvm-halt-wait:
 restore-sys-usb-dispvm:
   qvm.prefs:
     - name: sys-usb
-    - template: fedora-36-dvm
+    - template: fedora-37-dvm
     - require:
       - cmd: restore-sys-usb-dispvm-halt-wait
       - cmd: set-fedora-as-default-dispvm

--- a/dom0/sd-clean-default-dispvm.sls
+++ b/dom0/sd-clean-default-dispvm.sls
@@ -3,4 +3,4 @@
 
 set-fedora-as-default-dispvm:
   cmd.run:
-    - name: qvm-check fedora-36-dvm && qubes-prefs default_dispvm fedora-36-dvm || qubes-prefs default_dispvm ''
+    - name: qvm-check fedora-37-dvm && qubes-prefs default_dispvm fedora-37-dvm || qubes-prefs default_dispvm ''

--- a/dom0/sd-sys-vms.sls
+++ b/dom0/sd-sys-vms.sls
@@ -61,10 +61,7 @@ set-fedora-default-template-version:
   {% set _ = required_dispvms.append("sd-" + sd_supported_fedora_version + "-dvm") %}
 {% endif %}
 
-{% set existing_vms = salt['cmd.shell']('qvm-ls --raw-list').split('\n') %}
-
 {% for required_dispvm in required_dispvms %}
-{% if required_dispvm not in existing_vms %}
 create-{{ required_dispvm }}:
   qvm.vm:
     - name: {{ required_dispvm }}
@@ -79,9 +76,7 @@ create-{{ required_dispvm }}:
 {% endif %}
     - require:
       - cmd: dom0-install-fedora-template
-{% endif %}
 {% endfor %}
-
 
 # Now proceed with rebooting all the sys-* VMs, since the new template is up to date.
 

--- a/dom0/sd-sys-vms.sls
+++ b/dom0/sd-sys-vms.sls
@@ -125,7 +125,7 @@ sd-{{ sys_vm }}-fedora-version-update:
 # We're numbering our VMs now even though its contents wouldn't change, to work
 # around Salt's limitations, so the non-numbered VM should be removed.
 {% if sys_vm == "sys-usb" %}
-remove-old-fedora-dvm:
+remove-sd-fedora-dvm:
   qvm.absent:
     - name: sd-fedora-dvm
     - require:

--- a/dom0/sd-sys-vms.sls
+++ b/dom0/sd-sys-vms.sls
@@ -118,17 +118,18 @@ sd-{{ sys_vm }}-fedora-version-update:
       - template: {{ sd_supported_fedora_template }}
     - require:
       - cmd: sd-{{ sys_vm }}-fedora-version-halt-wait
-{% if not dvm_needs_updating and sd_supported_fedora_template.endswith("-dvm") %}
+{% if sd_supported_fedora_template.endswith("-dvm") %}
       - qvm: create-{{ sd_supported_fedora_template }}
 {% endif %}
 
 # We're numbering our VMs now even though its contents wouldn't change, to work
 # around Salt's limitations, so the non-numbered VM should be removed.
 {% if sys_vm == "sys-usb" %}
+remove-old-fedora-dvm:
   qvm.absent:
     - name: sd-fedora-dvm
     - require:
-        qvm: sd-sys-usb-fedora-version-update
+      - qvm: sd-sys-usb-fedora-version-update
 {% endif %}
 
 sd-{{ sys_vm }}-fedora-version-start:

--- a/dom0/sd-usb-autoattach-add.sls
+++ b/dom0/sd-usb-autoattach-add.sls
@@ -6,7 +6,7 @@
 # USB devices to sd-devices.
 ##
 
-# If sys-usb is disposable, we have already set up sd-fedora-dvm to make our
+# If sys-usb is disposable, we have already set up sd-fedora-37-dvm to make our
 # modifications in, so we only want to modify sys-usb if it is a regular AppVM
 
 {% set apply = True %}

--- a/dom0/sd-workstation.top
+++ b/dom0/sd-workstation.top
@@ -41,7 +41,7 @@ base:
   securedrop-workstation-bullseye:
     - sd-workstation-template-files
     - sd-logging-setup
-  'sd-fedora-dvm,sys-usb':
+  'sd-fedora-37-dvm,sys-usb':
     - match: list
     - sd-usb-autoattach-add
   sd-log:

--- a/launcher/sdw_updater_gui/Updater.py
+++ b/launcher/sdw_updater_gui/Updater.py
@@ -40,7 +40,7 @@ detail_log = Util.get_logger(prefix=DETAIL_LOGGER_PREFIX, module=__name__)
 # as well as their associated TemplateVMs.
 # In the future, we could use qvm-prefs to extract this information.
 current_vms = {
-    "fedora": "fedora-36",
+    "fedora": "fedora-37",
     "sd-viewer": "sd-large-{}-template".format(DEBIAN_VERSION),
     "sd-app": "sd-small-{}-template".format(DEBIAN_VERSION),
     "sd-log": "sd-small-{}-template".format(DEBIAN_VERSION),

--- a/launcher/tests/test_updater.py
+++ b/launcher/tests/test_updater.py
@@ -492,7 +492,7 @@ def test_shutdown_and_start_vms(
         call("sys-usb"),
     ]
     template_vm_calls = [
-        call("fedora-36"),
+        call("fedora-37"),
         call("sd-large-{}-template".format(DEBIAN_VERSION)),
         call("sd-small-{}-template".format(DEBIAN_VERSION)),
         call("whonix-gw-16"),
@@ -538,7 +538,7 @@ def test_shutdown_and_start_vms_sysvm_fail(
         call("sd-log"),
     ]
     template_vm_calls = [
-        call("fedora-36"),
+        call("fedora-37"),
         call("sd-large-{}-template".format(DEBIAN_VERSION)),
         call("sd-small-{}-template".format(DEBIAN_VERSION)),
         call("whonix-gw-16"),

--- a/scripts/provision-all
+++ b/scripts/provision-all
@@ -31,8 +31,8 @@ echo "Provision all SecureDrop Workstation VMs with service-specific configs"
 sudo qubesctl --show-output --max-concurrency "$max_concurrency" --skip-dom0 --targets "$all_sdw_vms_target" state.highstate
 
 echo "Add SecureDrop export device handling to sys-usb"
-# If sd-fedora-dvm exists it's because salt determined that sys-usb was disposable
-qvm-check --quiet sd-fedora-dvm 2> /dev/null && \
-  sudo qubesctl --show-output --skip-dom0 --targets sd-fedora-dvm state.highstate && \
+# If sd-fedora-37-dvm exists it's because salt determined that sys-usb was disposable
+qvm-check --quiet sd-fedora-37-dvm 2> /dev/null && \
+  sudo qubesctl --show-output --skip-dom0 --targets sd-fedora-37-dvm state.highstate && \
   qvm-shutdown --wait sys-usb && qvm-start sys-usb || \
   sudo qubesctl --show-output --skip-dom0 --targets sys-usb state.highstate

--- a/tests/base.py
+++ b/tests/base.py
@@ -7,7 +7,7 @@ from qubesadmin import Qubes
 
 # Reusable constant for DRY import across tests
 WANTED_VMS = ["sd-gpg", "sd-log", "sd-proxy", "sd-app", "sd-viewer", "sd-whonix", "sd-devices"]
-CURRENT_FEDORA_VERSION = "36"
+CURRENT_FEDORA_VERSION = "37"
 CURRENT_FEDORA_TEMPLATE = "fedora-" + CURRENT_FEDORA_VERSION
 CURRENT_WHONIX_VERSION = "16"
 

--- a/tests/test_qubes_vms.py
+++ b/tests/test_qubes_vms.py
@@ -30,7 +30,7 @@ class SD_Qubes_VM_Tests(unittest.TestCase):
             wanted_templates = [CURRENT_FEDORA_TEMPLATE]
             if sys_vm in sys_vms_maybe_disp:
                 if sys_vm in sys_vms_custom_disp:
-                    wanted_templates.append("sd-fedora-dvm")
+                    wanted_templates.append("sd-fedora-37-dvm")
                 else:
                     wanted_templates.append(CURRENT_FEDORA_TEMPLATE + "-dvm")
 


### PR DESCRIPTION
## Description of Changes

Fedora 37 will be shipped with Qubes OS R4.1.2. As soon as Qubes R4.1.2 has been released, this should probably be merged so that the next release doesn't download Fedora 36 unnecessarily.

Fixes #841

## Testing

- [ ] There are no references to Fedora 36 left in the repository
- [ ] `sd-fedora-37-dvm` is used in place of `sd-fedora-dvm` through the repo (except for the salt state removing the latter)
- Check out this branch in your sd-dev vm and ensure you [set the SDW environment variables](https://developers.securedrop.org/en/latest/workstation_setup.html#download-configure-copy-to-dom0). Ensure SD VMs (lookin at you, sd-whonix) are all shut down (otherwise, during `make test`, you could encounter tests that report that VMs aren't fully updated). In dom0 `make clone` then `make dev`
   - [ ] `make dev` completes without error
   - [ ] `sd-fedora-37-dvm` exists and is based on `fedora-37`
   - [ ] `sd-fedora-dvm` is removed
   - [ ] `make test` passes in dom0

Note that removing the f36 template/f36-dvm template is _not_ part of the template update process.