### PR TITLE
fix: pass `--no-show-signature` to `git log`

### DIFF
--- a/scripts/build-dom0-rpm
+++ b/scripts/build-dom0-rpm
@@ -21,7 +21,7 @@ git clean -fdX rpm-build/ dist/
 # SOURCE_DATE_EPOCH="$(git tag | sort -V | tail -n 1 | xargs git log -1 --format=%at)"
 # Use the epoch time of the most recent commit. If works in dev,
 # as well as building from signed tags.
-SOURCE_DATE_EPOCH="$(git log -1 --format=%at HEAD)"
+SOURCE_DATE_EPOCH="$(git log -1 --format=%at --no-show-signature HEAD)"
 export SOURCE_DATE_EPOCH
 
 # Place tarball where rpmbuild will find it


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

If `$SECUREDROP_DEV_VM`'s Git has `log.showsignature=true`, that output will be included in `$SOURCE_DATE_EPOCH`, and `rpmbuild` will choke on it.  (Therefore so will `make clone` from `dom0`).  Here we disable it explicitly.

Without this change:

```sh-session
user@sd-dev:~/securedrop-workstation$ make dom0-rpm
[...]
error: Bad exit status from /var/tmp/rpm-tmp.9NJJFt (%install)
    unable to parse SOURCE_DATE_EPOCH
    Bad exit status from /var/tmp/rpm-tmp.9NJJFt (%install)
make: *** [Makefile:26: dom0-rpm] Error 1
user@sd-dev:~/securedrop-workstation$ git log -1 --format=%at HEAD
gpg: Signature made Tue 28 Mar 2023 01:38:50 PM PDT
gpg:                using RSA key 4AEE18F83AFDEB23
gpg: Can't check signature: No public key
1680035930
user@sd-dev:~/securedrop-workstation$ git config log.showsignature
true
```

## Testing

```sh-session
$ git config log.showsignature true
$ make dom0-rpm  # passes
```

## Deployment

No special considerations.