### PR TITLE
Set menu items for sd-devices and sd-whonix

### DIFF
--- a/files/provision-all
+++ b/files/provision-all
@@ -44,6 +44,20 @@ echo "..........................................................................
 echo "Provision all SecureDrop Workstation VMs with service-specific configs"
 sudo qubesctl --show-output --max-concurrency "$max_concurrency" --skip-dom0 --targets "$all_sdw_vms_target" state.highstate
 
+# Sync appmenus now that all packages are installed
+# TODO: this should be done by salt or debs, but we do it manually here because it's
+# not straightforward to run a dom0 salt state after VMs run.
+# n.b. none of the small VMs are shown in the menu on prod, but nice to have it synced
+qvm-start --skip-if-running sd-small-bookworm-template && qvm-sync-appmenus sd-small-bookworm-template \
+  && qvm-shutdown sd-small-bookworm-template
+qvm-start --skip-if-running sd-large-bookworm-template && qvm-sync-appmenus sd-large-bookworm-template \
+  && qvm-shutdown sd-large-bookworm-template
+qvm-start --skip-if-running whonix-gateway-17 && qvm-sync-appmenus whonix-gateway-17 \
+  && qvm-shutdown whonix-gateway-17
+# These are the two ones we show in prod VMs, so sync explicitly
+qvm-sync-appmenus --regenerate-only sd-devices
+qvm-sync-appmenus --regenerate-only sd-whonix
+
 echo ".........................................................................."
 echo "Add SecureDrop export device handling to sys-usb"
 # If sd-fedora-40-dvm exists it's because salt determined that sys-usb was disposable

--- a/securedrop_salt/sd-app.sls
+++ b/securedrop_salt/sd-app.sls
@@ -55,15 +55,3 @@ sd-app-private-volume-size:
         qvm-volume resize sd-app:private {{ d.vmsizes.sd_app }}GiB
     - require:
       - qvm: sd-app
-
-# Ensure the Qubes menu is populated with relevant app entries,
-# so that Nautilus/Files can be started via GUI interactions.
-sd-app-template-sync-appmenus:
-  cmd.run:
-    - name: >
-        qvm-start --skip-if-running sd-small-{{ sdvars.distribution }}-template &&
-        qvm-sync-appmenus --force-root sd-small-{{ sdvars.distribution }}-template
-    - require:
-      - qvm: sd-small-{{ sdvars.distribution }}-template
-    - onchanges:
-      - qvm: sd-small-{{ sdvars.distribution }}-template

--- a/securedrop_salt/sd-devices.sls
+++ b/securedrop_salt/sd-devices.sls
@@ -35,18 +35,6 @@ sd-devices-dvm:
     - require:
       - qvm: sd-large-{{ sdvars.distribution }}-template
 
-# Ensure the Qubes menu is populated with relevant app entries,
-# so that Nautilus/Files can be started via GUI interactions.
-sd-devices-template-sync-appmenus:
-  cmd.run:
-    - name: >
-        qvm-start --skip-if-running sd-large-{{ sdvars.distribution }}-template &&
-        qvm-sync-appmenus --force-root sd-large-{{ sdvars.distribution }}-template
-    - require:
-      - qvm: sd-large-{{ sdvars.distribution }}-template
-    - onchanges:
-      - qvm: sd-large-{{ sdvars.distribution }}-template
-
 sd-devices-create-named-dispvm:
   qvm.vm:
     - name: sd-devices
@@ -64,5 +52,6 @@ sd-devices-create-named-dispvm:
         - service.securedrop-mime-handling
       - set:
         - vm-config.SD_MIME_HANDLING: sd-devices
+        - menu-items: "org.gnome.Nautilus.desktop org.gnome.DiskUtility.desktop"
     - require:
       - qvm: sd-devices-dvm

--- a/securedrop_salt/sd-whonix.sls
+++ b/securedrop_salt/sd-whonix.sls
@@ -50,3 +50,4 @@ sd-whonix-config:
     - set:
         - vm-config.SD_HIDSERV_HOSTNAME: {{ d.hidserv.hostname }}
         - vm-config.SD_HIDSERV_KEY: {{ d.hidserv.key }}
+        - menu-items: "anon_connection_wizard.desktop tor-control-panel.desktop"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

These are the only two VMs that will be visible on production systems and have specific tools we want users to be able to directly start.

* sd-devices: Files (Nautilus) and Disks
* sd-whonix: Anon Connection Wizard and Tor Control Panel

Ideally we would do all of this in salt, but since we need to run stuff via dom0 after we do things in the VMs, it would require adjusting the order of some salt states, which is a bit too intrusive for a fix during the RC/QA period.

A TODO indicates that this is not an ideal situation, and <https://github.com/freedomofpress/securedrop-client/issues/2078> tracks one potential fix

Fixes #520.
Fixes #1109.

## Testing

* [ ] Provision an SDW dev instance (or staging would be fine too)
* [ ] menu items for sd-devices are exactly `set(Files, Disks)`
* [ ] menu items for sd-whonix are exactly `set(Anon Connection Wizard, Tor Control Panel)`

## Deployment

n/a, only supporting new installs for 1.0.0

## Checklist

- [ ] All tests (`make test`) pass in `dom0`
  - n.b. I didn't add a test for this as I felt asserting the same features we set are present wasn't useful right now. 