### PR TITLE
Use conditional build in rpm to manage dev-only settings

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -30,7 +30,7 @@ jobs:
           git config --global --add safe.directory '*'
           # Version format is "${VERSION}-0.YYYYMMDDHHMMSS.fXX", which sorts lower than "${VERSION}-1"
           rpmdev-bumpspec --new="$(cat VERSION)-0.$(date +%Y%m%d%H%M%S)%{?dist}" rpm-build/SPECS/*.spec
-          make build-rpm
+          make build-dev-rpm
       - uses: actions/upload-artifact@v4
         id: upload
         with:

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,11 @@ dev staging: assert-dom0 ## Configures and builds a dev or staging environment
 build-rpm: ## Build RPM package
 	USE_BUILD_CONTAINER=true $(CONTAINER) ./scripts/build-rpm.sh
 
+# Dev RPMs don't contain power settings adjustment (lid)
+.PHONY: build-dev-rpm
+build-dev-rpm: ## Build RPM package
+	DEV_BUILD_FLAG=true USE_BUILD_CONTAINER=true $(CONTAINER) ./scripts/build-rpm.sh
+
 # FIXME: the time variations have been temporarily removed from reprotest
 # Suspecting upstream issues in rpm land is causing issues with 1 file\'s modification time not being clamped correctly only in a reprotest environment
 .PHONY: reprotest

--- a/dom0/sd-clean-all.sls
+++ b/dom0/sd-clean-all.sls
@@ -99,12 +99,6 @@ sd-cleanup-etc-changes:
     - repl: ''
     - backup: no
 
-{% if d.environment == "prod" or d.environment == "staging" %}
-apply-systemd-changes:
-  cmd.run:
-    - name: sudo systemctl restart systemd-logind
-{% endif %}
-
 sd-cleanup-sys-firewall:
   cmd.run:
     - names:

--- a/dom0/sd-dom0-systemd.sls
+++ b/dom0/sd-dom0-systemd.sls
@@ -8,24 +8,6 @@
 {% set gui_user = salt['cmd.shell']('groupmems -l -g qubes') %}
 {% set gui_user_id = salt['cmd.shell']('id -u ' + gui_user) %}
 
-{% import_json "sd/config.json" as d %}
-{% if d.environment == "prod" or d.environment == "staging" %}
-# Power off instead of suspend on lid close, for security reasons, but only in
-# prod and staging, to avoid interfering with developer workflows
-dom0-poweroff:
-  file.blockreplace:
-    - name: /etc/systemd/logind.conf
-    - append_if_not_found: True
-    - marker_start: "### BEGIN securedrop-workstation ###"
-    - marker_end: "### END securedrop-workstation ###"
-    - content: |
-        HandleLidSwitch=poweroff
-
-apply-systemd-changes:
-  cmd.run:
-    - name: sudo systemctl restart systemd-logind
-{% endif %}
-
 enable-user-units:
   cmd.run:
     - name: |

--- a/files/logind_override.conf
+++ b/files/logind_override.conf
@@ -1,0 +1,2 @@
+[Login]
+HandleLidSwitch=poweroff

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -14,10 +14,18 @@ git clean -fdX rpm-build/ dist/
 # Place tarball where rpmbuild will find it
 cp dist/*.tar.gz rpm-build/SOURCES/
 
-rpmbuild \
-    --quiet \
-    --define "_topdir $PWD/rpm-build" \
-    -bb --clean "rpm-build/SPECS/${PROJECT}.spec"
+# todo - not quite right
+RPM_BUILD_ARGS="--quiet \
+                 --define \"_topdir $PWD/rpm-build\" \
+                 -bb \
+                 --clean"
+
+# Check if dev build environment (disables laptop power management)
+if [[ -n "${DEV_BUILD_FLAG:-}" ]]; then
+    RPM_BUILD_ARGS="${RPM_BUILD_ARGS} --without=powersettings"
+fi
+
+rpmbuild $RPM_BUILD_ARGS "rpm-build/SPECS/${PROJECT}.spec"
 
 printf '\nBuild complete! RPMs and their checksums are:\n\n'
 find rpm-build/ -type f -iname "${PROJECT}-$(cat "${TOPLEVEL}/VERSION")*.rpm" -print0 | sort -zV | xargs -0 sha256sum

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -3,6 +3,10 @@ export TOPLEVEL
 PROJECT=$(git remote get-url origin | xargs basename -s .git)-dom0-config
 export PROJECT
 
+# DEV_BUILD_FLAG builds without power setting changes present in prod
+DEV_BUILD_FLAG="${DEV_BUILD_FLAG:-}"
+export DEV_BUILD_FLAG
+
 OCI_RUN_ARGUMENTS="${OCI_RUN_ARGUMENTS:-}"
 export OCI_RUN_ARGUMENTS
 


### PR DESCRIPTION
## Status

Work in progress  
(needs testing, needs rpmlinting and a fixup in `build-rpm.sh` if we decide to pursue this route - this is a napkin sketch) 

## Description of Changes
Refs #274 

To further the goal of removing more logic from Salt and into packaging (easier versioning, faster dom0 provisioning therefore faster updater runs, less salt breakage) we are moving files from being provisioned during the apply run into being packaged by the dom0 config and deb vmconfig packages (see eg #1030).

This is straightforward when files are static, but is somewhat trickier when files are either dynamically generated based on runtime info, or when they are provisioned conditionally (ie depending on build flavour).

Filing this PR as a discussion starting point for handling the latter situation. It introduces a [build condition](https://rpm-software-management.github.io/rpm/manual/conditionalbuilds.html) `powersettings` , which is on by default and currently configures the logind.conf power lid settings, but if we like this approach, should be expanded to include the power management xfce logic.

The goal of this type of change is to provide a path for deprecatating all* the the `if d.environment == "staging" or d.environment == "prod"`  type dynamic checking in our salt runs. *(All, or all but the keyring/repo provisioning, which will be handled in a separate bootstrap package.)

Changes proposed in this pull request:
* Replace inline configuration of logind.conf with a [drop-in file + directory](https://www.freedesktop.org/software/systemd/man/latest/systemd-system.conf.html) `/etc/systemd/login.conf.d/override_logind.conf`
* ...That is provisioned on prod and staging rpm builds (default option)
* ... And disabled on dev rpm builds (explicit build parameter passed to rpmbuild)
* And updates make targets and CI accordingly
Note: this change means that our power lid settings are applied when installing the RPM, as opposed to after successful orchestration. Per conversation with @zenmonkeykstop this seems like an acceptable decision given the amount of control we take over the SDW system, whether or not we go the conditional RPM build approach.

### More discussion
Another option could be to build fully separate rpm packages (workstation-dom0-config-staging, dom0-config-dev, etc). This could be a good idea particularly for rpm repo configuration (although in that case we might build different keyring/bootstrapping packages rather than different dom0 config packages. In any case, this solution is not mutually exclusive of that idea, but it's a little less complex.   

## Testing

- [ ] Visual Review
- [ ] CI Passes
- [ ] staging/ prod rpms are built correctly, and when installed, install a directory `/etc/systemd/login.conf.d/` with a configuration file that overrides power lid settings  
- [ ] Dev RPM is built correctly (in CI and locally) and does not include these changes

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing pilot instances
2. New installs

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation