### PR TITLE
deploy: install `template-from-qubesdb` in base template and `sd-whonix`

### DIFF
--- a/dom0/qubesdb-config.sls
+++ b/dom0/qubesdb-config.sls
@@ -1,0 +1,5 @@
+install-template-from-qubesdb:
+  file.managed:
+    - name: /usr/local/bin/template-from-qubesdb
+    - source: "salt://template-from-qubesdb.py"
+    - mode: 755

--- a/dom0/sd-workstation.top
+++ b/dom0/sd-workstation.top
@@ -20,6 +20,7 @@ base:
     - sd-remove-unused-templates
 
   sd-base-bookworm-template:
+    - qubesdb-config
     - sd-base-template-files
     - sd-workstation-template-files
   sd-small-bookworm-template:
@@ -39,6 +40,7 @@ base:
     - sd-app-config
     - sd-mime-handling
   sd-whonix:
+    - qubesdb-config
     - sd-whonix-hidserv-key
   'sd-fedora-39-dvm,sys-usb':
     - match: list

--- a/files/template-from-qubesdb.py
+++ b/files/template-from-qubesdb.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python3
+import argparse
+import subprocess
+from jinja2 import Template
+
+from qubesdb import QubesDB
+
+
+def get_env(args):
+    env = {}
+    try:
+        db = QubesDB()
+        for key in args or []:
+            value = db.read(f"/vm-config/{key}")
+            env[key] = (value or "").decode()
+
+    finally:
+        db.close()
+
+    return env
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Use -k/--key one or more times to read the specified key from QubesDB.  The input template will be written to the output file with those variables substituted."
+    )
+    parser.add_argument("-k", "--key", action="append")
+    parser.add_argument("input")
+    parser.add_argument("output")
+    args = parser.parse_args()
+    env = get_env(args.key)
+
+    with open(args.input) as input_f:
+        template = Template(input_f.read())
+
+    with open(args.output, "w") as output_f:
+        rendered = template.render(**env)
+        output_f.write(rendered)

--- a/files/template-from-qubesdb.py
+++ b/files/template-from-qubesdb.py
@@ -12,7 +12,8 @@ def get_env(args):
         db = QubesDB()
         for key in args or []:
             value = db.read(f"/vm-config/{key}")
-            env[key] = (value or "").decode()
+            if not value or len(value) == 0:
+                raise KeyError(f"Could not read from QubesDB: {key}")
 
     finally:
         db.close()

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -105,6 +105,7 @@ install -m 755 files/sdw-notify.py %{buildroot}/%{_bindir}/sdw-notify
 install -m 755 files/sdw-login.py %{buildroot}/%{_bindir}/sdw-login
 install -m 644 files/sdw-notify.service %{buildroot}/%{_userunitdir}/
 install -m 644 files/sdw-notify.timer %{buildroot}/%{_userunitdir}/
+install -m 755 files/template-from-qubesdb.py %{buildroot}/srv/salt/template-from-qubesdb.py
 
 install -m 755 -d %{buildroot}/etc/qubes/policy.d/
 install -m 644 files/31-securedrop-workstation.policy %{buildroot}/etc/qubes/policy.d/
@@ -129,7 +130,9 @@ install -m 755 -d %{buildroot}/opt/securedrop
 /srv/salt/securedrop-*
 /srv/salt/update-xfce-settings
 /srv/salt/fpf*
+/srv/salt/qubesdb-config.sls
 /srv/salt/press.freedom.SecureDropUpdater.desktop
+/srv/salt/template-from-qubesdb.py
 
 %attr(755, root, root) %{_bindir}/sdw-login
 %attr(755, root, root) %{_bindir}/sdw-notify


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

- Closes #1039 by adapting freedomofpress/securedrop-client@27cc69d into `template-from-qubesdb.py`, which is installed directly into the base template and `sd-whonix` so that it's available without requiring the installation of a separate package.  (This approach is up for debate!)
- Closes #936, of which this is the final non-secret-provisioning part.

### Follow-up work
- #1029
- https://github.com/freedomofpress/securedrop-workstation/blob/a106e93c3e022faa57b55502fb89e30b6b0a8f12/dom0/sd-whonix.sls#L47

## Testing
1. Delete all your `sd-*` VMs so that `sd-{large,small}-bookworm-templates` can be recreated
2. `make clone && make dev`
3. In `sd-whonix`, create and test a template, e.g.:

    ```sh-session
    [gateway user ~] % cat > template <<EOF
    > {"hidserv_hostname": "$SD_HIDSERV_HOSTNAME"}
    > EOF
    [gateway user ~] % template-from-qubesdb template newfile
    ```
4. [ ] `newfile` contains the value of `qubesdb-read /vm-config/SD_HIDSERV_HOSTNAME`.

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

No tests are required here, but they will be for the "Follow-Up Tasks" listed above.


### If you have added or removed files

- [x] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`