### PR TITLE
[0.8.0] Force a full migration for Fedora 37 template upgrade

### DIFF
--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -131,6 +131,8 @@ find /srv/salt -maxdepth 1 -type f -iname '*.top' \
     | xargs -n1 basename \
     | sed -e 's/\.top$$//g' \
     | xargs qubesctl top.enable > /dev/null
+mkdir -p /tmp/sdw-migrations
+touch /tmp/sdw-migrations/f37-update
 
 %changelog
 * Mon Apr 3 2023 SecureDrop Team <securedrop@freedom.press> - 0.8.0-rc1


### PR DESCRIPTION
## Status

Ready for review ?

## Description of Changes

The files needed for USB auto-attachment are only copied into sd-fedora-37-dvm during a full `sdw-admin --apply` run, which doesn't happen by default because it's slow.

Set a flag file to tell the updater to do a full migration. This is basically the same as was used in d4a8d1ba60f7.

Refs <https://github.com/freedomofpress/securedrop-workstation/issues/866#issuecomment-1496205177>.

## Testing

If you made non-trivial code changes, include a test plan and validated it for this PR.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing pilot instances
2. New installs

## Checklist

- [ ] All tests (`make test`) pass in `dom0`
- [x] CI passes
- [x] Target branch set to `release/0.8.0`