### PR TITLE
[0.11.1] Backport "Update sd-devices test to check for udisks2, not cryptsetup"

### DIFF
--- a/tests/test_sd_devices.py
+++ b/tests/test_sd_devices.py
@@ -15,7 +15,7 @@ class SD_Devices_Tests(SD_VM_Local_Test):
         self.assertTrue(self._fileExists("/usr/share/mime/packages/application-x-sd-export.xml"))
 
     def test_sd_export_package_installed(self):
-        self.assertTrue(self._package_is_installed("cryptsetup"))
+        self.assertTrue(self._package_is_installed("udisks2"))
         self.assertTrue(self._package_is_installed("printer-driver-brlaser"))
         self.assertTrue(self._package_is_installed("printer-driver-hpcups"))
         self.assertTrue(self._package_is_installed("securedrop-export"))


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backport of #954.

## Testing

* [ ] CI is passing
* [ ] base is `release/0.11.1`
* [ ] Only contains changes from #954.
