### PR TITLE
Remove --keep-template-rpm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ remove-sd-log: assert-dom0 ## Destroys SD logging VM
 clean: assert-dom0 prep-dev ## Destroys all SD VMs
 # Use the local script path, since system PATH location will be absent
 # if clean has already been run.
-	./scripts/sdw-admin.py --uninstall --keep-template-rpm --force
+	./scripts/sdw-admin.py --uninstall --force
 
 test: assert-dom0 ## Runs all application tests (no integration tests yet)
 	python3 -m unittest discover -v tests

--- a/files/sdw-admin.py
+++ b/files/sdw-admin.py
@@ -47,13 +47,6 @@ def parse_args():
         help="Completely Uninstalls the SecureDrop Workstation",
     )
     parser.add_argument(
-        "--keep-template-rpm",
-        default=False,
-        required=False,
-        action="store_true",
-        help="During uninstall action, leave TemplateVM RPM package installed in dom0",
-    )
-    parser.add_argument(
         "--force",
         default=False,
         required=False,
@@ -139,7 +132,7 @@ def refresh_salt():
         raise SDWAdminException("Error while synchronizing Salt")
 
 
-def perform_uninstall(keep_template_rpm=False):
+def perform_uninstall():
     try:
         subprocess.check_call(
             ["sudo", "qubesctl", "state.sls", "securedrop_salt.sd-clean-default-dispvm"]
@@ -208,7 +201,7 @@ def main():
                 print("Exiting.")
                 sys.exit(0)
         refresh_salt()
-        perform_uninstall(keep_template_rpm=args.keep_template_rpm)
+        perform_uninstall()
     else:
         sys.exit(0)
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

We no longer ship a template in an rpm package.

## Testing

* [ ] CI passes
* [ ] Visual review

## Deployment

Any special considerations for deployment? n/a, uninstall is also not an officially supported operation.
