### PR TITLE
Don't allow running sdw-admin.py as root

### DIFF
--- a/files/sdw-admin.py
+++ b/files/sdw-admin.py
@@ -134,6 +134,9 @@ def perform_uninstall(keep_template_rpm=False):
 
 
 def main():
+    if os.geteuid() == 0:
+        print("Please do not run this script as root.")
+        sys.exit(0)
     args = parse_args()
     if args.validate:
         print("Validating...")


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #861 

Changes proposed in this pull request: simple low-hanging fruit to prevent `sdw-admin.py` from being run as root.

(This was a useful change to test my CI environment after migrating it to Fedora 37)