### PR TITLE
Ensure and verify files in built RPM have their mtime clamped

### DIFF
--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -9,15 +9,20 @@ source "$(dirname "$0")/common.sh"
 # Prepare tarball, rpmbuild will use it
 mkdir -p dist/
 git clean -fdX rpm-build/ dist/
+# touch everything to a date in the future, so that way
+# rpm will clamp the mtimes down to the SOURCE_DATE_EPOCH
+find . -type f -exec touch -m -d "+1 day" {} \;
 /usr/bin/python3 setup.py sdist
 
 # Place tarball where rpmbuild will find it
 cp dist/*.tar.gz rpm-build/SOURCES/
 
 rpmbuild \
-    --quiet \
     --define "_topdir $PWD/rpm-build" \
     -bb --clean "rpm-build/SPECS/${PROJECT}.spec"
+
+# Check reproducibility
+python3 scripts/verify_rpm_mtime.py
 
 printf '\nBuild complete! RPMs and their checksums are:\n\n'
 find rpm-build/ -type f -iname "${PROJECT}-$(cat "${TOPLEVEL}/VERSION")*.rpm" -print0 | sort -zV | xargs -0 sha256sum

--- a/scripts/verify_rpm_mtime.py
+++ b/scripts/verify_rpm_mtime.py
@@ -1,0 +1,51 @@
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import rpm
+
+
+def check_rpm(filename: Path):
+    """verify every file in the RPM has the same mtime as changelog/build date"""
+    with filename.open("rb") as f:
+        ts = rpm.TransactionSet()
+        header = ts.hdrFromFdno(f.fileno())
+        build_date = datetime.fromtimestamp(header[rpm.RPMTAG_BUILDTIME], tz=timezone.utc)
+        filenames = header[rpm.RPMTAG_FILENAMES]
+        filemtimes = header[rpm.RPMTAG_FILEMTIMES]
+        changetimes = header[rpm.RPMTAG_CHANGELOGTIME]
+
+        # I don't understand why, but the changelog time is consistently 12 hours off of the
+        # build date (which is always 00:00:00 UTC)
+        changelog_date = datetime.fromtimestamp(changetimes[0], tz=timezone.utc) - timedelta(
+            hours=12
+        )
+
+        result = []
+
+        if changelog_date != build_date:
+            result.append(("Build Date", build_date))
+        for i, rpm_filename in enumerate(filenames):
+            mtime = datetime.fromtimestamp(filemtimes[i], tz=timezone.utc)
+            if mtime != build_date:
+                result.append((rpm_filename, mtime))
+
+    return changelog_date, result
+
+
+def main():
+    exit_code = 0
+    for filename in Path("rpm-build/RPMS/noarch").glob("*.rpm"):
+        changelog_date, result = check_rpm(filename)
+        print(f"checking mtimes in {filename.name}: {changelog_date}")
+        if result:
+            print("The following files have an incorrect mtime:")
+            for fname, mtime in result:
+                print(f"* {fname}: {mtime}")
+            exit_code = 1
+
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The mtime of all files in the RPM is supposed to be clamped to the
changelog, which is also set as the build date. "clamp" means that the
file's mtime will be no greater than SOURCE_DATE_EPOCH, not that it will
be fixed to it (like in Debian packages). So if you have a file with an
old mtime, it will not be adjusted by rpm, leading to a non-reproducible
build.

We now touch every file to a date in the future so rpm can clamp them
back to the changelog date, which hopefully will not also be in the
future.

Then a new script verifies the RPM has all of its files set to that
clamped time, and if not, causes the build to fail.

While we're at it, make builds more verbose by removing `--quiet` so we
can actually see the details of what RPM is doing under the hood.

This commit is compatible with Python 3.8 so it can be backported for
Qubes 4.1 / 0.11.1.

Fixes #1110.

## Testing

* [ ] CI passes
* [ ] Run `make build-rpm` a few times and it always succeeds (i.e., the build is reproducible)
* [ ] run `rpm -q --dump path/to/rpm` and verify the mtimes are all the same and match what the script printed
* [ ] Download the RPM from https://github.com/freedomofpress/securedrop-yum-test/pull/58, put it in the RPMS folder, run the script manually (`python3 scripts/verify_rpm_mtime.py`), it should exit with a non-zero status
* [ ] cherry-pick this to the `release/0.11.1` branch and run `make build-rpm`
* [ ] Set the most recent changelog time to a date at least a week in the future and the build fails

## Deployment

Any special considerations for deployment? n/a
