### PR TITLE
Initial Qubes 4.2 Updater Integration

### DIFF
--- a/launcher/tests/test_updater.py
+++ b/launcher/tests/test_updater.py
@@ -128,7 +128,7 @@ def test_apply_templates(templates, stderr, expected):
         "sdw_updater.Updater._start_qubes_updater_proc",
         return_value=subprocess.Popen(
             f"echo '{stderr}' >> /dev/stderr",
-            shell=True,
+            shell=True,  # noqa: S602
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         ),

--- a/launcher/tests/test_updater.py
+++ b/launcher/tests/test_updater.py
@@ -8,7 +8,7 @@ from unittest.mock import call
 import pytest
 
 from sdw_updater import Updater
-from sdw_updater.Updater import UpdateStatus, current_templates, current_vms
+from sdw_updater.Updater import UpdateStatus
 
 debian_based_vms = [
     "sd-app",
@@ -61,82 +61,72 @@ def test_updater_templatevms_present():
 
 @mock.patch("sdw_updater.Updater._write_updates_status_flag_to_disk")
 @mock.patch("sdw_updater.Updater._write_last_updated_flags_to_disk")
-@mock.patch("sdw_updater.Updater._apply_updates_vm")
 @mock.patch("sdw_updater.Updater._apply_updates_dom0", return_value=UpdateStatus.UPDATES_OK)
 @mock.patch("sdw_updater.Updater._check_updates_dom0", return_value=UpdateStatus.UPDATES_REQUIRED)
 @mock.patch("sdw_updater.Updater.sdlog.error")
 @mock.patch("sdw_updater.Updater.sdlog.info")
 def test_apply_updates_dom0_updates_available(
-    mocked_info, mocked_error, check_dom0, apply_dom0, apply_vm, write_updated, write_status
+    mocked_info, mocked_error, check_dom0, apply_dom0, write_updated, write_status
 ):
-    upgrade_generator = Updater.apply_updates(["dom0"])
-    results = {}
-
-    for vm, progress, result in upgrade_generator:
-        results[vm] = result
-        assert progress is not None
-
-    assert Updater.overall_update_status(results) == UpdateStatus.UPDATES_OK
+    assert Updater.apply_updates_dom0() == UpdateStatus.UPDATES_OK
     assert not mocked_error.called
     # Ensure we check for updates, and apply them (with no parameters)
     check_dom0.assert_called_once_with()
     apply_dom0.assert_called_once_with()
-    assert not apply_vm.called
 
 
 @mock.patch("sdw_updater.Updater._write_updates_status_flag_to_disk")
 @mock.patch("sdw_updater.Updater._write_last_updated_flags_to_disk")
-@mock.patch("sdw_updater.Updater._apply_updates_vm")
 @mock.patch("sdw_updater.Updater._apply_updates_dom0")
 @mock.patch("sdw_updater.Updater._check_updates_dom0", return_value=UpdateStatus.UPDATES_OK)
 @mock.patch("sdw_updater.Updater.sdlog.error")
 @mock.patch("sdw_updater.Updater.sdlog.info")
 def test_apply_updates_dom0_no_updates(
-    mocked_info, mocked_error, check_dom0, apply_dom0, apply_vm, write_updated, write_status
+    mocked_info, mocked_error, check_dom0, apply_dom0, write_updated, write_status
 ):
-    upgrade_generator = Updater.apply_updates(["dom0"])
-    results = {}
-
-    for vm, progress, result in upgrade_generator:
-        results[vm] = result
-        assert progress is not None
-
-    assert Updater.overall_update_status(results) == UpdateStatus.UPDATES_OK
+    assert Updater.apply_updates_dom0() == UpdateStatus.UPDATES_OK
     assert not mocked_error.called
     # We check for updates, but do not attempt to apply them
     check_dom0.assert_called_once_with()
     assert not apply_dom0.called
-    assert not apply_vm.called
 
 
 @mock.patch("sdw_updater.Updater._write_updates_status_flag_to_disk")
 @mock.patch("sdw_updater.Updater._write_last_updated_flags_to_disk")
-@mock.patch(
-    "sdw_updater.Updater._apply_updates_vm",
-    side_effect=[UpdateStatus.UPDATES_OK, UpdateStatus.UPDATES_REQUIRED],
-)
-@mock.patch("sdw_updater.Updater._apply_updates_dom0")
+@mock.patch("subprocess.check_output", return_value=b"")
 @mock.patch("sdw_updater.Updater.sdlog.error")
 @mock.patch("sdw_updater.Updater.sdlog.info")
-def test_apply_updates_required(
-    mocked_info, mocked_error, apply_dom0, apply_vm, write_updated, write_status
+def test_apply_templates_success(
+    mocked_info, mocked_error, mocked_check, write_updated, write_status
 ):
-    upgrade_generator = Updater.apply_updates(["fedora", "sd-app"])
-    results = {}
+    templates = ["fedora", "debian"]
+    result = Updater.apply_updates_templates(templates=templates)
 
-    for vm, progress, result in upgrade_generator:
-        results[vm] = result
-        assert progress is not None
-
-    assert results == {"fedora": UpdateStatus.UPDATES_OK, "sd-app": UpdateStatus.UPDATES_REQUIRED}
-    calls = [call("fedora"), call("sd-app")]
-    apply_vm.assert_has_calls(calls)
-
-    assert results == {"fedora": UpdateStatus.UPDATES_OK, "sd-app": UpdateStatus.UPDATES_REQUIRED}
-
-    assert Updater.overall_update_status(results) == UpdateStatus.UPDATES_REQUIRED
+    mocked_check.assert_called_once_with(
+        [
+            "qubes-vm-update",
+            "--restart",
+            "--no-progress",
+            "--show-output",
+            "--targets",
+            ",".join(templates),
+        ],
+        stderr=subprocess.STDOUT,
+    )
+    assert result == UpdateStatus.UPDATES_OK
     assert not mocked_error.called
-    assert not apply_dom0.called
+
+
+@mock.patch(
+    "subprocess.check_output", side_effect=subprocess.CalledProcessError(cmd="", returncode=1)
+)
+@mock.patch("sdw_updater.Updater.sdlog.error")
+@mock.patch("sdw_updater.Updater.sdlog.info")
+def test_apply_templates_failure(mocked_info, mocked_error, mocked_check):
+    templates = ["fedora", "debian"]
+    result = Updater.apply_updates_templates(templates=templates)
+    assert result == UpdateStatus.UPDATES_FAILED
+    assert mocked_error.called
 
 
 @pytest.mark.parametrize("status", UpdateStatus)
@@ -248,28 +238,19 @@ def test_write_last_updated_flags_dom0_folder_creation_fail(
 
 
 @mock.patch("subprocess.check_call")
-@mock.patch("sdw_updater.Updater._write_updates_status_flag_to_disk")
-@mock.patch("sdw_updater.Updater._write_last_updated_flags_to_disk")
-@mock.patch("sdw_updater.Updater.shutdown_and_start_vms")
 @mock.patch("sdw_updater.Updater._check_updates_dom0", return_value=UpdateStatus.UPDATES_REQUIRED)
-@mock.patch("sdw_updater.Updater._apply_updates_vm")
 @mock.patch("sdw_updater.Updater.sdlog.error")
 @mock.patch("sdw_updater.Updater.sdlog.info")
 def test_apply_updates_dom0_updates_applied(
     mocked_info,
     mocked_error,
-    apply_vm,
     check_dom0,
-    shutdown,
-    write_updated,
-    write_status,
     mocked_call,
 ):
     result = Updater._apply_updates_dom0()
     assert result == UpdateStatus.REBOOT_REQUIRED
     mocked_call.assert_called_once_with(["sudo", "qubes-dom0-update", "-y"])
     assert not mocked_error.called
-    assert not apply_vm.called
 
 
 @mock.patch("subprocess.check_call", side_effect=subprocess.CalledProcessError(1, "check_call"))
@@ -285,41 +266,6 @@ def test_apply_updates_dom0_failure(mocked_info, mocked_error, mocked_call):
     assert mocked_call.called
     assert result == UpdateStatus.UPDATES_FAILED
     mocked_error.assert_has_calls(error_log)
-
-
-@pytest.mark.parametrize("vm", current_templates)
-@mock.patch("subprocess.check_call", side_effect="0")
-@mock.patch("sdw_updater.Updater.sdlog.error")
-@mock.patch("sdw_updater.Updater.sdlog.info")
-def test_apply_updates_vms(mocked_info, mocked_error, mocked_call, vm):
-    if vm != "dom0":
-        result = Updater._apply_updates_vm(vm)
-        assert result == UpdateStatus.UPDATES_OK
-
-        if vm.startswith(("fedora", "whonix")):
-            expected_salt_state = "update.qubes-vm"
-        else:
-            expected_salt_state = "fpf-apt-repo"
-
-        mocked_call.assert_called_once_with(
-            ["sudo", "qubesctl", "--skip-dom0", "--targets", vm, "state.sls", expected_salt_state]
-        )
-        assert not mocked_error.called
-
-
-@pytest.mark.parametrize("vm", current_templates)
-@mock.patch("subprocess.check_call", side_effect=subprocess.CalledProcessError(1, "check_call"))
-@mock.patch("sdw_updater.Updater.sdlog.error")
-@mock.patch("sdw_updater.Updater.sdlog.info")
-def test_apply_updates_vms_fails(mocked_info, mocked_error, mocked_call, vm):
-    error_calls = [
-        call(f"An error has occurred updating {vm}. Please contact your administrator."),
-        call("Command 'check_call' returned non-zero exit status 1."),
-    ]
-    result = Updater._apply_updates_vm(vm)
-    assert result == UpdateStatus.UPDATES_FAILED
-
-    mocked_error.assert_has_calls(error_calls)
 
 
 @mock.patch("subprocess.check_call", side_effect=subprocess.CalledProcessError(1, "check_call"))
@@ -398,148 +344,6 @@ def test_overall_update_status_reboot_not_done_previously(
     result = Updater.overall_update_status(TEST_RESULTS_UPDATES)
     assert result == UpdateStatus.REBOOT_REQUIRED
     assert not mocked_error.called
-
-
-@pytest.mark.parametrize("vm", current_vms.keys())
-@mock.patch("subprocess.check_output")
-@mock.patch("sdw_updater.Updater.sdlog.error")
-@mock.patch("sdw_updater.Updater.sdlog.info")
-def test_safely_shutdown(mocked_info, mocked_error, mocked_output, vm):
-    call_list = [call(["qvm-shutdown", "--wait", f"{vm}"], stderr=-1)]
-
-    Updater._safely_shutdown_vm(vm)
-    mocked_output.assert_has_calls(call_list)
-    assert not mocked_error.called
-
-
-@pytest.mark.parametrize("vm", current_vms.keys())
-@mock.patch("subprocess.check_output", side_effect=["0", "0", "0"])
-@mock.patch("sdw_updater.Updater.sdlog.error")
-@mock.patch("sdw_updater.Updater.sdlog.info")
-def test_safely_start(mocked_info, mocked_error, mocked_output, vm):
-    call_list = [
-        call(["qvm-ls", "--running", "--raw-list"], stderr=-1),
-        call(["qvm-start", "--skip-if-running", vm], stderr=-1),
-    ]
-
-    Updater._safely_start_vm(vm)
-    mocked_output.assert_has_calls(call_list)
-    assert not mocked_error.called
-
-
-@pytest.mark.parametrize("vm", current_vms.keys())
-@mock.patch("subprocess.check_output", side_effect=subprocess.CalledProcessError(1, "check_output"))
-@mock.patch("sdw_updater.Updater.sdlog.error")
-@mock.patch("sdw_updater.Updater.sdlog.info")
-def test_safely_start_fails(mocked_info, mocked_error, mocked_output, vm):
-    call_list = [
-        call(f"Error while starting {vm}"),
-        call("Command 'check_output' returned non-zero exit status 1."),
-    ]
-
-    Updater._safely_start_vm(vm)
-    mocked_error.assert_has_calls(call_list)
-
-
-@pytest.mark.parametrize("vm", current_vms.keys())
-@mock.patch("subprocess.check_output", side_effect=subprocess.CalledProcessError(1, "check_output"))
-@mock.patch("sdw_updater.Updater.sdlog.error")
-@mock.patch("sdw_updater.Updater.sdlog.info")
-def test_safely_shutdown_fails(mocked_info, mocked_error, mocked_call, vm):
-    call_list = [
-        call(f"Failed to shut down {vm}"),
-        call("Command 'check_output' returned non-zero exit status 1."),
-    ]
-
-    Updater._safely_shutdown_vm(vm)
-    mocked_error.assert_has_calls(call_list)
-
-
-@mock.patch("subprocess.check_output")
-@mock.patch("sdw_updater.Updater._safely_start_vm")
-@mock.patch("sdw_updater.Updater._safely_shutdown_vm")
-@mock.patch("sdw_updater.Updater.sdlog.error")
-@mock.patch("sdw_updater.Updater.sdlog.info")
-def test_shutdown_and_start_vms(
-    mocked_info, mocked_error, mocked_shutdown, mocked_start, mocked_output
-):
-    sys_vm_kill_calls = [
-        call(["qvm-kill", "sys-firewall"], stderr=-1),
-        call(["qvm-kill", "sys-net"], stderr=-1),
-    ]
-    sys_vm_shutdown_calls = [call("sys-usb"), call("sys-whonix")]
-    sys_vm_start_calls = [
-        call("sys-net"),
-        call("sys-firewall"),
-        call("sys-whonix"),
-        call("sys-usb"),
-    ]
-    template_vm_calls = [
-        call("fedora-39-xfce"),
-        call(f"sd-large-{DEBIAN_VERSION}-template"),
-        call(f"sd-small-{DEBIAN_VERSION}-template"),
-        call("whonix-gateway-17"),
-    ]
-    app_vm_calls = [
-        call("sd-app"),
-        call("sd-proxy"),
-        call("sd-whonix"),
-        call("sd-gpg"),
-        call("sd-log"),
-    ]
-    Updater.shutdown_and_start_vms()
-    mocked_output.assert_has_calls(sys_vm_kill_calls)
-    mocked_shutdown.assert_has_calls(template_vm_calls + app_vm_calls + sys_vm_shutdown_calls)
-    app_vm_calls_reversed = list(reversed(app_vm_calls))
-    mocked_start.assert_has_calls(sys_vm_start_calls + app_vm_calls_reversed)
-    assert not mocked_error.called
-
-
-@mock.patch("subprocess.check_output", side_effect=subprocess.CalledProcessError(1, "check_output"))
-@mock.patch("sdw_updater.Updater._safely_start_vm")
-@mock.patch("sdw_updater.Updater._safely_shutdown_vm")
-@mock.patch("sdw_updater.Updater.sdlog.error")
-@mock.patch("sdw_updater.Updater.sdlog.info")
-def test_shutdown_and_start_vms_sysvm_fail(
-    mocked_info, mocked_error, mocked_shutdown, mocked_start, mocked_output
-):
-    sys_vm_kill_calls = [
-        call(["qvm-kill", "sys-firewall"], stderr=-1),
-        call(["qvm-kill", "sys-net"], stderr=-1),
-    ]
-    sys_vm_start_calls = [
-        call("sys-net"),
-        call("sys-firewall"),
-        call("sys-whonix"),
-        call("sys-usb"),
-    ]
-    app_vm_calls = [
-        call("sd-app"),
-        call("sd-proxy"),
-        call("sd-whonix"),
-        call("sd-gpg"),
-        call("sd-log"),
-    ]
-    template_vm_calls = [
-        call("fedora-39-xfce"),
-        call(f"sd-large-{DEBIAN_VERSION}-template"),
-        call(f"sd-small-{DEBIAN_VERSION}-template"),
-        call("whonix-gateway-17"),
-    ]
-    error_calls = [
-        call("Error while killing system VM: sys-firewall"),
-        call("Command 'check_output' returned non-zero exit status 1."),
-        call("None"),
-        call("Error while killing system VM: sys-net"),
-        call("Command 'check_output' returned non-zero exit status 1."),
-        call("None"),
-    ]
-    Updater.shutdown_and_start_vms()
-    mocked_output.assert_has_calls(sys_vm_kill_calls)
-    mocked_shutdown.assert_has_calls(template_vm_calls + app_vm_calls)
-    app_vm_calls_reversed = list(reversed(app_vm_calls))
-    mocked_start.assert_has_calls(sys_vm_start_calls + app_vm_calls_reversed)
-    mocked_error.assert_has_calls(error_calls)
 
 
 @pytest.mark.parametrize("status", UpdateStatus)

--- a/sdw_updater/Updater.py
+++ b/sdw_updater/Updater.py
@@ -185,28 +185,6 @@ def _apply_updates_dom0():
     return UpdateStatus.REBOOT_REQUIRED
 
 
-def _apply_updates_vm(vm):
-    """
-    Apply updates to a given TemplateVM. Any update to the base fedora template
-    will require a reboot after the upgrade.
-    """
-    sdlog.info(f"Updating {vm}")
-
-    # We run custom Salt logic for our own Debian-based TemplateVMs
-    salt_state = "update.qubes-vm" if vm.startswith(("fedora", "whonix")) else "fpf-apt-repo"
-
-    try:
-        subprocess.check_call(
-            ["sudo", "qubesctl", "--skip-dom0", "--targets", vm, "state.sls", salt_state]
-        )
-    except subprocess.CalledProcessError as e:
-        sdlog.error(f"An error has occurred updating {vm}. Please contact your administrator.")
-        sdlog.error(str(e))
-        return UpdateStatus.UPDATES_FAILED
-    sdlog.info(f"{vm} update successful")
-    return UpdateStatus.UPDATES_OK
-
-
 def _write_last_updated_flags_to_disk():
     """
     Writes the time of last successful upgrade to dom0 and sd-app
@@ -392,81 +370,6 @@ def apply_dom0_state():
         clean_output = Util.strip_ansi_colors(e.output.decode("utf-8").strip())
         detail_log.error(f"Output from failed command: {cmd_for_log}\n{clean_output}")
         return UpdateStatus.UPDATES_FAILED
-
-
-def shutdown_and_start_vms():
-    """
-    Power cycles the vms to ensure. we should do them all in one shot to reduce complexity
-    and likelihood of failure. Rebooting the VMs will ensure the TemplateVM
-    updates are picked up by the AppVM. We must first shut all VMs down to ensure
-    correct order of operations, as sd-whonix cannot shutdown if sd-proxy is powered
-    on, for example.
-
-    All system AppVMs (sys-net, sys-firewall and sys-usb) need to be restarted.
-    We use qvm-kill for sys-firewall and sys-net, because a shutdown may fail
-    if they are currently in use as NetVMs by any of the user's other VMs.
-    """
-
-    sdw_vms_in_order = ["sd-app", "sd-proxy", "sd-whonix", "sd-gpg", "sd-log"]
-
-    sdlog.info("Shutting down SDW TemplateVMs for updates")
-    for vm in sorted(current_templates):
-        _safely_shutdown_vm(vm)
-
-    sdlog.info("Shutting down SDW AppVMs for updates")
-    for vm in sdw_vms_in_order:
-        _safely_shutdown_vm(vm)
-
-    # System VMs that can be safely shut down (order should not matter, but will
-    # be respected).
-    safe_sys_vms_in_order = ["sys-usb", "sys-whonix"]
-    for vm in safe_sys_vms_in_order:
-        sdlog.info(f"Safely shutting down system VM: {vm}")
-        _safely_shutdown_vm(vm)
-
-    # TODO: Use of qvm-kill should be considered unsafe and may have unexpected
-    # side effects. We should aim for a more graceful shutdown strategy.
-    unsafe_sys_vms_in_order = ["sys-firewall", "sys-net"]
-    for vm in unsafe_sys_vms_in_order:
-        sdlog.info(f"Killing system VM: {vm}")
-        try:
-            subprocess.check_output(["qvm-kill", vm], stderr=subprocess.PIPE)
-        except subprocess.CalledProcessError as e:
-            sdlog.error(f"Error while killing system VM: {vm}")
-            sdlog.error(str(e))
-            sdlog.error(str(e.stderr))
-
-    all_sys_vms_in_order = safe_sys_vms_in_order + unsafe_sys_vms_in_order
-    sdlog.info("Starting fedora-based system VMs after updates")
-    for vm in reversed(all_sys_vms_in_order):
-        _safely_start_vm(vm)
-
-    sdlog.info("Starting SDW VMs after updates")
-    for vm in reversed(sdw_vms_in_order):
-        _safely_start_vm(vm)
-
-
-def _safely_shutdown_vm(vm):
-    try:
-        subprocess.check_output(["qvm-shutdown", "--wait", vm], stderr=subprocess.PIPE)
-    except subprocess.CalledProcessError as e:
-        sdlog.error(f"Failed to shut down {vm}")
-        sdlog.error(str(e))
-        sdlog.error(str(e.stderr))
-        return UpdateStatus.UPDATES_FAILED
-
-
-def _safely_start_vm(vm):
-    try:
-        running_vms = subprocess.check_output(
-            ["qvm-ls", "--running", "--raw-list"], stderr=subprocess.PIPE
-        )
-        sdlog.info(f"VMs running before start of {vm}: {running_vms}")
-        subprocess.check_output(["qvm-start", "--skip-if-running", vm], stderr=subprocess.PIPE)
-    except subprocess.CalledProcessError as e:
-        sdlog.error(f"Error while starting {vm}")
-        sdlog.error(str(e))
-        sdlog.error(str(e.stderr))
 
 
 def should_launch_updater(interval):

--- a/sdw_updater/Updater.py
+++ b/sdw_updater/Updater.py
@@ -115,34 +115,37 @@ def apply_updates_dom0():
     return upgrade_results
 
 
-def apply_updates_templates(progress_start=15, progress_end=75):
+def apply_updates_templates(templates=current_templates):
     """
     Apply updates to all TemplateVMs.
-
-    Returns a tuple of (vm_name, percentage_progress, upgrade_results),
-    for use in updating the GUI progress bar.
     """
     sdlog.info(f"Applying all updates to VMs: {current_templates}")
-    # Figure out how much each completed VM should bump the progress bar.
-    if progress_end <= progress_start:
-        raise Exception("Invalid progress range")
-    progress_step = (progress_end - progress_start) // len(current_templates)
+    try:
+        update_cmd = [
+            "qubes-vm-update",
+            "--restart",  # Enforce app qube restarts
+            "--no-progress",  # Progress does not play nicely with text-logging
+            "--show-output",  # Debug information on updated packages and success status
+            "--targets",
+            ",".join(templates),
+        ]
+        update_cmd_result = subprocess.check_output(update_cmd, stderr=subprocess.STDOUT)
+        update_status = UpdateStatus.UPDATES_OK
+        sdlog.info("Update successful.")
+    except subprocess.CalledProcessError as e:
+        update_cmd_result = e.output
+        sdlog.error(
+            "An error has occurred updating templates. Please contact your administrator."
+            f" See {DETAIL_LOG_FILE} for details."
+        )
+        sdlog.error(str(e))
+        update_status = UpdateStatus.UPDATES_FAILED
 
-    progress_current = progress_start
+    cmd_for_log = " ".join(update_cmd)
+    clean_output = Util.strip_ansi_colors(update_cmd_result.decode("utf-8").strip())
+    detail_log.info(f"Output from update command: {cmd_for_log}\n{clean_output}")
 
-    for vm in current_templates:
-        upgrade_results = UpdateStatus.UPDATES_FAILED
-        upgrade_results = _apply_updates_vm(vm)
-
-        progress_current += progress_step
-
-        # constrain progress_current to given progress range
-        def clamp(val, min_val, max_val):
-            return max(min(max_val, val), min_val)
-
-        progress_current = clamp(progress_current, progress_start, progress_end)
-
-        yield vm, progress_current, upgrade_results
+    return update_status
 
 
 def _check_updates_dom0():

--- a/sdw_updater/Updater.py
+++ b/sdw_updater/Updater.py
@@ -101,31 +101,38 @@ def migration_is_required():
     return result
 
 
-def apply_updates(vms=current_templates, progress_start=15, progress_end=75):
+def apply_updates_dom0():
+    """
+    Apply updates to dom0
+    """
+    sdlog.info("Applying all updates to dom0")
+
+    dom0_status = _check_updates_dom0()
+    if dom0_status == UpdateStatus.UPDATES_REQUIRED:
+        upgrade_results = _apply_updates_dom0()
+    else:
+        upgrade_results = UpdateStatus.UPDATES_OK
+    return upgrade_results
+
+
+def apply_updates_templates(progress_start=15, progress_end=75):
     """
     Apply updates to all TemplateVMs.
 
     Returns a tuple of (vm_name, percentage_progress, upgrade_results),
     for use in updating the GUI progress bar.
     """
-    sdlog.info(f"Applying all updates to VMs: {vms}")
+    sdlog.info(f"Applying all updates to VMs: {current_templates}")
     # Figure out how much each completed VM should bump the progress bar.
     if progress_end <= progress_start:
         raise Exception("Invalid progress range")
-    progress_step = (progress_end - progress_start) // len(vms)
+    progress_step = (progress_end - progress_start) // len(current_templates)
 
     progress_current = progress_start
 
-    for vm in vms:
+    for vm in current_templates:
         upgrade_results = UpdateStatus.UPDATES_FAILED
-        if vm == "dom0":
-            dom0_status = _check_updates_dom0()
-            if dom0_status == UpdateStatus.UPDATES_REQUIRED:
-                upgrade_results = _apply_updates_dom0()
-            else:
-                upgrade_results = UpdateStatus.UPDATES_OK
-        else:
-            upgrade_results = _apply_updates_vm(vm)
+        upgrade_results = _apply_updates_vm(vm)
 
         progress_current += progress_step
 

--- a/sdw_updater/Updater.py
+++ b/sdw_updater/Updater.py
@@ -129,11 +129,11 @@ def apply_updates_templates(templates=current_templates):
             "--targets",
             ",".join(templates),
         ]
-        update_cmd_result = subprocess.check_output(update_cmd, stderr=subprocess.STDOUT)
+        update_cmd_output = subprocess.check_output(update_cmd, stderr=subprocess.STDOUT)
         update_status = UpdateStatus.UPDATES_OK
         sdlog.info("Update successful.")
     except subprocess.CalledProcessError as e:
-        update_cmd_result = e.output
+        update_cmd_output = e.output
         sdlog.error(
             "An error has occurred updating templates. Please contact your administrator."
             f" See {DETAIL_LOG_FILE} for details."
@@ -141,9 +141,10 @@ def apply_updates_templates(templates=current_templates):
         sdlog.error(str(e))
         update_status = UpdateStatus.UPDATES_FAILED
 
-    cmd_for_log = " ".join(update_cmd)
-    clean_output = Util.strip_ansi_colors(update_cmd_result.decode("utf-8").strip())
-    detail_log.info(f"Output from update command: {cmd_for_log}\n{clean_output}")
+    if update_cmd_output:
+        cmd_for_log = " ".join(update_cmd)
+        clean_output = Util.strip_ansi_colors(update_cmd_output.decode("utf-8").strip())
+        detail_log.info(f"Output from update command: {cmd_for_log}\n{clean_output}")
 
     return update_status
 

--- a/sdw_updater/UpdaterApp.py
+++ b/sdw_updater/UpdaterApp.py
@@ -235,22 +235,17 @@ class UpgradeThread(QThread):
         results["apply_dom0"] = Updater.apply_dom0_state()
 
         self.progress_signal.emit(15)
-        # rerun full config if dom0 checks determined it's required,
-        # otherwise proceed with per-VM package updates
+        # rerun full config if dom0 checks determined it's required
         if Updater.migration_is_required():
             # Progress bar will freeze for ~15m during full state run
             self.progress_signal.emit(35)
             # add to results dict, if it fails it will show error message
             results["apply_all"] = Updater.run_full_install()
-            self.progress_signal.emit(75)
-        else:
-            upgrade_generator = Updater.apply_updates_templates(progress_start=15, progress_end=75)
-            for vm, progress, result in upgrade_generator:
-                results[vm] = result
-                self.progress_signal.emit(progress)
+            self.progress_signal.emit(60)
 
-        # reboot vms
-        Updater.shutdown_and_start_vms()
+        # Update all VMs regardless of migrations
+        results["templates"] = Updater.apply_updates_templates()
+        self.progress_signal.emit(75)
 
         # write flags to disk
         run_results = Updater.overall_update_status(results)

--- a/sdw_updater/UpdaterApp.py
+++ b/sdw_updater/UpdaterApp.py
@@ -222,15 +222,12 @@ class UpgradeThread(QThread):
         QThread.__init__(self)
 
     def run(self):
+        results = {}
+
         # Update dom0 first, then apply dom0 state. If full state run
         # is required, the dom0 state will drop a flag.
         self.progress_signal.emit(5)
-        upgrade_generator = Updater.apply_updates(vms=["dom0"], progress_start=5, progress_end=10)
-
-        results = {}
-        for vm, progress, result in upgrade_generator:
-            results[vm] = result
-            self.progress_signal.emit(progress)
+        results["dom0"] = Updater.apply_updates_dom0()
 
         # apply dom0 state
         self.progress_signal.emit(10)
@@ -247,7 +244,7 @@ class UpgradeThread(QThread):
             results["apply_all"] = Updater.run_full_install()
             self.progress_signal.emit(75)
         else:
-            upgrade_generator = Updater.apply_updates(progress_start=15, progress_end=75)
+            upgrade_generator = Updater.apply_updates_templates(progress_start=15, progress_end=75)
             for vm, progress, result in upgrade_generator:
                 results[vm] = result
                 self.progress_signal.emit(progress)


### PR DESCRIPTION
## Status
Ready for Review 

(Opened PR due again to the closure of https://github.com/freedomofpress/securedrop-workstation/pull/979 -- see this for background discussion)

TODO:
  - [ ] Consider if it makes sense to update even after a migration was applied (this was not the case before)

Blockers:
  - https://github.com/QubesOS/qubes-issues/issues/8493

## Description of Changes

Fixes #899 . Keeps most of the existing updater logic.

Changes proposed in this pull request:
- updates templates via the CLI Qubes Updater instead of via salt
- removes functions deprecated by the new Qubes updater

## Testing
- [ ] updates failed - no network connection (expectation: updater should quickly bail rather than trying all updates, https://github.com/freedomofpress/securedrop-workstation/issues/633)
- [ ] all updates work
   1. launch updater
   2. Observe templates starting as they are updated
   3. Observe app qubes getting restarted in background
   4. See "successfully completed"
   5. Inspect SDW-launcher logs to ensure correct updating of templates.
- [ ] migration included
   - trigger migration flag and ensure that a migration takes place
- [ ] dom0 updates fail
  - tip: setting sys-firewall's netvm to none helps test this scenario
  - updater should inform of failure. Confirm in logs that dom0 failed to update.
- [ ] vm updates fail
  - tip: use qvm-volume revert on templates to simulate having updates again.
  - tip: disconnect network after 10% (after dom0 updating)
  - updater should inform of failure. Confirm in logs that template failed to update.


## Deployment

Any special considerations for deployment? Will only apply to new installs

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

> **Note**: tests don't pass due to the WIP nature of the base 4.2 branch. However, it seems that launcher-specific tests weren't passing already and it was unclear how to run the tests. 

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation