### PR TITLE
Install grub2-xen-pvh through RPM dependencies

### DIFF
--- a/files/sdw-admin.py
+++ b/files/sdw-admin.py
@@ -63,17 +63,6 @@ def parse_args():
     return args
 
 
-def install_pvh_support():
-    """
-    Installs grub2-xen-pvh in dom0 - required for PVH with AppVM local kernels
-    TODO: install this via package requirements instead if possible
-    """
-    try:
-        subprocess.run(["sudo", "qubes-dom0-update", "-y", "-q", "grub2-xen-pvh"])
-    except subprocess.CalledProcessError:
-        raise SDWAdminException("Error installing grub2-xen-pvah: local PVH not available.")
-
-
 def copy_config():
     """
     Copies config.json and sd-journalist.sec to /srv/salt/sd
@@ -191,7 +180,6 @@ def main():
                 sys.exit(0)
         print("Applying configuration...")
         validate_config(SCRIPTS_PATH)
-        install_pvh_support()
         copy_config()
         refresh_salt()
         provision_all()

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -33,6 +33,7 @@ BuildRequires:	python3-wheel
 # This package installs all standard VMs in Qubes
 Requires:		qubes-mgmt-salt-dom0-virtual-machines
 Requires:		python3-qt5
+Requires:		grub2-xen-pvh
 
 %description
 This package contains VM configuration files for the Qubes-based

--- a/scripts/prep-dev
+++ b/scripts/prep-dev
@@ -27,6 +27,9 @@ echo "Deploying Salt config..."
 echo "Uninstalling any previous RPM versions..."
 sudo dnf clean all
 sudo dnf remove -y securedrop-workstation-dom0-config || true
+# First install needed dependencies (ignore virtual rpmlib dependencies)
+sudo qubes-dom0-update -y $(rpm -qpR $latest_rpm | grep -v rpmlib)
+# Then install the RPM itself
 echo "Installing RPM at $latest_rpm ..."
 sudo dnf install -y "$latest_rpm"
 


### PR DESCRIPTION
## Status

Not ready for review

## Description of Changes

In a normal production install, we install the
securedrop-workstation-dom0-config RPM through `qubes-dom0-update`, which will fetch any dependencies since it has network access.

However in a dev setup, we install the RPM we just built using plain `dnf`, which has no network access, and is therefore unable to download missing dependencies. We can workaround this by passing the dependency list to `qubes-dom0-update` prior to RPM installation. I was unable to figure out how to pass a local RPM file qubes-dom0-update in the same way you can to dnf.

## Testing

* [ ] CI passes

## Deployment

Any special considerations for deployment? No, prod install behavior should already work

## Checklist

- [ ] All tests (`make test`) pass in `dom0`
