### PR TITLE
Remove base template additional package installation from Salt config…

### DIFF
--- a/securedrop_salt/sd-base-template-files.sls
+++ b/securedrop_salt/sd-base-template-files.sls
@@ -3,19 +3,14 @@
 include:
   - securedrop_salt.fpf-apt-repo
 
-# install recommended Qubes VM packages for core functionality
+# install recommended Qubes VM packages for core functionality.
+# Note: additional system packages are installed as dependencies
+# of securedrop-workstation-config.
+# See https://github.com/freedomofpress/securedrop-client/blob/main/debian/control
 install-qubes-vm-recommended:
   pkg.installed:
     - pkgs:
       - qubes-vm-recommended
-
-# install additional base packages required by SecureDrop
-sd-base-template-install-additional-packages:
-  pkg.installed:
-    - pkgs:
-      - rsyslog
-      - mailcap
-      - apparmor
 
 # install workstation-config and grsec kernel
 sd-base-template-install-securedrop-packages:


### PR DESCRIPTION
… (replaced by workstation-config debian package dependency). See https://github.com/freedomofpress/securedrop-client/pull/1957.

## Status

Ready for review

## Description of Changes

Fixes #977 
Refs https://github.com/freedomofpress/securedrop-client/pull/1957

Changes proposed in this pull request:

Drop Salt installation of debian packages needed for sdw, since they are listed as dependencies in the securedrop-workstation-config package.

## Testing

- [ ] CI passes
- [ ] Visual review - observe removed packages are listed as dependencies [here](https://github.com/freedomofpress/securedrop-client/pull/1957/files) 

## Deployment

n/a - should be no-op

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation