### PR TITLE
Don't verify a specific kernel version

### DIFF
--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -6,7 +6,6 @@ from base import WANTED_VMS
 
 
 DEBIAN_VERSION = "bullseye"
-EXPECTED_KERNEL_VERSION = "5.15.41-grsec-workstation"
 
 
 class SD_VM_Tests(unittest.TestCase):
@@ -31,11 +30,10 @@ class SD_VM_Tests(unittest.TestCase):
         self.assertTrue(vm.virt_mode == "hvm")
         self.assertTrue(vm.kernel == "")
 
-        # Check exact kernel version in VM
+        # Check kernel flavor in VM
         stdout, stderr = vm.run("uname -r")
         kernel_version = stdout.decode("utf-8").rstrip()
         assert kernel_version.endswith("-grsec-workstation")
-        assert kernel_version == EXPECTED_KERNEL_VERSION
 
     def _check_service_running(self, vm, service):
         """


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

We are now shipping kernels more frequently, so it's not useful to assert an exact kernel version is being used, continually needing to be manually updated.

As of <https://github.com/freedomofpress/securedrop/commit/9cd5e8d107a1997ffcb9e061113932911ab20bfe> in SecureDrop server, we only verify that the running kernel is using the correct grsec flavor, which is what I've updated this test to match.

Fixes #872.

## Testing

* [ ] Visual review
* [ ] If desired, do a `make test` run, should have no failures (or at least this test should no longer be failing!)

## Deployment

Any special considerations for deployment? No, test only.

## Checklist

- [ ] All tests (`make test`) pass in `dom0`
