### PR TITLE
Use `make build-deps` for nightlies

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -24,7 +24,7 @@ jobs:
       - run: dnf install -y make git
       - uses: actions/checkout@v4
       - name: Install dependencies
-        run: make install-deps
+        run: make build-deps
       - name: Build RPM
         run: |
           git config --global --add safe.directory '*'


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The `install-deps` target was removed in 79a18cc, and this usage was missed. grep turns up no other occurrences of it.

## Testing

* [x] visual review
* [x] `rg --hidden install-deps` turns up nothing else

## Deployment

Any special considerations for deployment? n/a
