### PR TITLE
Check if template is installed before trying to install it

### DIFF
--- a/dom0/sd-dom0-files.sls
+++ b/dom0/sd-dom0-files.sls
@@ -68,7 +68,7 @@ dom0-workstation-templates-repo:
 dom0-install-securedrop-workstation-template:
   cmd.run:
     - name: >
-        qvm-template install securedrop-workstation-{{ sdvars.distribution }}
+        qvm-template info --machine-readable securedrop-workstation-{{ sdvars.distribution }} | grep -q "installed|securedrop-workstation-{{ sdvars.distribution }}|" || qvm-template install securedrop-workstation-{{ sdvars.distribution }}
     - require:
       - file: dom0-workstation-rpm-repo
 

--- a/dom0/sd-sys-vms.sls
+++ b/dom0/sd-sys-vms.sls
@@ -16,7 +16,7 @@ include:
 dom0-install-fedora-template:
   cmd.run:
     - name: >
-        qvm-template install {{ sd_supported_fedora_version }}
+        qvm-template info {{ sd_supported_fedora_version }} | grep -q Installed || qvm-template install {{ sd_supported_fedora_version }}
 
 # Update the mgmt VM before updating the new Fedora VM. The order is required
 # and listed in the release notes for F32 & F33.

--- a/dom0/sd-sys-vms.sls
+++ b/dom0/sd-sys-vms.sls
@@ -16,7 +16,7 @@ include:
 dom0-install-fedora-template:
   cmd.run:
     - name: >
-        qvm-template info {{ sd_supported_fedora_version }} | grep -q Installed || qvm-template install {{ sd_supported_fedora_version }}
+        qvm-template info --machine-readable {{ sd_supported_fedora_version }} | grep -q "installed|{{ sd_supported_fedora_version }}|" || qvm-template install {{ sd_supported_fedora_version }}
 
 # Update the mgmt VM before updating the new Fedora VM. The order is required
 # and listed in the release notes for F32 & F33.


### PR DESCRIPTION
## Description of Changes

Addresses https://github.com/freedomofpress/securedrop-workstation/issues/884#issuecomment-1570597339

This allows an installation to succeed if a template was installed manually even if a template isn't available from `qvm-template` repositories. Applies to both system and `securedrop-workstation-*` templates.

## Testing

- Stage 1, fresh install
   - [ ] Installation succeeds as normal
   - [ ] Running the updater succeeds
- Stage 2, fresh install
  - ~Manually rename `fedora-37` template to a name of your choice, change `sd_supported_fedora_version` to that name~
  - [ ] ~Installation succeeds as normal, despite that template name not referencing available templates in Qubes' or our repositories~
  - [ ] Manual installation of a template from disk (per [#884](https://github.com/freedomofpress/securedrop-workstation/issues/884#issuecomment-1574154240) before SDW installation allows for successful install
## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`