### PR TITLE
Clean up shebangs so they don't need mangling

### DIFF
--- a/dom0/remove-tags
+++ b/dom0/remove-tags
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 """
 Removes tags used for exempting VMs from default SecureDrop Workstation
 RPC policies from all VMs (including non-SecureDrop ones).

--- a/dom0/securedrop-handle-upgrade
+++ b/dom0/securedrop-handle-upgrade
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/bash
 
 set -e
 set -u

--- a/dom0/update-xfce-settings
+++ b/dom0/update-xfce-settings
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/bash
 
 # A maintenance script for altering the XFCE config for the currently logged in
 # user to settings more appropriate for SecureDrop Workstation, or resetting

--- a/files/clean-salt
+++ b/files/clean-salt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/bash
 # Utility script to clean Saltstack config
 # files for the SecureDrop Workstation.
 set -e

--- a/files/destroy-vm
+++ b/files/destroy-vm
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 """
 Utility to quickly destroy a Qubes VM managed by the Workstation
 salt config, for use in repeated builds during development.

--- a/files/provision-all
+++ b/files/provision-all
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/bash
 # Create and configure all SecureDrop Workstation VMs.
 set -e
 set -u

--- a/files/sdw-admin.py
+++ b/files/sdw-admin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 """
 Admin wrapper script for applying salt states for staging and prod scenarios. The rpm
 packages only puts the files in place `/srv/salt` but does not apply the state, nor

--- a/files/sdw-login
+++ b/files/sdw-login
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 """
 Utility script for SecureDrop Workstation. Launches the SecureDrop Workstation
 updater on boot. It will prompt users to apply template and dom0 updates

--- a/files/sdw-notify
+++ b/files/sdw-notify
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 """
 Displays a warning to the user if the workstation has been running continuously
 for too long without checking for security updates. Writes output to a logfile,

--- a/files/sdw-updater
+++ b/files/sdw-updater
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 import argparse
 import sys
 

--- a/files/validate_config.py
+++ b/files/validate_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 """
 Utility to verify that SecureDrop Workstation config is properly structured.
 Checks for

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/bash
 # Helper script for fully reproducible RPMs
 set -e
 set -u

--- a/scripts/clone-to-dom0
+++ b/scripts/clone-to-dom0
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/bash
 # Utility to copy workstation config files from target AppVM
 # to dom0, for use in testing the salt logic for VM configuration.
 # Should only be run in dom0!

--- a/scripts/configure-environment
+++ b/scripts/configure-environment
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 """
 Updates the config.json in-place in dom0 to set the environment to 'dev' or
 'staging'.

--- a/scripts/container.sh
+++ b/scripts/container.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/bash
 # shellcheck disable=SC2086
 # we ignore SC2086 because ${OCI_BUILD_ARGUMENTS:-} is intended to
 # be evaluated into multiple strings, not a single argument.

--- a/scripts/prep-dev
+++ b/scripts/prep-dev
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/bash
 # Developer-oriented utility script for deploying Saltstack config
 # files for the SecureDrop Workstation dev env. Installs the latest
 # locally built RPM in order to deploy the Salt config.

--- a/scripts/shellcheck.sh
+++ b/scripts/shellcheck.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/bash
 
 set -e
 

--- a/update_version.sh
+++ b/update_version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/bash
 ## Usage: ./update_version.sh <version>
 
 set -e

--- a/usb-autoattach/sd-attach-export-device
+++ b/usb-autoattach/sd-attach-export-device
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/bash
 
 # udev action for attaching USB export devices to sd-devices
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

rpm has some support for mangling shebangs, but it is sometimes flaky under reprotest (#1010). We should understand that better, but we can also avoid the need for inconsistent mangling by fixing them up in source itself. All of the Python files are executed by the system interpreter and not a virtualenv, so they shouldn't go through `env` first.

Modern Fedora and Debian Bookworm have had /usr merged, so /bin is a symlink to /usr/bin, so we can specify the full path to /usr/bin/bash in shebangs.

Fixes #1010.

## Testing

* [ ] CI passes
* [ ] visual review

## Deployment

Any special considerations for deployment? In theory this is a no-op because previously rpm would do this mangling.

## Checklist

- [ ] All tests (`make test`) pass in `dom0`