### PR TITLE
Increase priority of our .policy files and remove references to old policy files in /etc/qubes-rpc

### DIFF
--- a/dom0/sd-clean-all.sls
+++ b/dom0/sd-clean-all.sls
@@ -74,15 +74,13 @@ remove-dom0-sdw-config-files:
       - /usr/share/securedrop/icons
       - /home/{{ gui_user }}/.config/autostart/SDWLogin.desktop
       - /usr/bin/securedrop-login
-      - /etc/qubes-rpc/policy/securedrop.Log
-      - /etc/qubes-rpc/policy/securedrop.Proxy
       - /home/{{ gui_user }}/Desktop/securedrop-launcher.desktop
       - /home/{{ gui_user }}/.securedrop_launcher
       - /srv/salt/qa-switch.tar.gz
       - /srv/salt/qa-switch
       - /srv/salt/consolidation-qa-switch.sh
-      - /etc/qubes/policy.d/60-securedrop-workstation.policy
-      - /etc/qubes/policy.d/70-securedrop-workstation.policy
+      - /etc/qubes/policy.d/31-securedrop-workstation.policy
+      - /etc/qubes/policy.d/32-securedrop-workstation.policy
 
 # Remove any custom RPC policy tags added to non-SecureDrop VMs by the user
 remove-rpc-policy-tags:
@@ -115,25 +113,3 @@ sd-cleanup-sys-firewall:
       - qvm-run sys-firewall 'sudo rm -f /rw/config/RPM-GPG-KEY-securedrop-workstation-test'
       - qvm-run sys-firewall 'sudo rm -f /etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation'
       - qvm-run sys-firewall 'sudo rm -f /etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation-test'
-
-sd-cleanup-rpc-mgmt-policy:
-  file.replace:
-    - names:
-      - /etc/qubes-rpc/policy/qubes.VMShell
-      - /etc/qubes-rpc/policy/qubes.VMRootShell
-    - repl: ''
-    - ignore_if_missing: True
-    - pattern: '^disp-mgmt-sd-\w+\s+sd-\w+\s+allow,user=root'
-
-{% set sdw_customized_rpc_files = salt['cmd.shell']('grep -rIl "BEGIN securedrop-workstation" /etc/qubes-rpc/ | cat').splitlines() %}
-{% if sdw_customized_rpc_files|length > 0 %}
-sd-cleanup-rpc-policy-grants:
-  file.replace:
-    - names: {{ sdw_customized_rpc_files }}
-    - pattern: '### BEGIN securedrop-workstation ###.*### END securedrop-workstation ###\s*'
-    - flags:
-      - MULTILINE
-      - DOTALL
-    - repl: ''
-    - backup: no
-{% endif %}

--- a/dom0/sd-dom0-qvm-rpc.sls
+++ b/dom0/sd-dom0-qvm-rpc.sls
@@ -4,16 +4,24 @@
 ## Configure Qubes RPC policies for SecureDrop Workstation.
 #
 # As a general strategy, in addition to explicit grants, we provide
-# catch-all deny policies for SDW-provisioned VMs. Where possible,
-# we prefer to prepend SDW policies, in order to support overrides
-# for the general system.
+# catch-all deny policies for SDW-provisioned VMs.
 #
-# Qubes suggests using files starting with 70- to be the allow policies
-# and 60- deny policies, but due to the way SDW policies are stacked at the
-# moment, we reverse this suggested order
+# Qubes suggests the allow policies be evaluated after (with a higher file
+# number than) the deny policies, but due to the way SDW policies are stacked at the
+# moment, we reverse this suggested order.
+#
+# We also want SDW policies in the new format to be evaluated before the legacy
+# compatibility policies (`/etc/qubes/policy.d/35-compat.policy`), to avoid
+# having to maintain two sets of policies. We therefore choose policy file numbers
+# between 30 (used by system, `/etc/qubes/policy.d/30-qubesctl-salt.policy) and 35
+# (legacy compatibility, as above). This way, if users have legacy compatibility
+# policies defined for non-SecureDrop Workstation qubes, they will be evaluated
+# normally and will not be broken by SecureDrop Workstation, but will not be
+# evaluated before our own policies.
+#
 dom0-rpc-qubes.r5-format-deny:
   file.managed:
-    - name: /etc/qubes/policy.d/70-securedrop-workstation.policy
+    - name: /etc/qubes/policy.d/32-securedrop-workstation.policy
     - contents: |
         securedrop.Log          *           @anyvm @anyvm deny
 
@@ -24,6 +32,10 @@ dom0-rpc-qubes.r5-format-deny:
 
         qubes.Gpg               *           @anyvm @tag:sd-workstation deny
         qubes.Gpg               *           @tag:sd-workstation @anyvm deny
+
+        # Future: qubes-app-linux-split-gpg2
+        qubes.Gpg2              *           @anyvm @tag:sd-workstation deny
+        qubes.Gpg2              *           @tag:sd-workstation @anyvm deny
 
         qubes.USBAttach         *           @anyvm @tag:sd-workstation deny
         qubes.USBAttach         *           @tag:sd-workstation @anyvm deny
@@ -62,9 +74,15 @@ dom0-rpc-qubes.r5-format-deny:
         qubes.VMShell           *           @anyvm @tag:sd-workstation deny
         qubes.VMShell           *           @tag:sd-workstation @anyvm deny
 
+        qubes.VMExec            *           @anyvm @tag:sd-workstation deny
+        qubes.VMExec            *           @tag:sd-workstation @anyvm deny
+
+        qubes.VMExecGUI         *           @anyvm @tag:sd-workstation deny
+        qubes.VMExecGUI         *           @tag:sd-workstation @anyvm deny
+
 dom0-rpc-qubes.r5-format-ask-allow:
   file.managed:
-    - name: /etc/qubes/policy.d/60-securedrop-workstation.policy
+    - name: /etc/qubes/policy.d/31-securedrop-workstation.policy
     - contents: |
         # required to suppress unsupported loopback error notifications
         securedrop.Log          *           sd-log sd-log deny notify=no
@@ -73,6 +91,10 @@ dom0-rpc-qubes.r5-format-ask-allow:
         securedrop.Proxy        *           sd-app sd-proxy allow
 
         qubes.Gpg               *           @tag:sd-client sd-gpg allow
+        qubes.GpgImportKey      *           @tag:sd-client sd-gpg allow
+
+        # Future: qubes-app-linux-split-gpg2
+        qubes.Gpg2              *           @tag:sd-client sd-gpg allow target=sd-gpg
 
         qubes.USBAttach         *           sys-usb sd-devices allow  user=root
         qubes.USBAttach         *           @anyvm @anyvm ask

--- a/tests/test_qubes_rpc.py
+++ b/tests/test_qubes_rpc.py
@@ -6,8 +6,8 @@ import unittest
 class SD_Qubes_Rpc_Tests(unittest.TestCase):
     def test_policies(self):
         """verify the policies are installed"""
-        assert os.path.exists("/etc/qubes/policy.d/70-securedrop-workstation.policy")
-        assert os.path.exists("/etc/qubes/policy.d/60-securedrop-workstation.policy")
+        assert os.path.exists("/etc/qubes/policy.d/31-securedrop-workstation.policy")
+        assert os.path.exists("/etc/qubes/policy.d/32-securedrop-workstation.policy")
 
 
 def load_tests(loader, tests, pattern):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Closes #964
Closes https://github.com/freedomofpress/securedrop-workstation/issues/968 
Closes https://github.com/freedomofpress/securedrop-workstation/issues/818
Changes proposed in this pull request:

- Remove references to qrexec policy files in `/etc/qubes-rpc/policy`, which are now deprecated
- Bump the priority of our two policy files to 31 (allow) and 32 (deny). (Rationale: evaluated after system file `30-qubesctl-salt.policy` but before `35-compat.policy`, which loads backwards-compatible policy files that may be create by the user. (Recall that policies are evaluated as first-match). See discussion in #968 but I'm open to opinions here. 
- Add missing allow policy for `qubes.GpgImportKey` (noted in #969)
- Add policies for `qubes.Gpg2`, the [future split gpg implementation](https://github.com/QubesOS/qubes-app-linux-split-gpg2).

## Testing

- [ ] Visual review (note that v2 style policies were deleted in [#969](https://github.com/freedomofpress/securedrop-workstation/tree/4_2-compat-deb12-base) so some of this is cleanup)
- [ ] CI is green
- [ ] Basic functionality (testing may have to be revisited after kernel issues are resolved) 

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing pilot instances
2. New installs

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation