### PR TITLE
[0.9.0] backport build container dev deps removal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ dev staging: assert-dom0 ## Configures and builds a dev or staging environment
 
 .PHONY: build-rpm
 build-rpm: ## Build RPM package
-	@$(CONTAINER) ./scripts/build-rpm.sh
+	USE_BUILD_CONTAINER=true $(CONTAINER) ./scripts/build-rpm.sh
 
 .PHONY: reprotest
 reprotest: ## Check RPM package reproducibility

--- a/bootstrap/DevDockerfile
+++ b/bootstrap/DevDockerfile
@@ -1,0 +1,4 @@
+FROM securedrop-workstation-dom0-config
+
+COPY requirements requirements
+RUN pip3 install --no-deps --require-hashes -r requirements/dev-requirements.txt

--- a/bootstrap/Dockerfile
+++ b/bootstrap/Dockerfile
@@ -13,7 +13,4 @@ COPY Makefile Makefile
 
 RUN make install-deps
 
-COPY requirements requirements
-RUN pip3 install --no-deps --require-hashes -r requirements/dev-requirements.txt
-
 RUN if test $USER_NAME != root ; then useradd --no-create-home --home-dir /tmp --uid $USER_ID $USER_NAME && echo "$USER_NAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers ; fi


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Backports #924. Creates two separate containers, the original and one for builds that does not include dev python dependencies.

Changes proposed in this pull request:

## Testing

- [x] base is release/0.9.0
- [x] contains only changes from #924 
- [ ] CI is passing 
