### PR TITLE
Pass -it to container.sh's oci_run() only if we're a tty

### DIFF
--- a/scripts/container.sh
+++ b/scripts/container.sh
@@ -17,6 +17,11 @@ if [[ "$(uname -sm)" != "Linux x86_64" ]]; then
     OCI_BUILD_ARGUMENTS="${OCI_RUN_ARGUMENTS} --platform linux/amd64"
 fi
 
+# Pass -it if we're a tty
+if test -t 0; then
+    OCI_RUN_ARGUMENTS="${OCI_RUN_ARGUMENTS} -it"
+fi
+
 function oci_image() {
     NAME="${1}"
 
@@ -63,7 +68,7 @@ function oci_run() {
            --workdir "${TOPLEVEL}" \
            --name "${NAME}" \
            --hostname "${NAME}" \
-           -ti $OCI_RUN_ARGUMENTS "${NAME}" "${@:2}"
+           $OCI_RUN_ARGUMENTS "${NAME}" "${@:2}"
 }
 
 oci_image "${PROJECT}"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Works towards: https://github.com/freedomofpress/securedrop-workstation-ci/issues/15

Since the containerization of building the RPM, when `make clone` is run in dom0, it errors with `make: *** [Makefile:49: clone] Error 2`

See an example in the CI output [here](https://ws-ci-runner.securedrop.org/2023-05-01-181242881507.log.txt).

The cause is because of the `-ti`, as reported in the journalctl of the dev appVM that's running the container image build/run:

```
[...]
Apr 28 14:48:58 sd-ssh qubes.VMShell-dom0[4341]: #10 DONE 20.5s
Apr 28 14:48:58 sd-ssh qubes.VMShell-dom0[4341]: 
Apr 28 14:48:58 sd-ssh qubes.VMShell-dom0[4341]: #11 [7/7] RUN if test user != root ; then useradd --no-create-home --home-dir /tmp --uid 1000 user && echo "user ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers ; fi
Apr 28 14:48:58 sd-ssh qubes.VMShell-dom0[4341]: #11 DONE 0.3s
Apr 28 14:48:58 sd-ssh qubes.VMShell-dom0[4341]: 
Apr 28 14:48:58 sd-ssh qubes.VMShell-dom0[4341]: #12 exporting to image
Apr 28 14:48:58 sd-ssh qubes.VMShell-dom0[4341]: #12 exporting layers
Apr 28 14:49:01 sd-ssh qubes.VMShell-dom0[4341]: #12 exporting layers 3.1s done
Apr 28 14:49:01 sd-ssh qubes.VMShell-dom0[4341]: #12 writing image sha256:7e7268b735b85a433a68e6cb72bb363ea00f5a5dd15d2a69ed6dd132fb4b9e1d done
Apr 28 14:49:01 sd-ssh qubes.VMShell-dom0[4341]: #12 naming to docker.io/library/securedrop-workstation-dom0-config done
Apr 28 14:49:01 sd-ssh qubes.VMShell-dom0[4341]: #12 DONE 3.1s
Apr 28 14:49:02 sd-ssh qubes.VMShell-dom0[4341]: the input device is not a TTY
```

Simple fix, we can conditionally drop the `-ti` if we're not in a TTY same as is done in the [securedrop project's build-debs.sh](https://github.com/freedomofpress/securedrop/blob/d01e743d2853d42c47459163dfae05e4540344f1/builder/build-debs.sh#L18). Thanks @legoktm for the tip!

## Testing

Run `make clone` in dom0 and confirm you don't get a non-zero return code. 

Or, you can look at the CI [build log](https://ws-ci-runner.securedrop.org/2023-05-02-092929673026.log.txt) of this commit, which now passes, compared to the previous build log linked above.

## Deployment

No special considerations, this is just a build fix for developers (and the new CI flow!) I think.

## Checklist

### If you have made changes to the provisioning logic

- [x] All tests (`make test`) pass in `dom0` - see the 'sd-ci-runner' build log linked to this commit.