### PR TITLE
Update lookup path for Notify.py script

### DIFF
--- a/sdw_notify/Notify.py
+++ b/sdw_notify/Notify.py
@@ -11,7 +11,7 @@ from sdw_util import Util
 sdlog = Util.get_logger(module=__name__)
 
 # The directory where status files and logs are stored
-BASE_DIRECTORY = os.path.join(os.path.expanduser("~"), ".securedrop_updater")
+BASE_DIRECTORY = Util.BASE_DIRECTORY
 
 # The file and format that contains the timestamp of the last successful update
 LAST_UPDATED_FILE = os.path.join(BASE_DIRECTORY, "sdw-last-updated")

--- a/sdw_notify/Notify.py
+++ b/sdw_notify/Notify.py
@@ -11,7 +11,7 @@ from sdw_util import Util
 sdlog = Util.get_logger(module=__name__)
 
 # The directory where status files and logs are stored
-BASE_DIRECTORY = os.path.join(os.path.expanduser("~"), ".securedrop_launcher")
+BASE_DIRECTORY = os.path.join(os.path.expanduser("~"), ".securedrop_updater")
 
 # The file and format that contains the timestamp of the last successful update
 LAST_UPDATED_FILE = os.path.join(BASE_DIRECTORY, "sdw-last-updated")

--- a/securedrop_salt/sd-clean-all.sls
+++ b/securedrop_salt/sd-clean-all.sls
@@ -58,7 +58,7 @@ remove-dom0-sdw-config-files:
       - /etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation-test
       - /home/{{ gui_user }}/.config/autostart/press.freedom.SecureDropUpdater.desktop
       - /home/{{ gui_user }}/Desktop/press.freedom.SecureDropUpdater.desktop
-      - /home/{{ gui_user }}/.securedrop_launcher
+      - /home/{{ gui_user }}/.securedrop_updater
       - /var/lib/securedrop-workstation
 
 # Remove any custom RPC policy tags added to non-SecureDrop VMs by the user


### PR DESCRIPTION
Fixes #1107

## Status

Ready for review 
## Description of Changes

Updates outdated path.

## Testing

1. Ensure that `.securedrop_updater/sdw-last-updated` is set to a recent date like `2024-06-26 18:00:00` (you can fake it 😎)
2. Run `sdw-notify` in `dom0` without the change in this branch 
3. - [ ] Confirm that a warning appears despite the up-to-date goodness
4. Run `sdw-notify` with the change in this branch
5. - [ ] Confirm that no warning appears