### PR TITLE
Tell workstation-ci which Qubes version to use for tests

### DIFF
--- a/.github/workstation-ci.yml
+++ b/.github/workstation-ci.yml
@@ -1,0 +1,2 @@
+# for <https://github.com/freedomofpress/securedrop-workstation-ci>
+qubes: "4.1"


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

As we move towards 4.2, we'll still have a 4.1 branch for backports, so the CI runner needs to know which Qubes version to test against. Having this file will tell it what to do and avoids us from needing special branch prefixes and is hopefully future-proof.

Refs <https://github.com/freedomofpress/infrastructure/issues/4603#issuecomment-1942883978>.

## Testing

* [ ] Visual review + approval from infra (@mig5, et al.) that this is good with them
