### PR TITLE
Add -r to xargs invocation in case no .rpm files are found

### DIFF
--- a/scripts/prep-dev
+++ b/scripts/prep-dev
@@ -14,7 +14,7 @@ function find_latest_rpm() {
     # Look up which version of dom0 we're using.
     # Qubes 4.0 is fedora-25, Qubes 4.1 will be fedora-32.
     fedora_version="$(rpm --eval '%{fedora}')"
-    find "${dom0_dev_dir}/rpm-build/RPMS/" -type f -iname "*fc${fedora_version}.noarch.rpm" -print0 | xargs -0 ls -t | head -n 1
+    find "${dom0_dev_dir}/rpm-build/RPMS/" -type f -iname "*fc${fedora_version}.noarch.rpm" -print0 | xargs -r -0 ls -t | head -n 1
 }
 
 latest_rpm="$(find_latest_rpm)"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

If no matching `.rpm` files exist, the `find | xargs` in `scripts/prep-dev` will run `ls` with no arguments, listing files in the current directory, and then attempt to install whatever other file showed up there as most recently modified as an RPM. This adds `-r` so that there will be no output, and the test to bail out in that case works as intended.

## Testing

Remove any RPMs in `rpm-build/RPMS` and try running `./scripts/prep-dev`. It should print `Could not find RPM!` and exit with failure, instead of attempting to run `rpm` on `config.json` or the like.

## Deployment

N/A, dev-related change.