### PR TITLE
Don't install dev deps in the RPM build container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ dev staging: assert-dom0 ## Configures and builds a dev or staging environment
 
 .PHONY: build-rpm
 build-rpm: ## Build RPM package
-	@$(CONTAINER) ./scripts/build-rpm.sh
+	USE_BUILD_CONTAINER=true $(CONTAINER) ./scripts/build-rpm.sh
 
 .PHONY: reprotest
 reprotest: ## Check RPM package reproducibility

--- a/bootstrap/DevDockerfile
+++ b/bootstrap/DevDockerfile
@@ -1,0 +1,4 @@
+FROM securedrop-workstation-dom0-config
+
+COPY requirements requirements
+RUN pip3 install --no-deps --require-hashes -r requirements/dev-requirements.txt

--- a/bootstrap/Dockerfile
+++ b/bootstrap/Dockerfile
@@ -13,7 +13,4 @@ COPY Makefile Makefile
 
 RUN make install-deps
 
-COPY requirements requirements
-RUN pip3 install --no-deps --require-hashes -r requirements/dev-requirements.txt
-
 RUN if test $USER_NAME != root ; then useradd --no-create-home --home-dir /tmp --uid $USER_ID $USER_NAME && echo "$USER_NAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers ; fi


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The RPM build container needs to be highly trustworthy, so it should only contain things from Fedora itself and any audited code. We don't audit development dependencies, so we shouldn't be installing them into the build container.

We split the container used by `./scripts/container.sh` into two, a base, build container and then a container layered on top with dev dependencies.

Functionally this should be a no-op since none of the dependencies are used at build time but it cuts down on the risk of malicious code injection.

Fixes #921.

## Testing

* [x] visual review
* [x] Run `make rpm-build` with PR, note the checksum, run without this PR, should get the same checksum.


