### PR TITLE
Add feature and bug report templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Create a report to help us improve SecureDrop Workstation
+
+---
+
+* [ ] I have searched for duplicates or related issues
+
+## Description
+
+A short summary of the issue.
+
+## Steps to Reproduce
+
+Please specify your environment if that is necessary to reproduce the bug (if in doubt, include it).
+
+## Expected Behavior
+
+
+## Actual Behavior
+
+Please provide screenshots where appropriate.
+
+## Comments
+
+Suggestions to fix, any other relevant information.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for SecureDrop Workstation
+
+---
+
+* [ ] I have searched for duplicates or related issues
+
+## Description
+
+A short summary of the idea.
+
+## How will this impact [SecureDrop/SecureDrop Workstation users](https://github.com/freedomofpress/securedrop-ux/wiki/Users)?
+<!-- How do you feel this change might impact SecureDrop Workstation's usability, accessibility, or usefulness—and specifically, for which users? Has anecdotal feedback from users influenced this change? Does evidence exist from user research to support this idea? Could design or user research efforts be helpful to support a change? -->
+
+## How would this affect the SecureDrop Workstation [threat model](https://github.com/freedomofpress/securedrop-workstation/#threat-model)?
+<!-- Would this change create new risks for sources, journalists, or administrators? Would it mitigate existing risks? -->
+
+## User Stories
+<!-- If appropriate, add one or more relevant user stories in this format: “As a [role], I want to [task], so that [reason].” -->


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

When I merged #962 I should have noticed it would also clobber the default issue template, so add bug report and feature request templates back.

## Test Plan
- [ ] Visual review
- [ ] CI passes

## Deployment

n/a

## Checklist

n/a
