### PR TITLE
Fix and improve _validate_apt_sources test

### DIFF
--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -34,7 +34,7 @@ class SD_VM_Platform_Tests(unittest.TestCase):
             elif config["environment"] == "staging":
                 self.apt_url = FPF_APT_TEST_SOURCES.format(dist=dist, component="main")
             else:
-                self.apt_url = FPF_APT_TEST_SOURCES.format(dist=dist, component="nightlies")
+                self.apt_url = FPF_APT_TEST_SOURCES.format(dist=dist, component="main nightlies")
 
     def tearDown(self):
         pass


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

* Update tests now that dev enables multiple apt components (Fixes #982.)
* Improve _validate_apt_sources test

See commit messages for more detail.

## Testing

* [x] Visual review
* [x] This test no longer fails in workstation CI (n.b. overall job will still fail)

## Deployment

Any special considerations for deployment? n/a

