### PR TITLE
Use specific unittest asserts when possible

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -138,7 +138,7 @@ class SD_VM_Local_Test(unittest.TestCase):
         import difflib
 
         print("".join(difflib.unified_diff(remote_content, content)), end="")
-        self.assertTrue(remote_content == content)
+        self.assertEqual(remote_content, content)
 
     def assertFileHasLine(self, remote_path, wanted_line):
         remote_content = self._get_file_contents(remote_path)
@@ -205,7 +205,7 @@ remotevm = sd-log
         # Several VMs show this error message even though they're shipping logs,
         # so let's investigate further.
         # cmd_output = self._run("sudo grep -F \"action 'action-0-omprog' suspended (module 'omprog')\" /var/log/syslog | wc -l").strip()  # noqa
-        # self.assertTrue(cmd_output == "0")
+        # self.assertEqual(cmd_output, "0")
 
     def mailcap_hardened(self):
         """

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -21,7 +21,7 @@ class SD_App_Tests(SD_VM_Local_Test):
             "Exec=/usr/bin/qvm-open-in-vm --view-only @dispvm:sd-viewer %f",
         ]
         for line in expected_contents:
-            self.assertTrue(line in contents)
+            self.assertIn(line, contents)
 
     def test_mimeapps(self):
         cmd = "perl -F= -lane 'print $F[1]' /usr/share/applications/mimeapps.list | sort | uniq -c"

--- a/tests/test_log_vm.py
+++ b/tests/test_log_vm.py
@@ -32,19 +32,19 @@ class SD_Log_Tests(SD_VM_Local_Test):
         cmd_output = self._run("ls -1 /home/user/QubesIncomingLogs")
         log_dirs = cmd_output.split("\n")
         # Confirm AppVMs are sending logs
-        self.assertTrue("sd-app" in log_dirs)
+        self.assertIn("sd-app", log_dirs)
         # The following will only have logs if the machine has booted,
         # which is not guaranteed given that we randomize test order.
-        # self.assertTrue("sd-devices" in log_dirs)
-        # self.assertTrue("sd-proxy" in log_dirs)
-        # self.assertTrue("sd-viewer" in log_dirs)
+        # self.assertIn("sd-devices", log_dirs)
+        # self.assertIn("sd-proxy", log_dirs)
+        # self.assertIn("sd-viewer", log_dirs)
 
     def test_log_dirs_properly_named(self):
         # Rerunning this command to keep test output readable
         cmd_output = self._run("ls -1 /home/user/QubesIncomingLogs")
         log_dirs = cmd_output.split("\n")
         # Confirm we don't have 'host' entries from Whonix VMs
-        self.assertFalse("host" in log_dirs)
+        self.assertNotIn("host", log_dirs)
 
 
 def load_tests(loader, tests, pattern):

--- a/tests/test_sd_devices.py
+++ b/tests/test_sd_devices.py
@@ -48,7 +48,7 @@ class SD_Devices_Tests(SD_VM_Local_Test):
             "Exec=/usr/bin/qvm-open-in-vm --view-only @dispvm:sd-viewer %f",
         ]
         for line in expected_contents:
-            self.assertTrue(line in contents)
+            self.assertIn(line, contents)
 
 
 def load_tests(loader, tests, pattern):

--- a/tests/test_sd_whonix.py
+++ b/tests/test_sd_whonix.py
@@ -46,8 +46,9 @@ class SD_Whonix_Tests(SD_VM_Local_Test):
         torrc_contents = self._get_file_contents("/etc/tor/torrc")
         duplicate_includes = """%include /etc/torrc.d/
 %include /etc/torrc.d/95_whonix.conf"""
-        self.assertFalse(
-            duplicate_includes in torrc_contents,
+        self.assertNotIn(
+            duplicate_includes,
+            torrc_contents,
             "Whonix GW torrc contains duplicate %include lines",
         )
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Using assertEqual(x, y) over assertTrue(x == y) means that unittest can show us a proper diff of the two things that aren't equal, instead of just saying False isn't True.


## Testing

* [ ] CI passes

## Deployment

Any special considerations for deployment? n/a
## Checklist

- [ ] All tests (`make test`) pass in `dom0`
