### PR TITLE
fixup: sd large template requisite type

### DIFF
--- a/dom0/sd-workstation-template.sls
+++ b/dom0/sd-workstation-template.sls
@@ -49,4 +49,4 @@ sd-large-{{ sdvars.distribution }}-template:
       - enable:
         - service.paxctld
     - require:
-      - qvm: sd-base-template
+      - sls: sd-base-template


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Make `require` module type consistent for sd-small and sd-large template. Currently one has the template-creation state (`qvm`) as its requisite, and one has the file of the same name (`sls`) as its requisite.
The latter is probably a better requisite in case we ever add new stanzas to that file.

Changes proposed in this pull request:
adjust one requisite type from `qvm` to `sls`

## Testing

If you made non-trivial code changes, include a test plan and validated it for this PR.

## Deployment

Any special considerations for deployment? (n/a) Consider both:

1. Upgrading existing pilot instances
2. New installs

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation