### PR TITLE
Make sd-viewer and sd-app internal (again)

### DIFF
--- a/securedrop_salt/sd-app.sls
+++ b/securedrop_salt/sd-app.sls
@@ -30,15 +30,14 @@ sd-app:
         - sd-client
         - sd-workstation
     - features:
-    {% if d.environment == "prod" %}
       - set:
+        - vm-config.SD_MIME_HANDLING: sd-app
+{% if d.environment == "prod" %}
         - internal: 1
-    {% endif %}
+{% endif %}
       - enable:
         - service.paxctld
         - service.securedrop-mime-handling
-      - set:
-        - vm-config.SD_MIME_HANDLING: sd-app
     - require:
       - qvm: sd-small-{{ sdvars.distribution }}-template
 

--- a/securedrop_salt/sd-viewer.sls
+++ b/securedrop_salt/sd-viewer.sls
@@ -38,15 +38,14 @@ sd-viewer:
         - sd-viewer-vm
         - sd-{{ sdvars.distribution }}
     - features:
-    {% if d.environment == "prod" %}
       - set:
+        - vm-config.SD_MIME_HANDLING: sd-viewer
+{% if d.environment == "prod" %}
         - internal: 1
-    {% endif %}
+{% endif %}
       - enable:
         - service.paxctld
         - service.securedrop-mime-handling
-      - set:
-        - vm-config.SD_MIME_HANDLING: sd-viewer
     - require:
       - qvm: sd-large-{{ sdvars.distribution }}-template
 

--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -12,6 +12,9 @@ from base import (
 )
 from qubesadmin import Qubes
 
+with open("config.json") as f:
+    CONFIG = json.load(f)
+
 
 class SD_VM_Tests(unittest.TestCase):
     def setUp(self):
@@ -28,6 +31,16 @@ class SD_VM_Tests(unittest.TestCase):
         sdw_tagged_vm_names = [vm.name for vm in self.sdw_tagged_vms]
         expected_vms = set(SD_VMS + SD_DVM_TEMPLATES + SD_TEMPLATES)
         self.assertEqual(set(sdw_tagged_vm_names), set(expected_vms))
+
+    @unittest.skipIf(CONFIG["environment"] != "prod", "Skipping on non-prod system")
+    def test_internal(self):
+        not_internal = ["sd-proxy", "sd-whonix", "sd-devices"]
+
+        for vm_name in SD_VMS:
+            if vm_name in not_internal:
+                continue
+            vm = self.app.domains[vm_name]
+            self.assertEqual(vm.features.get("internal"), "1")
 
     def test_grsec_kernel(self):
         """


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes https://github.com/freedomofpress/securedrop-workstation/issues/1097

Changes proposed in this pull request:

## Testing

n/a (test included)

## Deployment

Any special considerations for deployment? no

## Checklist

### If you have made changes to the provisioning logic

- [x] All tests (`make test`) pass in `dom0`

### If documentation is required

Not required.