### PR TITLE
deploy: set `vm-config` features for `sd-{app,proxy,whonix}`

### DIFF
--- a/dom0/sd-app.sls
+++ b/dom0/sd-app.sls
@@ -33,6 +33,15 @@ sd-app:
 
 {% import_json "sd/config.json" as d %}
 
+sd-app-config:
+  qvm.features:
+    - name: sd-app
+    - set:
+        # TODO: freedomofpress/securedrop-client:client/files/sd-app-qubes-gpg-domain.sh
+        - vm-config.QUBES_GPG_DOMAIN: sd-gpg
+        # TODO: sd-app:/home/user/.securedrop_client/config.json
+        - vm-config.SD_SUBMISSION_KEY_FPR: {{ d.submission_key_fpr }}
+
 # The private volume size should be defined in the config.json
 sd-app-private-volume-size:
   cmd.run:

--- a/dom0/sd-proxy.sls
+++ b/dom0/sd-proxy.sls
@@ -29,3 +29,12 @@ sd-proxy:
     - require:
       - qvm: sd-whonix
       - qvm: sd-small-{{ sdvars.distribution }}-template
+
+{% import_json "sd/config.json" as d %}
+
+sd-proxy-config:
+  qvm.features:
+    - name: sd-proxy
+    - set:
+        # TODO: sd-proxy: /home/user/.securedrop_proxy/sd-proxy.yaml
+        - vm-config.SD_PROXY_ORIGIN: http://{{ d.hidserv.hostname }}

--- a/dom0/sd-whonix.sls
+++ b/dom0/sd-whonix.sls
@@ -37,3 +37,13 @@ sd-whonix:
     - require:
       - sls: sd-upgrade-templates
       - sls: sd-sys-whonix-vms
+
+{% import_json "sd/config.json" as d %}
+
+sd-whonix-config:
+  qvm.features:
+    - name: sd-whonix
+    - set:
+        # TODO: sd-whonix:/var/lib/tor/keys/app_journalist.auth_private
+        - vm-config.SD_HIDSERV_HOSTNAME: {{ d.hidserv.hostname }}
+        - vm-config.SD_HIDSERV_KEY: {{ d.hidserv.key }}

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,3 +1,4 @@
+import json
 import subprocess
 import time
 import unittest
@@ -49,6 +50,10 @@ class SD_VM_Local_Test(unittest.TestCase):
             pass
         else:
             self.vm.start()
+
+        # Make the dom0 "config.json" available to tests.
+        with open("config.json") as config_file:
+            self.dom0_config = json.load(config_file)
 
     # def tearDown(self):
     #     self.vm.shutdown()

--- a/tests/base.py
+++ b/tests/base.py
@@ -144,6 +144,15 @@ class SD_VM_Local_Test(unittest.TestCase):
 
         return True
 
+    def _vm_config_read(self, key):
+        """Read `key` from the QubesDB `/vm-config/` hierarchy and return its
+        value if set, otherwise `None`.
+        """
+        try:
+            return self._run(f"qubesdb-read /vm-config/{key}")
+        except subprocess.CalledProcessError:
+            return None
+
     def logging_configured(self):
         """
         Make sure rsyslog is configured to send in data to sd-log vm.

--- a/tests/base.py
+++ b/tests/base.py
@@ -210,12 +210,11 @@ remotevm = sd-log
         sd-app should have it set to sd-gpg.
         All other AppVMs should not have this configured.
         """
-        env_cmd = 'echo "$QUBES_GPG_DOMAIN"'
-        env_contents = self._run(env_cmd)
+        env_contents = self._vm_config_read("QUBES_GPG_DOMAIN")
 
         if vmname == "sd-app":
             expected_env = "sd-gpg"
         else:
-            expected_env = ""
+            expected_env = None
 
         self.assertEqual(env_contents, expected_env)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -8,9 +8,7 @@ class SD_App_Tests(SD_VM_Local_Test):
     def setUp(self):
         self.vm_name = "sd-app"
         super(SD_App_Tests, self).setUp()
-
-    def test_gpg_domain_configured(self):
-        self.qubes_gpg_domain_configured(self.vm_name)
+        self.expected_config_keys = {"QUBES_GPG_DOMAIN", "SD_SUBMISSION_KEY_FPR"}
 
     def test_open_in_dvm_desktop(self):
         contents = self._get_file_contents("/usr/share/applications/open-in-dvm.desktop")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -46,12 +46,9 @@ class SD_App_Tests(SD_VM_Local_Test):
         self.assertTrue(self._package_is_installed("python3-pyqt5.qtsvg"))
 
     def test_sd_client_config(self):
-        with open("config.json") as c:
-            config = json.load(c)
-            submission_fpr = config["submission_key_fpr"]
-
-        line = '{{"journalist_key_fingerprint": "{}"}}'.format(submission_fpr)
-        self.assertFileHasLine("/home/user/.securedrop_client/config.json", line)
+        self.assertEqual(
+            self.dom0_config["submission_key_fpr"], self._vm_config_read("SD_SUBMISSION_KEY_FPR")
+        )
 
     def test_sd_client_apparmor(self):
         cmd = "sudo aa-status --json"

--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -80,9 +80,6 @@ class SD_GPG_Tests(SD_VM_Local_Test):
         # Logging to sd-log should be disabled on sd-gpg
         self.assertFalse(self._fileExists("/etc/rsyslog.d/sdlog.conf"))
 
-    def test_gpg_domain_configured(self):
-        self.qubes_gpg_domain_configured(self.vm_name)
-
 
 def load_tests(loader, tests, pattern):
     suite = unittest.TestLoader().loadTestsFromTestCase(SD_GPG_Tests)

--- a/tests/test_log_vm.py
+++ b/tests/test_log_vm.py
@@ -48,9 +48,6 @@ class SD_Log_Tests(SD_VM_Local_Test):
         # Confirm we don't have 'host' entries from Whonix VMs
         self.assertFalse("host" in log_dirs)
 
-    def test_gpg_domain_configured(self):
-        self.qubes_gpg_domain_configured(self.vm_name)
-
 
 def load_tests(loader, tests, pattern):
     suite = unittest.TestLoader().loadTestsFromTestCase(SD_Log_Tests)

--- a/tests/test_proxy_vm.py
+++ b/tests/test_proxy_vm.py
@@ -9,6 +9,7 @@ class SD_Proxy_Tests(SD_VM_Local_Test):
     def setUp(self):
         self.vm_name = "sd-proxy"
         super(SD_Proxy_Tests, self).setUp()
+        self.expected_config_keys = {"SD_PROXY_ORIGIN"}
 
     def test_do_not_open_here(self):
         """
@@ -84,9 +85,6 @@ class SD_Proxy_Tests(SD_VM_Local_Test):
 
     def test_mailcap_hardened(self):
         self.mailcap_hardened()
-
-    def test_gpg_domain_configured(self):
-        self.qubes_gpg_domain_configured(self.vm_name)
 
 
 def load_tests(loader, tests, pattern):

--- a/tests/test_proxy_vm.py
+++ b/tests/test_proxy_vm.py
@@ -38,6 +38,12 @@ class SD_Proxy_Tests(SD_VM_Local_Test):
         for line in wanted_lines:
             self.assertFileHasLine("/home/user/.securedrop_proxy/sd-proxy.yaml", line)
 
+    def test_sd_proxy_config(self):
+        self.assertEqual(
+            f"http://{self.dom0_config['hidserv']['hostname']}",
+            self._vm_config_read("SD_PROXY_ORIGIN"),
+        )
+
     def test_sd_proxy_writable_config_dir(self):
         # Directory must be writable by normal user. If owned by root,
         # sd-proxy can't write logs, and will fail, blocking client logins.

--- a/tests/test_sd_devices.py
+++ b/tests/test_sd_devices.py
@@ -49,9 +49,6 @@ class SD_Devices_Tests(SD_VM_Local_Test):
         for line in expected_contents:
             self.assertTrue(line in contents)
 
-    def test_gpg_domain_configured(self):
-        self.qubes_gpg_domain_configured(self.vm_name)
-
 
 def load_tests(loader, tests, pattern):
     suite = unittest.TestLoader().loadTestsFromTestCase(SD_Devices_Tests)

--- a/tests/test_sd_whonix.py
+++ b/tests/test_sd_whonix.py
@@ -10,6 +10,7 @@ class SD_Whonix_Tests(SD_VM_Local_Test):
         self.vm_name = "sd-whonix"
         self.whonix_apt_list = "/etc/apt/sources.list.d/derivative.list"
         super(SD_Whonix_Tests, self).setUp()
+        self.expected_config_keys = {"SD_HIDSERV_HOSTNAME", "SD_HIDSERV_KEY"}
 
     def test_accept_sd_xfer_extracted_file(self):
         with open("config.json") as c:
@@ -62,9 +63,6 @@ class SD_Whonix_Tests(SD_VM_Local_Test):
             duplicate_includes in torrc_contents,
             "Whonix GW torrc contains duplicate %include lines",
         )
-
-    def test_gpg_domain_configured(self):
-        self.qubes_gpg_domain_configured(self.vm_name)
 
 
 def load_tests(loader, tests, pattern):

--- a/tests/test_sd_whonix.py
+++ b/tests/test_sd_whonix.py
@@ -32,6 +32,12 @@ class SD_Whonix_Tests(SD_VM_Local_Test):
 
             self.assertFileHasLine("/var/lib/tor/keys/app-journalist.auth_private", line)
 
+    def test_sd_whonix_config(self):
+        self.assertEqual(
+            self.dom0_config["hidserv"]["hostname"], self._vm_config_read("SD_HIDSERV_HOSTNAME")
+        )
+        self.assertEqual(self.dom0_config["hidserv"]["key"], self._vm_config_read("SD_HIDSERV_KEY"))
+
     def test_sd_whonix_repo_enabled(self):
         """
         During Whonix 14 -> 15 migration, we removed the apt list file

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -47,9 +47,6 @@ class SD_Viewer_Tests(SD_VM_Local_Test):
     def test_mailcap_hardened(self):
         self.mailcap_hardened()
 
-    def test_gpg_domain_configured(self):
-        self.qubes_gpg_domain_configured(self.vm_name)
-
 
 def load_tests(loader, tests, pattern):
     suite = unittest.TestLoader().loadTestsFromTestCase(SD_Viewer_Tests)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Towards #936 (superseding #956 due to its `skip-ci/` prefix):
1. sets values from the dom0 `config.json` to keys under the `vm-config/` prefix in QubesDB (under the `vm-config.` prefix in Salt); and
2. tests *all* VMs for expected configuration keys, eliminating the special-casing of `QUBES_GPG_DOMAIN`;
3. tests configured VMs for their expected values from `config.json`; and
4. leaves `TODO` hints in state files that can be removed as each VM's applications are updated to read configuration from this store, as in freedomofpress/securedrop-client#1883, and their Salt-managed configuration files can be removed.

## Testing

With this branch checked out in your `$SECUREDROP_DEV_VM`:

```sh-session
[user@dom0 securedrop-workstation]$ make clone
[user@dom0 securedrop-workstation]$ make dev
```

Now you can poke around (e.g.):

```sh-session
[user@dom0 securedrop-workstation]$ qvm-run --pass-io sd-app qubesdb-read /vm-config/QUBES_GPG_DOMAIN
sd-gpg
[user@dom0 securedrop-workstation]$ qvm-run --pass-io sd-app qubesdb-read /vm-config/SD_SUBMISSION_KEY_FPR
5F4BB12BAF811C789347DDFF148B87347CB3DDA1
```

That's it!  Since nothing downstream consumes from this configuration store yet, it has no side effects.

### Extra credit

Test the enforcement of expected configuration keys:

```sh-session
[user@dom0 securedrop-workstation]$ qubesdb-write -d sd-proxy /vm-config/QUBES_GPG_DOMAIN "you shouldn't have this"
[user@dom0 securedrop-workstation]$ make test-proxy  # Expected: "AssertionError: Items in the first set but not the second..."
```


## Deployment

As part of work towards https://github.com/freedomofpress/securedrop-workstation/issues/965, this assumes a fresh installation (except during testing) and so has no special considerations.


## Checklist

### If you have made changes to the provisioning logic

- [x] All tests (`make test`) pass in `dom0`