### PR TITLE
Pull fedora:32 image from Fedora's own registry, always

### DIFF
--- a/bootstrap/Dockerfile
+++ b/bootstrap/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:32
+FROM registry.fedoraproject.org/fedora:32
 LABEL org="Freedom of the Press"
 LABEL image_name="securedrop-workstation-qubes-4.1"
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

docker and podman interpret "fedora:32" in different ways, docker pulls it from Docker Hub and podman gets it from
registry.fedoraproject.org.

Despite presumably being maintained by the same people, those two 32 images are different. Let's be explicit and have docker use Fedora's own registry too.

Fixes #912.

## Testing

* [x] Visual review
* [x] CI passes

## Deployment

Any special considerations for deployment? No
