### PR TITLE
Add sd-viewer symlink test for mimetypes

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -99,6 +99,11 @@ class SD_VM_Local_Test(unittest.TestCase):
         contents = subprocess.check_output(cmd).decode("utf-8")
         return contents
 
+    def _get_symlink_location(self, path):
+        cmd = ["qvm-run", "-p", self.vm_name, "/usr/bin/readlink -f {}".format(path)]
+        contents = subprocess.check_output(cmd).decode("utf-8").strip()
+        return contents
+
     def _package_is_installed(self, pkg):
         """
         Confirms that a given package is installed inside the VM.

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -47,6 +47,11 @@ class SD_Viewer_Tests(SD_VM_Local_Test):
     def test_mailcap_hardened(self):
         self.mailcap_hardened()
 
+    def test_mimetypes_symlink(self):
+        self.assertTrue(self._fileExists(".local/share/applications/mimeapps.list"))
+        symlink_location = self._get_symlink_location(".local/share/applications/mimeapps.list")
+        assert symlink_location == "/opt/sdw/mimeapps.list.sd-viewer"
+
 
 def load_tests(loader, tests, pattern):
     suite = unittest.TestLoader().loadTestsFromTestCase(SD_Viewer_Tests)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #711.

I added a new dom0 test to confirm that `~/.local/share/applications/mimeapps.list` on `sd-viewer` is a symlink to `/opt/sdw/mimeapps.list.sd-viewer`.

I also added a `_get_symlink_location` method to the base test class, so it'll be simpler to make more symlink tests like this in the future.

## Checklist

### If you have made changes to the provisioning logic

- [x] All tests (`make test`) pass in `dom0`