### PR TITLE
Stop using assert in validate_config.py

### DIFF
--- a/files/validate_config.py
+++ b/files/validate_config.py
@@ -41,20 +41,20 @@ class SDWConfigValidator(object):
         self.validate_existing_size()
 
     def confirm_config_file_exists(self):
-        try:
-            assert os.path.exists(self.config_filepath)
-        except AssertionError:
+        if not os.path.exists(self.config_filepath):
             msg = "Config file does not exist: {}".format(self.config_filepath)
             msg += "Create from config.json.example"
-            raise AssertionError(msg)
+            raise ValidationError(msg)
 
     def confirm_environment_valid(self):
         """
         The 'environment' config item is required to determine
         whether prod or dev URLs are used for installing packages.
         """
-        assert "environment" in self.config
-        assert self.config["environment"] in ("prod", "dev", "staging")
+        if "environment" not in self.config:
+            raise ValidationError
+        if self.config["environment"] not in ("prod", "dev", "staging"):
+            raise ValidationError
 
     def confirm_onion_config_valid(self):
         """
@@ -71,20 +71,27 @@ class SDWConfigValidator(object):
             raise
 
     def confirm_onion_v3_url(self):
-        assert "hidserv" in self.config
-        assert "hostname" in self.config["hidserv"]
-        assert re.match(TOR_V3_HOSTNAME_REGEX, self.config["hidserv"]["hostname"])
+        if "hidserv" not in self.config:
+            raise ValidationError
+        if "hostname" not in self.config["hidserv"]:
+            raise ValidationError
+        if not re.match(TOR_V3_HOSTNAME_REGEX, self.config["hidserv"]["hostname"]):
+            raise ValidationError
 
     def confirm_onion_v3_auth(self):
-        assert "hidserv" in self.config
-        assert "key" in self.config["hidserv"]
-        assert re.match(TOR_V3_AUTH_REGEX, self.config["hidserv"]["key"])
+        if "hidserv" not in self.config:
+            raise ValidationError
+        if "key" not in self.config["hidserv"]:
+            raise ValidationError
+        if not re.match(TOR_V3_AUTH_REGEX, self.config["hidserv"]["key"]):
+            raise ValidationError
 
     def confirm_submission_privkey_file(self):
         """
         Import privkey into temporary keyring, to validate.
         """
-        assert os.path.exists(self.secret_key_filepath)
+        if not os.path.exists(self.secret_key_filepath):
+            raise ValidationError
         gpg_cmd = ["gpg", "--import", self.secret_key_filepath]
         result = False
         with tempfile.TemporaryDirectory() as d:
@@ -98,21 +105,30 @@ class SDWConfigValidator(object):
             except subprocess.CalledProcessError:
                 # suppress error since "result" is checked next
                 pass
-        assert result, "GPG private key is not valid: {}".format(self.secret_key_filepath)
+
+        if not result:
+            raise ValidationError(
+                "GPG private key is not valid: {}".format(self.secret_key_filepath)
+            )
 
     def confirm_submission_privkey_fingerprint(self):
-        assert "submission_key_fpr" in self.config
-        assert re.match("^[a-fA-F0-9]{40}$", self.config["submission_key_fpr"])
+        if "submission_key_fpr" not in self.config:
+            raise ValidationError
+        if not re.match("^[a-fA-F0-9]{40}$", self.config["submission_key_fpr"]):
+            raise ValidationError
         gpg_cmd = ["gpg2", "--show-keys", self.secret_key_filepath]
         try:
             out = subprocess.check_output(gpg_cmd, stderr=subprocess.STDOUT).decode(
                 sys.stdout.encoding
             )
             match = "      {}".format(self.config["submission_key_fpr"])
-            assert re.search(match, out), "Configured fingerprint does not match key!"
+            if not re.search(match, out):
+                raise ValidationError("Configured fingerprint does not match key!")
 
         except subprocess.CalledProcessError as e:
-            assert False, "Key validation failed: {}".format(e.output.decode(sys.stdout.encoding))
+            raise ValidationError(
+                "Key validation failed: {}".format(e.output.decode(sys.stdout.encoding))
+            )
 
     def read_config_file(self):
         with open(self.config_filepath, "r") as f:
@@ -122,31 +138,30 @@ class SDWConfigValidator(object):
     def validate_existing_size(self):
         """This method checks for existing private volume size and new
         values in the config.json"""
-        assert "vmsizes" in self.config
-        assert "sd_app" in self.config["vmsizes"]
-        assert "sd_log" in self.config["vmsizes"]
+        if "vmsizes" not in self.config:
+            raise ValidationError
+        if "sd_app" not in self.config["vmsizes"]:
+            raise ValidationError
+        if "sd_log" not in self.config["vmsizes"]:
+            raise ValidationError
 
-        assert isinstance(
-            self.config["vmsizes"]["sd_app"], int
-        ), "Private volume size of sd-app must be an integer value."
-        assert isinstance(
-            self.config["vmsizes"]["sd_log"], int
-        ), "Private volume size of sd-log must be an integer value."
+        if not isinstance(self.config["vmsizes"]["sd_app"], int):
+            raise ValidationError("Private volume size of sd-app must be an integer value.")
+        if not isinstance(self.config["vmsizes"]["sd_log"], int):
+            raise ValidationError("Private volume size of sd-log must be an integer value.")
 
         app = Qubes()
         if "sd-app" in app.domains:
             vm = app.domains["sd-app"]
             vol = vm.volumes["private"]
-            assert (
-                vol.size <= self.config["vmsizes"]["sd_app"] * 1024 * 1024 * 1024
-            ), "sd-app private volume is already bigger than configuration."
+            if not (vol.size <= self.config["vmsizes"]["sd_app"] * 1024 * 1024 * 1024):
+                raise ValidationError("sd-app private volume is already bigger than configuration.")
 
         if "sd-log" in app.domains:
             vm = app.domains["sd-log"]
             vol = vm.volumes["private"]
-            assert (
-                vol.size <= self.config["vmsizes"]["sd_log"] * 1024 * 1024 * 1024
-            ), "sd-log private volume is already bigger than configuration."
+            if not (vol.size <= self.config["vmsizes"]["sd_log"] * 1024 * 1024 * 1024):
+                raise ValidationError("sd-log private volume is already bigger than configuration.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #683.

Here's how to reproduce the `TOB-SDW-024` bug:

In sd-dev switch to the `main` branch in `securedrop-workstation`. In dom0, run `make clone`.

One of the checks in `validate_config.py`  is that `self.config["vmsizes"]["sd_log"]` is an integer. So, in dom0, edit `/usr/share/securedrop-workstation-dom0-config/config.json` and make `sd_log` a string instead, like this:

```json
{
    "submission_key_fpr": "65A1B5FF195B56353CC63DFFCC40EF1228271441",
    "hidserv": {
        "hostname": "pmlfte7wii27fi5ioyjwzbgdmjk2i5nx2gd6v3rk5bym7rattnvm36ad.onion",
        "key": "NDN4MWTGFCCJMJWXISZDN2RO3DZJKMVRBGIFCNYN2RKX4VDGKJTQ"
    },
    "environment": "dev",
    "vmsizes": {
        "sd_app": 10,
        "sd_log": "5"
    }
}
```

In dom0, change to `~/securedrop-workstation` and run this to validate the config:

```sh
python3 files/sdw-admin.py --validate
```

It should fail:

```
[user@dom0 securedrop-workstation]$ python3 files/sdw-admin.py --validate
Validating...Traceback (most recent call last):
  File "/home/user/securedrop-workstation/files/sdw-admin.py", line 221, in <module>
    main()
  File "/home/user/securedrop-workstation/files/sdw-admin.py", line 172, in main
    validate_config(SCRIPTS_PATH)
  File "/home/user/securedrop-workstation/files/sdw-admin.py", line 108, in validate_config
    validator = SDWConfigValidator(path)  # noqa: F841
                ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/securedrop-workstation/files/validate_config.py", line 41, in __init__
    self.validate_existing_size()
  File "/home/user/securedrop-workstation/files/validate_config.py", line 132, in validate_existing_size
    assert isinstance(
AssertionError: Private volume size of sd-log must be an integer value.
```

Now run it with the `-OO` flag:

```sh
python3 -OO files/sdw-admin.py --validate
```

It will pass when really it should fail -- this is the bug:

```
[user@dom0 securedrop-workstation]$ python3 -OO files/sdw-admin.py --validate
Validating...OK
```

Now, switch to this PR's branch and run `make clone` in dom0. This time when you run it with the `-OO` flag, it will fail validation like it should:

```
[user@dom0 securedrop-workstation]$ python3 -OO files/sdw-admin.py --validate
Validating...Traceback (most recent call last):
  File "/home/user/securedrop-workstation/files/sdw-admin.py", line 108, in validate_config
    validator = SDWConfigValidator(path)  # noqa: F841
                ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/securedrop-workstation/files/validate_config.py", line 41, in __init__
    self.validate_existing_size()
  File "/home/user/securedrop-workstation/files/validate_config.py", line 151, in validate_existing_size
    raise ValidationError("Private volume size of sd-log must be an integer value.")
validate_config.ValidationError: Private volume size of sd-log must be an integer value.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/user/securedrop-workstation/files/sdw-admin.py", line 221, in <module>
    main()
  File "/home/user/securedrop-workstation/files/sdw-admin.py", line 172, in main
    validate_config(SCRIPTS_PATH)
  File "/home/user/securedrop-workstation/files/sdw-admin.py", line 110, in validate_config
    raise SDWAdminException("Error while validating configuration")
SDWAdminException: Error while validating configuration
```