### PR TITLE
Just set `Version` in RPM spec

### DIFF
--- a/update_version.sh
+++ b/update_version.sh
@@ -3,55 +3,16 @@
 
 set -e
 
-readonly NEW_VERSION=$1
-
-if [ -z "$NEW_VERSION" ]; then
+if [ -z "$1" ]; then
   echo "You must specify the new version!"
   exit 1
 fi
 
-OLD_VERSION=$(cat VERSION)
+# We want the Python and RPM versions to match, so we'll use a PEP 440
+# compatible version, e.g. 0.9.0rc1 or 0.9.0.
+NEW_VERSION=$(echo $1 | sed 's/-//g' | sed 's/~//g' )
 
-if [ -z "$OLD_VERSION" ]; then
-  echo "Couldn't find the old version: does this script need to be updated?"
-  exit 1
-fi
-
-RELEASE_FIELD="1%{?dist}"
-VERSION_FIELD="$NEW_VERSION"
-RC_VERSION=""
-
-rc_error_msg="Release candidates should use the versioning 0.x.y-rcZ, where 0.x.y is the next version"
-if [[ $NEW_VERSION == *~rc* ]]; then
-    echo "$rc_error_msg"
-    exit 1
-elif [[ $NEW_VERSION == *-rc* ]]; then
-    RC_VERSION="$(perl -nE '/\-rc(\d+)/ and say $1' <<< "$NEW_VERSION")"
-    VERSION_FIELD="$(perl -F'[\-~]' -lanE 'print $F[0]' <<< "$NEW_VERSION")"
-    if [[ -z $RC_VERSION || -z $VERSION_FIELD ]]; then
-        echo "$rc_error_msg"
-        exit 2
-    fi
-    RELEASE_FIELD="0.rc${RC_VERSION}.1%{?dist}"
-fi
-
-# Remove hyphens to ensure tarball filepath is built correctly
-CLEAN_VERSION="$(sed 's/-//' <<< "$NEW_VERSION")"
-
-# Update the version in rpm-build/SPECS/securedrop-workstation-dom0-config.spec and setup.py
-# We change the Version, Release, and Source0 fields in the rpm spec. The spec file also contains the changelog entries,
-# and we don't want to increment those versions.
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    # The empty '' after sed -i is required on macOS to indicate no backup file should be saved.
-    sed -i '' "s@$(echo "${OLD_VERSION}" | sed 's/\./\\./g')@$NEW_VERSION@g" VERSION
-    sed -i '' -e "/Source0/s/Source0:.*/Source0:\tsecuredrop-workstation-dom0-config-${CLEAN_VERSION}.tar.gz/" rpm-build/SPECS/securedrop-workstation-dom0-config.spec
-    sed -i '' -r -e "s/^(%global version ).*/\1$VERSION_FIELD/" rpm-build/SPECS/securedrop-workstation-dom0-config.spec
-    sed -i '' -r -e "/^Release/s/Release.*/Release:\t${RELEASE_FIELD}/" rpm-build/SPECS/securedrop-workstation-dom0-config.spec
-    sed -i '' -r -e "/\%setup/s/%setup.*/%setup -n securedrop-workstation-dom0-config-${CLEAN_VERSION}/" rpm-build/SPECS/securedrop-workstation-dom0-config.spec
-else
-    sed -i "s@$(echo "${OLD_VERSION}" | sed 's/\./\\./g')@$NEW_VERSION@g" VERSION
-    sed -i -e "/Source0/s/Source0:.*/Source0:\tsecuredrop-workstation-dom0-config-${CLEAN_VERSION}.tar.gz/" rpm-build/SPECS/securedrop-workstation-dom0-config.spec
-    sed -i -r -e "s/^(%global version ).*/\1$VERSION_FIELD/" rpm-build/SPECS/securedrop-workstation-dom0-config.spec
-    sed -i -r -e "/^Release/s/Release.*/Release:\t${RELEASE_FIELD}/" rpm-build/SPECS/securedrop-workstation-dom0-config.spec
-    sed -i -r -e "/\%setup/s/%setup.*/%setup -n securedrop-workstation-dom0-config-${CLEAN_VERSION}/" rpm-build/SPECS/securedrop-workstation-dom0-config.spec
-fi
+# Update the version in the spec file and VERSION.
+# TODO: Use rpmdev-bumpspec
+echo "${NEW_VERSION}" > VERSION
+sed -i'' -r -e "s/^(Version:\\t).*/\\1${NEW_VERSION}/" "rpm-build/SPECS/securedrop-workstation-dom0-config.spec"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This is mostly a copy of @eaon's change in securedrop-updater[1], with one key change of normalizing the version down to a PEP 440 compatible format.

Since we use setuptools's sdist to create a tarball and then expect rpmbuild to be able to find it, we need to use a common version format across both setuptools and RPM. Encoding the RC version in the `Release` field has always been wrong, since that's used for changes to packaging, not when the upstream (i.e. sdist tarball) changes.

This also means we no longer need to update `Source` in the release branch to point at the tarball, since it can be inferred correctly from the existing `%{name}-%{version}.tar.gz` macros.

Leave a TODO to switch to rpmdev-bumpspec which is the RPM `dch` equivalent to bump the version and insert a changelog entry.

[1] https://github.com/freedomofpress/securedrop-updater/commit/42a55c7f10546710e99fa73ae291a69b04dc4eeb

## Testing

* Run `./update_version.sh` with `0.9.0-rc1`, run `make rpm-build` and you get a package of what you expect
* Repeat with `0.9.0`

## Deployment

Any special considerations for deployment? Applies to everything

## Checklist

- [x] I would appreciate help with the documentation