### PR TITLE
[4.1] Add systemd service to remove and reimport signing key to dom0 …

### DIFF
--- a/files/securedrop-user-dom0-rpm-key-reimport.service
+++ b/files/securedrop-user-dom0-rpm-key-reimport.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Reimport SecureDrop Release Signing Key into rpm database
+After=grub-boot-success.service
+
+[Service]
+Type=oneshot
+
+# The pubkey name format is `gpg-pubkey-$VERSION-$CREATION_SEC_SINCE_UNIX_EPOCH`,
+# where $VERSION is the last 8 characters of the GPG key's fingerprint, and
+# $CREATIONDATE is the key creation date, expressed as
+# `date -d "1970-1-1 + $((0x$CREATION_UNIX_EPOCH)) sec"`
+ExecCondition=sh -c 'test $$(id -un) != lightdm'
+ExecCondition=sh -c 'rpm -q gpg-pubkey-7b22e6a3-646b9337'
+ExecCondition=sh -c 'test -f /etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation'
+
+# From systemd documentation:
+# when an ExecCondition= command exits with exit code 1 through 254 (inclusive),
+# the remaining commands are skipped and the unit is not marked as failed.
+ExecStart=sh -c "rpm -q gpg-pubkey --qf '%{NAME}-%{VERSION}-%{RELEASE}\t%{SUMMARY}\n' | grep 'SecureDrop Release Signing Key' | cut -f1 | xargs sudo rpm -e"
+ExecStart=sh -c "sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation"
+
+[Install]
+WantedBy=default.target

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -65,6 +65,7 @@ install -m 755 -d %{buildroot}/srv/salt/sd/sys-firewall
 install -m 755 -d %{buildroot}/srv/salt/sd/usb-autoattach
 install -m 755 -d %{buildroot}/%{_datadir}/%{name}/scripts
 install -m 755 -d %{buildroot}/%{_bindir}
+install -m 755 -d %{buildroot}/%{_userunitdir}
 install -m 644 dom0/*.sls %{buildroot}/srv/salt/
 install -m 644 dom0/*.top %{buildroot}/srv/salt/
 install -m 644 dom0/*.j2 %{buildroot}/srv/salt/
@@ -93,7 +94,7 @@ install -m 644 launcher/sdw_notify/*.py %{buildroot}/opt/securedrop/launcher/sdw
 install -m 644 launcher/sdw_util/*.py %{buildroot}/opt/securedrop/launcher/sdw_util/
 install -m 755 files/sdw-admin.py %{buildroot}/%{_bindir}/sdw-admin
 install -m 644 files/config.json.example %{buildroot}/%{_datadir}/%{name}/
-
+install -m 644 files/securedrop-user-dom0-rpm-key-reimport.service %{buildroot}/%{_userunitdir}/
 
 %files
 %attr(755, root, root) /opt/securedrop/launcher/sdw-launcher.py
@@ -115,13 +116,16 @@ install -m 644 files/config.json.example %{buildroot}/%{_datadir}/%{name}/
 /srv/salt/fpf*
 %doc README.md
 %license LICENSE
-
+%{_userunitdir}/securedrop-user-dom0-rpm-key-reimport.service
 
 %post
 find /srv/salt -maxdepth 1 -type f -iname '*.top' \
     | xargs -n1 basename \
     | sed -e 's/\.top$$//g' \
     | xargs qubesctl top.enable > /dev/null
+
+# rpm key reimport
+systemctl --global enable securedrop-user-dom0-rpm-key-reimport.service ||:
 
 # Force full run of all Salt states - uncomment in release branch
 mkdir -p /tmp/sdw-migrations


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #953 (4.1)
Fixes https://github.com/freedomofpress/securedrop-workstation/issues/423 (4.1)

Changes proposed in this pull request:

4.1 only: add systemd service to conditionally remove and reimport dom0 pubkey from the rpm database. Automates the steps found at https://gist.github.com/rocodes/41a8dee0c9098445ea3629770c29c690

Explanation:  can't update the rpm database in rpm post, since there is rightfully a transaction lock on the database.

Subsequent versions of systemd will remove the need for this workaround.

## Testing

Testing this PR requires testing the "upgrade scenario" for the release key, meaning testers should start from a Qubes system that has at minimum the soon-to-expire SD Release Signing pubkey in /etc/pki/rpm-gpg/ and in the rpm database.
That can be accomplished by installing an old dom0 config rpm and running `apply`, or by manually copying the (soon to expire) release signing pubkey into place at `/etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation` then running `sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation` in dom0, skipping the full provisioning setup. 

- [x] Visual review
- [x] Base branch is release/0.11.1
- [x] Install rpm built from the tip of this branch on a 4.1 system as described above. Switch to prod in config.json and run either `sdw-admin --apply` **or** manually copy the config.json into `/srv/salt/sd/config.json` then run `sudo qubesctl --show-output state.highstate` (just the dom0 states - saves time), then reboot. 
- [x] On first reboot, journal shows dom0 systemd (with PID != 1) log
 ```
dom0 systemd[123456]: Starting Reimport SecureDrop Release Signing Key into rpm database...`
[additional loglines showing dom0 sudo calls to rpm -e gpg-pubkey-7b22e6a3-646b9337 then reimport]
dom0 systemd[123456]: securedrop-user-dom0-rpm-key-reimport.service: Succeeded
dom0 systemd[123456]: Finished Reimport SecureDrop Release Signing Key into rpm database.
```
- [x] rpm -q gpg-pubkey-7b22e6a3-646b9337 in dom0 returns "package gpg-pubkey-7b22e6a3-646b9337 is not installed"
- [x] rpm -q gpg-pubkey-7b22e6a3-* shows new pubkey in rpm database
- [x] On subsequent reboots, service does not run but is not marked as failed when viewing `systemctl --user status securedrop-user-dom0-rpm-key-reimport.service` (https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#ExecCondition=)

## Deployment

Any special considerations for deployment? Consider both:

This will only affect upgrading instances as no new installs should be happening against Qubes 4.1.

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0` : Manual testing on 4.1 will be required 

### If you have added or removed files

- [x] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec` (Just the spec file)

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation