### PR TITLE
Update sd-devices test to check for udisks2, not cryptsetup

### DIFF
--- a/tests/test_sd_devices.py
+++ b/tests/test_sd_devices.py
@@ -15,7 +15,7 @@ class SD_Devices_Tests(SD_VM_Local_Test):
         self.assertTrue(self._fileExists("/usr/share/mime/packages/application-x-sd-export.xml"))
 
     def test_sd_export_package_installed(self):
-        self.assertTrue(self._package_is_installed("cryptsetup"))
+        self.assertTrue(self._package_is_installed("udisks2"))
         self.assertTrue(self._package_is_installed("printer-driver-brlaser"))
         self.assertTrue(self._package_is_installed("printer-driver-hpcups"))
         self.assertTrue(self._package_is_installed("securedrop-export"))


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Now that udisks2 is used for locking/unlocking export devices, update sd-devices vm test. 
Refs https://github.com/freedomofpress/securedrop-client/pull/1777

## Testing

visual review, ci passes. `udisks2` is already installed on sd-devices by default, but otherwise this would not be expected to pass until updated packages and their dependencies were installed on the target sdw machine.

## Deployment
n/a

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation