### PR TITLE
Trigger CI on GitHub's merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 ---
 name: ci
 
-on: [push, pull_request]
+on: [push, pull_request, merge_group]
 
 jobs:
   lint:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This doesn't enable the merge queue, but is a prerequisite. See <https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions> for details.

## Testing

* [x] visual review, can also compare with https://github.com/freedomofpress/securedrop-dev-docs/pull/130

## Deployment

Any special considerations for deployment? n/a