### PR TITLE
Add core Qubes VM packages for SDW minimal-based templates.

### DIFF
--- a/dom0/sd-base-template-files.sls
+++ b/dom0/sd-base-template-files.sls
@@ -3,16 +3,21 @@
 include:
   - fpf-apt-repo
 
-# TODO: test if this works, if not it may need to be a qvm-run command
+# install recommended Qubes VM packages for core functionality
+install-qubes-vm-recommended:
+  pkg.installed:
+    - pkgs:
+      - qubes-vm-recommended
+
+# install additional base packages required by SecureDrop
 sd-base-template-install-additional-packages:
   pkg.installed:
     - pkgs:
-      - qubes-core-agent-passwordless-root
       - rsyslog
       - mailcap
       - apparmor
-      - apparmor-utils
 
+# install workstation-config and grsec kernel
 sd-base-template-install-securedrop-packages:
   pkg.installed:
     - pkgs:

--- a/dom0/sd-proxy-template-files.sls
+++ b/dom0/sd-proxy-template-files.sls
@@ -4,8 +4,7 @@ include:
   - fpf-apt-repo
   - sd-logging-setup
 
-# Depends on FPF-controlled apt repo, already present
-# in underlying "securedrop-workstation" base template.
+# Depends on FPF-controlled apt repo
 install-securedrop-proxy-package:
   pkg.installed:
     - pkgs:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes
- adds core Qubes VM functionality (networking, passwordless root, split-gpg, dom0 notifications etc) via the `qubes-vm-recommended` metapackage.
- apparmor-utils is not required, removed from base template

Fixes #978
Fixes #980

Changes proposed in this pull request:

## Testing

- [ ] CI is good
- [ ] After installing from the RPM from this repo, small and large templates include the qubes-vm-recommended package
- [ ] After installation, sd-proxy has network access (via sd-whonix)
- [ ] usual visual review.