### PR TITLE
Move to fedora-38 as base system Fedora version

### DIFF
--- a/dom0/sd-clean-all.sls
+++ b/dom0/sd-clean-all.sls
@@ -5,7 +5,7 @@
 
 set-fedora-as-default-dispvm:
   cmd.run:
-    - name: qvm-check fedora-37-dvm && qubes-prefs default_dispvm fedora-37-dvm || qubes-prefs default_dispvm ''
+    - name: qvm-check fedora-38-dvm && qubes-prefs default_dispvm fedora-38-dvm || qubes-prefs default_dispvm ''
 
 {% set gui_user = salt['cmd.shell']('groupmems -l -g qubes') %}
 
@@ -23,7 +23,7 @@ restore-sys-usb-dispvm-halt-wait:
 restore-sys-usb-dispvm:
   qvm.prefs:
     - name: sys-usb
-    - template: fedora-37-dvm
+    - template: fedora-38-dvm
     - require:
       - cmd: restore-sys-usb-dispvm-halt-wait
       - cmd: set-fedora-as-default-dispvm
@@ -34,11 +34,11 @@ restore-sys-usb-dispvm-start:
     - require:
       - qvm: restore-sys-usb-dispvm
 
-# autoattach modifications are only present in sd-fedora-37-dvm
+# autoattach modifications are only present in sd-fedora-38-dvm
 # so no more sd-usb-autoattach-remove necessary
 remove-sd-fedora-dispvm:
   qvm.absent:
-    - name: sd-fedora-37-dvm
+    - name: sd-fedora-38-dvm
     - require:
       - qvm: restore-sys-usb-dispvm
 {% else %}

--- a/dom0/sd-clean-default-dispvm.sls
+++ b/dom0/sd-clean-default-dispvm.sls
@@ -3,4 +3,4 @@
 
 set-fedora-as-default-dispvm:
   cmd.run:
-    - name: qvm-check fedora-37-dvm && qubes-prefs default_dispvm fedora-37-dvm || qubes-prefs default_dispvm ''
+    - name: qvm-check fedora-38-dvm && qubes-prefs default_dispvm fedora-38-dvm || qubes-prefs default_dispvm ''

--- a/dom0/sd-sys-vms.sls
+++ b/dom0/sd-sys-vms.sls
@@ -9,7 +9,7 @@ include:
   # DispVM is created
   - qvm.default-dispvm
 
-{% set sd_supported_fedora_version = 'fedora-37' %}
+{% set sd_supported_fedora_version = 'fedora-38' %}
 
 
 # Install latest templates required for SDW VMs.
@@ -125,6 +125,15 @@ remove-sd-fedora-dvm:
     - name: sd-fedora-dvm
     - require:
       - qvm: sd-sys-usb-fedora-version-update
+
+# Finally, remove the old supported fedora DVM we created. We won't uninstall
+# the template, in case it's being used elsewhere, but the `sd-` VMs we can
+# reasonably manage (remove) ourselves.
+remove-sd-fedora-37-dvm:
+  qvm.absent:
+    - name: sd-fedora-37-dvm
+    - require:
+      - qvm: sd-sys-usb-fedora-version-update
 {% endif %}
 
 sd-{{ sys_vm }}-fedora-version-start:
@@ -134,3 +143,4 @@ sd-{{ sys_vm }}-fedora-version-start:
       - qvm: sd-{{ sys_vm }}-fedora-version-update
 {% endif %}
 {% endfor %}
+

--- a/dom0/sd-usb-autoattach-add.sls
+++ b/dom0/sd-usb-autoattach-add.sls
@@ -6,7 +6,7 @@
 # USB devices to sd-devices.
 ##
 
-# If sys-usb is disposable, we have already set up sd-fedora-37-dvm to make our
+# If sys-usb is disposable, we have already set up sd-{supported-fedora-version}-dvm to make our
 # modifications in, so we only want to modify sys-usb if it is a regular AppVM
 
 {% set apply = True %}

--- a/dom0/sd-workstation.top
+++ b/dom0/sd-workstation.top
@@ -41,7 +41,7 @@ base:
   securedrop-workstation-bullseye:
     - sd-workstation-template-files
     - sd-logging-setup
-  'sd-fedora-37-dvm,sys-usb':
+  'sd-fedora-38-dvm,sys-usb':
     - match: list
     - sd-usb-autoattach-add
   sd-log:

--- a/files/provision-all
+++ b/files/provision-all
@@ -31,8 +31,8 @@ echo "Provision all SecureDrop Workstation VMs with service-specific configs"
 sudo qubesctl --show-output --max-concurrency "$max_concurrency" --skip-dom0 --targets "$all_sdw_vms_target" state.highstate
 
 echo "Add SecureDrop export device handling to sys-usb"
-# If sd-fedora-37-dvm exists it's because salt determined that sys-usb was disposable
-qvm-check --quiet sd-fedora-37-dvm 2> /dev/null && \
-  sudo qubesctl --show-output --skip-dom0 --targets sd-fedora-37-dvm state.highstate && \
+# If sd-fedora-38-dvm exists it's because salt determined that sys-usb was disposable
+qvm-check --quiet sd-fedora-38-dvm 2> /dev/null && \
+  sudo qubesctl --show-output --skip-dom0 --targets sd-fedora-38-dvm state.highstate && \
   qvm-shutdown --wait sys-usb && qvm-start sys-usb || \
   sudo qubesctl --show-output --skip-dom0 --targets sys-usb state.highstate

--- a/launcher/sdw_updater_gui/Updater.py
+++ b/launcher/sdw_updater_gui/Updater.py
@@ -40,7 +40,7 @@ detail_log = Util.get_logger(prefix=DETAIL_LOGGER_PREFIX, module=__name__)
 # as well as their associated TemplateVMs.
 # In the future, we could use qvm-prefs to extract this information.
 current_vms = {
-    "fedora": "fedora-37",
+    "fedora": "fedora-38",
     "sd-viewer": "sd-large-{}-template".format(DEBIAN_VERSION),
     "sd-app": "sd-small-{}-template".format(DEBIAN_VERSION),
     "sd-log": "sd-small-{}-template".format(DEBIAN_VERSION),

--- a/launcher/tests/test_updater.py
+++ b/launcher/tests/test_updater.py
@@ -492,7 +492,7 @@ def test_shutdown_and_start_vms(
         call("sys-usb"),
     ]
     template_vm_calls = [
-        call("fedora-37"),
+        call("fedora-38"),
         call("sd-large-{}-template".format(DEBIAN_VERSION)),
         call("sd-small-{}-template".format(DEBIAN_VERSION)),
         call("whonix-gw-16"),
@@ -538,7 +538,7 @@ def test_shutdown_and_start_vms_sysvm_fail(
         call("sd-log"),
     ]
     template_vm_calls = [
-        call("fedora-37"),
+        call("fedora-38"),
         call("sd-large-{}-template".format(DEBIAN_VERSION)),
         call("sd-small-{}-template".format(DEBIAN_VERSION)),
         call("whonix-gw-16"),

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -123,9 +123,9 @@ find /srv/salt -maxdepth 1 -type f -iname '*.top' \
     | sed -e 's/\.top$$//g' \
     | xargs qubesctl top.enable > /dev/null
 
-# Force full run of all Salt states
-mkdir -p /tmp/sdw-migrations
-touch /tmp/sdw-migrations/f38-update
+# Force full run of all Salt states - uncomment in release branch
+# mkdir -p /tmp/sdw-migrations
+# touch /tmp/sdw-migrations/f38-update
 
 %changelog
 * Mon Jun 26 2023 SecureDrop Team <securedrop@freedom.press> - 0.8.1

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -123,6 +123,10 @@ find /srv/salt -maxdepth 1 -type f -iname '*.top' \
     | sed -e 's/\.top$$//g' \
     | xargs qubesctl top.enable > /dev/null
 
+# Force full run of all Salt states
+mkdir -p /tmp/sdw-migrations
+touch /tmp/sdw-migrations/f38-update
+
 %changelog
 * Mon Jun 26 2023 SecureDrop Team <securedrop@freedom.press> - 0.8.1
 - Update the SecureDrop release signing key

--- a/tests/base.py
+++ b/tests/base.py
@@ -7,7 +7,7 @@ from qubesadmin import Qubes
 
 # Reusable constant for DRY import across tests
 WANTED_VMS = ["sd-gpg", "sd-log", "sd-proxy", "sd-app", "sd-viewer", "sd-whonix", "sd-devices"]
-CURRENT_FEDORA_VERSION = "37"
+CURRENT_FEDORA_VERSION = "38"
 CURRENT_FEDORA_TEMPLATE = "fedora-" + CURRENT_FEDORA_VERSION
 CURRENT_WHONIX_VERSION = "16"
 

--- a/tests/test_qubes_vms.py
+++ b/tests/test_qubes_vms.py
@@ -30,7 +30,7 @@ class SD_Qubes_VM_Tests(unittest.TestCase):
             wanted_templates = [CURRENT_FEDORA_TEMPLATE]
             if sys_vm in sys_vms_maybe_disp:
                 if sys_vm in sys_vms_custom_disp:
-                    wanted_templates.append("sd-fedora-37-dvm")
+                    wanted_templates.append("sd-fedora-38-dvm")
                 else:
                     wanted_templates.append(CURRENT_FEDORA_TEMPLATE + "-dvm")
 


### PR DESCRIPTION
## Status

Ready for Review 

## Description of Changes

Towards #892

Changes proposed in this pull request:
- Move to Fedora 38-based system template for sys- vms, including sd-fedora-3x-dvm (optionally used as template if sys-usb is disposable)
- Remove sd-fedora-37-dvm (previous USB appvm with autoattach udev rules) if present
- Force full apply run (to ensure above-mentioned sys-usb changes are included)
  
## Testing

Testing scenarios to be covered by various folks, not just the reviewer, since it's a lot of wall time.

**Clean install, 4.1 [no f38 template pre-downloaded]** (done by @zenmonkeykstop )
Check out this branch, build RPM, copy to dom0, sdw-admin apply.
- [x] Apply run is successful
- [x] f38 template is downloaded and used for sys vms

**Clean install, 4.1 [f38 template is pre-downloaded]** (this would be 4.2 rc3 testing if we were all set to support 4.2). (done by @nathandyer)
- [x] Apply run is successful

**Upgrade scenario, 4.1** (done by @nathandyer)
- [x] Apply run is successful
- [x] sd-fedora-37-dvm is deleted, if it was previously present
- [x] sys VMs use fedora-38 template

## Deployment

TK

Any special considerations for deployment? Consider both:

1. Upgrading existing pilot instances
2. New installs

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation