### PR TITLE
Don't hide output during `make clone`'s `make build-rpm` step

### DIFF
--- a/scripts/clone-to-dom0
+++ b/scripts/clone-to-dom0
@@ -25,7 +25,7 @@ dom0_dev_dir="$HOME/securedrop-workstation"
 # in the subsequent tarball, which is fetched to dom0.
 function build-dom0-rpm() {
     printf "Building RPM on %s ...\n" "${dev_vm}"
-    qvm-run -q "$dev_vm" "make -C $dev_dir build-rpm"
+    qvm-run --pass-io "$dev_vm" "make -C $dev_dir build-rpm"
 }
 
 # Call out to target AppVM to create a tarball in dom0


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

For a development step, be more verbose instead of hiding things. Makes understanding failures from CI logs much easier too.

## Testing

* [ ] Visual review
* [ ] Look at CI log and see the output from `make build-rpm`

## Deployment

Any special considerations for deployment? n/a, dev only.

## Checklist

- [ ] All tests (`make test`) pass in `dom0`