### PR TITLE
Functional RPC policy tests

### DIFF
--- a/tests/test_qubes_rpc.py
+++ b/tests/test_qubes_rpc.py
@@ -1,6 +1,6 @@
 import os
-import unittest
 import subprocess
+import unittest
 
 RETURNCODE_SUCCESS = 0
 RETURNCODE_DENIED = 126

--- a/tests/test_qubes_rpc.py
+++ b/tests/test_qubes_rpc.py
@@ -4,10 +4,42 @@ import unittest
 
 # TODO: add actual integration testing of policies
 class SD_Qubes_Rpc_Tests(unittest.TestCase):
-    def test_policies(self):
+    def test_policies_exist(self):
         """verify the policies are installed"""
         assert os.path.exists("/etc/qubes/policy.d/31-securedrop-workstation.policy")
         assert os.path.exists("/etc/qubes/policy.d/32-securedrop-workstation.policy")
+
+    # securedrop.Log from @tag:sd-workstation to sd-log should be allowed
+    def test_sdlog_from_sdw_to_sdlog_allowed(self):
+        pass
+
+    # securedrop.Log from anything else to sd-log should be denied
+    def test_sdlog_from_other_to_sdlog_denied(self):
+        pass
+
+    # securedrop.Proxy from sd-app to sd-proxy should be allowed
+    def test_sdproxy_from_sdapp_to_sdproxy_allowed(self):
+        pass
+
+    # securedrop.Proxy from anything else to sd-proxy should be denied
+    def test_sdproxy_from_other_to_sdproxy_denied(self):
+        pass
+
+    # qubes.Gpg, qubes.GpgImportKey, and qubes.Gpg2 from @tag:sd-client to sd-gpg should be allowed
+    def test_qubesgpg_from_sdclient_to_sdgpg_allowed(self):
+        pass
+
+    # qubes.Gpg, qubes.GpgImportKey, and qubes.Gpg2 from anything else to sd-gpg should be denied
+    def test_qubesgpg_from_other_to_sdgpg_denied(self):
+        pass
+
+    # qubes.Filecopy from sd-proxy to @tag:sd-client should be allowed
+    def test_qubesfilecopy_from_sdproxy_to_sdclient_allowed(self):
+        pass
+
+    # qubes.Filecopy from anything else to @tag:sd-client should be denied
+    def test_qubesfilecopy_from_other_to_sdclient_denied(self):
+        pass
 
 
 def load_tests(loader, tests, pattern):

--- a/tests/test_qubes_rpc.py
+++ b/tests/test_qubes_rpc.py
@@ -36,20 +36,8 @@ class SD_Qubes_Rpc_Tests(unittest.TestCase):
     def test_sdproxy_from_other_to_sdproxy_denied(self):
         pass
 
-    # qubes.Gpg, qubes.GpgImportKey, and qubes.Gpg2 from @tag:sd-client to sd-gpg should be allowed
-    def test_qubesgpg_from_sdclient_to_sdgpg_allowed(self):
-        pass
-
     # qubes.Gpg, qubes.GpgImportKey, and qubes.Gpg2 from anything else to sd-gpg should be denied
     def test_qubesgpg_from_other_to_sdgpg_denied(self):
-        pass
-
-    # qubes.Filecopy from sd-proxy to @tag:sd-client should be allowed
-    def test_qubesfilecopy_from_sdproxy_to_sdclient_allowed(self):
-        pass
-
-    # qubes.Filecopy from anything else to @tag:sd-client should be denied
-    def test_qubesfilecopy_from_other_to_sdclient_denied(self):
         pass
 
 

--- a/tests/test_qubes_rpc.py
+++ b/tests/test_qubes_rpc.py
@@ -30,15 +30,25 @@ class SD_Qubes_Rpc_Tests(unittest.TestCase):
 
     # securedrop.Proxy from sd-app to sd-proxy should be allowed
     def test_sdproxy_from_sdapp_to_sdproxy_allowed(self):
-        pass
+        self.assertEqual(self._qrexec("sd-app", "sd-proxy", "securedrop.Proxy"), RETURNCODE_SUCCESS)
 
     # securedrop.Proxy from anything else to sd-proxy should be denied
     def test_sdproxy_from_other_to_sdproxy_denied(self):
-        pass
+        self.assertEqual(self._qrexec("sys-net", "sd-proxy", "securedrop.Proxy"), RETURNCODE_DENIED)
+        self.assertEqual(
+            self._qrexec("sys-firewall", "sd-proxy", "securedrop.Proxy"), RETURNCODE_DENIED
+        )
 
     # qubes.Gpg, qubes.GpgImportKey, and qubes.Gpg2 from anything else to sd-gpg should be denied
     def test_qubesgpg_from_other_to_sdgpg_denied(self):
-        pass
+        self.assertEqual(self._qrexec("sys-net", "sd-gpg", "qubes.Gpg"), RETURNCODE_DENIED)
+        self.assertEqual(self._qrexec("sys-firewall", "sd-gpg", "qubes.Gpg"), RETURNCODE_DENIED)
+        self.assertEqual(self._qrexec("sys-net", "sd-gpg", "qubes.GpgImportKey"), RETURNCODE_DENIED)
+        self.assertEqual(
+            self._qrexec("sys-firewall", "sd-gpg", "qubes.GpgImportKey"), RETURNCODE_DENIED
+        )
+        self.assertEqual(self._qrexec("sys-net", "sd-gpg", "qubes.Gpg2"), RETURNCODE_DENIED)
+        self.assertEqual(self._qrexec("sys-firewall", "sd-gpg", "qubes.Gpg2"), RETURNCODE_DENIED)
 
 
 def load_tests(loader, tests, pattern):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #759.

This was simpler than I first expected it to be.

As discussed in #759, I skipped testing `qubes.USBAttach`, `qubes.USB`, `qubes.OpenInVM` rules, and also GPG-related allow rules, to allow the tests to run without user interaction.

This tests `securedrop.Log` (allow and deny), `securedrop.Proxy` (allow and deny), and the GPG-related rules (deny). It relies on there existing `sys-net` and `sys-firewall` VMs, as it uses these as example VMs where various SDW policies should be denied.