### PR TITLE
Set skip_if_unavailable=False in .repo file

### DIFF
--- a/dom0/sd-dom0-files.sls
+++ b/dom0/sd-dom0-files.sls
@@ -39,6 +39,7 @@ dom0-workstation-rpm-repo:
     - contents: |
         [securedrop-workstation-dom0]
         gpgcheck=1
+        skip_if_unavailable=False
         gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation
         enabled=1
         baseurl={{ sdvars.dom0_yum_repo_url }}

--- a/tests/test_dom0_rpm_repo.py
+++ b/tests/test_dom0_rpm_repo.py
@@ -43,6 +43,7 @@ class SD_Dom0_Rpm_Repo_Tests(unittest.TestCase):
         wanted_lines = [
             "[securedrop-workstation-dom0]",
             "gpgcheck=1",
+            "skip_if_unavailable=False",
             "gpgkey=file://{}".format(self.pubkey_actual),  # noqa
             "enabled=1",
             f"baseurl={self.yum_repo_url}",


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes https://github.com/freedomofpress/securedrop-workstation/pull/1023#pullrequestreview-2089387812 : hat tip @deeplow  for originally noticing this 

Changes proposed in this pull request:

* Adjust .repo file to include `skip_if_unavailable=False`

## Testing

- [x] Visual review (see eg mock / sample configs [here](https://github.com/rpm-software-management/mock/blob/main/mock-core-configs/etc/mock/eol/templates/fedora-30.tpl) - this is a standard/recommended configuration)
- [x] CI is green
- [ ] Updater run completes successfully

Optional/bonus points:
- [ ] with repo unreachable, dom0 updates fail

## Deployment

n/a

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation