### PR TITLE
Explicitly set default_dispvm on all VMs we manage

### DIFF
--- a/securedrop_salt/sd-app.sls
+++ b/securedrop_salt/sd-app.sls
@@ -24,6 +24,7 @@ sd-app:
     - prefs:
       - template: sd-small-{{ sdvars.distribution }}-template
       - netvm: ""
+      - default_dispvm: "sd-viewer"
     - tags:
       - add:
         - sd-client

--- a/securedrop_salt/sd-base-template.sls
+++ b/securedrop_salt/sd-base-template.sls
@@ -14,6 +14,8 @@ sd-base-template:
     - clone:
       - source: debian-12-minimal
       - label: red
+    - prefs:
+      - default_dispvm: ""
     - tags:
       - add:
         - sd-workstation

--- a/securedrop_salt/sd-devices.sls
+++ b/securedrop_salt/sd-devices.sls
@@ -23,6 +23,7 @@ sd-devices-dvm:
       - template: sd-large-{{ sdvars.distribution }}-template
       - netvm: ""
       - template_for_dispvms: True
+      - default_dispvm: ""
     - tags:
       - add:
         - sd-workstation
@@ -53,6 +54,8 @@ sd-devices-create-named-dispvm:
       - template: sd-devices-dvm
       - class: DispVM
       - label: red
+    - prefs:
+      - default_dispvm: ""
     - tags:
       - add:
         - sd-workstation

--- a/securedrop_salt/sd-gpg.sls
+++ b/securedrop_salt/sd-gpg.sls
@@ -29,6 +29,7 @@ sd-gpg:
       - template: sd-small-{{ sdvars.distribution }}-template
       - netvm: ""
       - autostart: true
+      - default_dispvm: ""
     - features:
       - enable:
         - service.securedrop-logging-disabled

--- a/securedrop_salt/sd-log.sls
+++ b/securedrop_salt/sd-log.sls
@@ -27,6 +27,7 @@ sd-log:
       - template: sd-small-{{ sdvars.distribution }}-template
       - netvm: ""
       - autostart: true
+      - default_dispvm: ""
     - tags:
       - add:
         - sd-workstation

--- a/securedrop_salt/sd-viewer.sls
+++ b/securedrop_salt/sd-viewer.sls
@@ -50,6 +50,9 @@ sd-viewer:
     - require:
       - qvm: sd-large-{{ sdvars.distribution }}-template
 
+# Set sd-viewer as the global default_dispvm
+# While all of our VMs have explit default_dispvm set, this is a better default
+# than the stock fedora-XX-dvm in case someone creates their own VMs.
 sd-viewer-default-dispvm:
   cmd.run:
     - name: qubes-prefs default_dispvm sd-viewer

--- a/securedrop_salt/sd-whonix.sls
+++ b/securedrop_salt/sd-whonix.sls
@@ -30,6 +30,7 @@ sd-whonix:
       - netvm: "sys-firewall"
       - autostart: true
       - kernelopts: "nopat apparmor=1 security=apparmor"
+      - default_dispvm: ""
     - tags:
       - add:
         - sd-workstation

--- a/securedrop_salt/sd-workstation-template.sls
+++ b/securedrop_salt/sd-workstation-template.sls
@@ -22,6 +22,7 @@ sd-small-{{ sdvars.distribution }}-template:
     - prefs:
       - virt-mode: pvh
       - kernel: 'pvgrub2-pvh'
+      - default_dispvm: ""
     - tags:
       - add:
         - sd-workstation
@@ -41,6 +42,7 @@ sd-large-{{ sdvars.distribution }}-template:
     - prefs:
       - virt-mode: pvh
       - kernel: 'pvgrub2-pvh'
+      - default_dispvm: ""
     - tags:
       - add:
         - sd-workstation


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Enforce that all VMs we manage have `default_dispvm` set to None, except for sd-app and sd-devices, which are set to sd-viewer and sd-devices-dvm, respectively.

On the test side, instead of needing to specify it for each individual VM, verify `default_dispvm` is None for all of `@tag:sd-workstation`, with the above exceptions.

## Testing

* [ ] CI passes
* [ ] Open Qube Manager, visually check that all of the SDW VMs have an empty space in the "Default DispVM" column
* [ ] Or do the same with the CLI, `qvm-ls --tags sd-workstation --fields name,default_dispvm`
* [ ] Open client, verify files are still opened in a sd-viewer based dispVM

## Deployment

Any special considerations for deployment? should apply same to both

## Checklist

- [x] All tests (`make test`) pass in `dom0`
