### PR TITLE
Fixup: remove whitespace in %preun macro

### DIFF
--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -186,7 +186,7 @@ systemctl enable securedrop-logind-override-disable.service
 systemctl --global enable securedrop-user-xfce-icon-size.service ||:
 systemctl --global enable securedrop-user-xfce-settings.service ||:
 
-% preun
+%preun
 # If we're uninstalling (vs upgrading)
 if [ $1 -eq 0 ]; then
     systemctl disable --now securedrop-logind-override-disable.service


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Remove errant whitespace in %preun macro

## Testing

If you made non-trivial code changes, include a test plan and validated it for this PR.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing pilot instances
2. New installs

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation