### PR TITLE
Test desired state of Linux Security Module configuration

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,4 +1,3 @@
-import json
 import unittest
 
 from base import SD_VM_Local_Test
@@ -13,6 +12,7 @@ class SD_App_Tests(SD_VM_Local_Test):
             "SD_SUBMISSION_KEY_FPR",
             "SD_MIME_HANDLING",
         }
+        self.enforced_apparmor_profiles = {"/usr/bin/securedrop-client"}
 
     def test_open_in_dvm_desktop(self):
         contents = self._get_file_contents("/usr/share/applications/open-in-dvm.desktop")
@@ -51,11 +51,6 @@ class SD_App_Tests(SD_VM_Local_Test):
         self.assertEqual(
             self.dom0_config["submission_key_fpr"], self._vm_config_read("SD_SUBMISSION_KEY_FPR")
         )
-
-    def test_sd_client_apparmor(self):
-        cmd = "sudo aa-status --json"
-        results = json.loads(self._run(cmd))
-        self.assertTrue(results["profiles"]["/usr/bin/securedrop-client"] == "enforce")
 
     def test_logging_configured(self):
         self.logging_configured()

--- a/tests/test_proxy_vm.py
+++ b/tests/test_proxy_vm.py
@@ -8,6 +8,7 @@ class SD_Proxy_Tests(SD_VM_Local_Test):
         self.vm_name = "sd-proxy"
         super().setUp()
         self.expected_config_keys = {"SD_PROXY_ORIGIN", "SD_MIME_HANDLING"}
+        self.enforced_apparmor_profiles = {"/usr/bin/securedrop-proxy"}
 
     def test_do_not_open_here(self):
         """

--- a/tests/test_sys_usb.py
+++ b/tests/test_sys_usb.py
@@ -7,6 +7,7 @@ class SD_SysUSB_Tests(SD_VM_Local_Test):
     def setUp(self):
         self.vm_name = "sys-usb"
         super().setUp()
+        self.lsm = "selinux"
 
     def test_files_are_properly_copied(self):
         self.assertTrue(self._fileExists("/etc/udev/rules.d/99-sd-devices.rules"))

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -8,6 +8,17 @@ class SD_Viewer_Tests(SD_Unnamed_DVM_Local_Test):
     def setUp(self):
         super().setUp("sd-viewer")
         self.expected_config_keys = {"SD_MIME_HANDLING"}
+        # this is not a comprehensive list, just a few that users are likely to use
+        self.enforced_apparmor_profiles = {
+            "/usr/bin/evince",
+            "/usr/bin/evince-previewer",
+            "/usr/bin/evince-previewer//sanitized_helper",
+            "/usr/bin/evince-thumbnailer",
+            "/usr/bin/totem",
+            "/usr/bin/totem-audio-preview",
+            "/usr/bin/totem-video-thumbnailer",
+            "/usr/bin/totem//sanitized_helper",
+        }
 
     def test_sd_viewer_metapackage_installed(self):
         self.assertTrue(self._package_is_installed("securedrop-workstation-viewer"))


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Assert that:

* Debian VMs have AppArmor running
* Fedora VMs have SELinux running in enforce mode
* securedrop-proxy profile is in enforce mode
* sd-viewer profiles are in enforce mode

For verifying AppArmor profiles, take the same approach as the vm-config
expected keys test by defining the expected value in each VM's test and
having a base test implement the checking logic.

## Testing

* [x] CI passes

## Deployment

Any special considerations for deployment? n/a

## Checklist

- [ ] All tests (`make test`) pass in `dom0`