### PR TITLE
[1.0.0] Backport Set sd-whonix and sd-devices menu items

### DIFF
--- a/files/provision-all
+++ b/files/provision-all
@@ -44,6 +44,20 @@ echo "..........................................................................
 echo "Provision all SecureDrop Workstation VMs with service-specific configs"
 sudo qubesctl --show-output --max-concurrency "$max_concurrency" --skip-dom0 --targets "$all_sdw_vms_target" state.highstate
 
+# Sync appmenus now that all packages are installed
+# TODO: this should be done by salt or debs, but we do it manually here because it's
+# not straightforward to run a dom0 salt state after VMs run.
+# n.b. none of the small VMs are shown in the menu on prod, but nice to have it synced
+qvm-start --skip-if-running sd-small-bookworm-template && qvm-sync-appmenus sd-small-bookworm-template \
+  && qvm-shutdown sd-small-bookworm-template
+qvm-start --skip-if-running sd-large-bookworm-template && qvm-sync-appmenus sd-large-bookworm-template \
+  && qvm-shutdown sd-large-bookworm-template
+qvm-start --skip-if-running whonix-gateway-17 && qvm-sync-appmenus whonix-gateway-17 \
+  && qvm-shutdown whonix-gateway-17
+# These are the two ones we show in prod VMs, so sync explicitly
+qvm-sync-appmenus --regenerate-only sd-devices
+qvm-sync-appmenus --regenerate-only sd-whonix
+
 echo ".........................................................................."
 echo "Add SecureDrop export device handling to sys-usb"
 # If sd-fedora-40-dvm exists it's because salt determined that sys-usb was disposable

--- a/securedrop_salt/sd-app.sls
+++ b/securedrop_salt/sd-app.sls
@@ -55,15 +55,3 @@ sd-app-private-volume-size:
         qvm-volume resize sd-app:private {{ d.vmsizes.sd_app }}GiB
     - require:
       - qvm: sd-app
-
-# Ensure the Qubes menu is populated with relevant app entries,
-# so that Nautilus/Files can be started via GUI interactions.
-sd-app-template-sync-appmenus:
-  cmd.run:
-    - name: >
-        qvm-start --skip-if-running sd-small-{{ sdvars.distribution }}-template &&
-        qvm-sync-appmenus --force-root sd-small-{{ sdvars.distribution }}-template
-    - require:
-      - qvm: sd-small-{{ sdvars.distribution }}-template
-    - onchanges:
-      - qvm: sd-small-{{ sdvars.distribution }}-template

--- a/securedrop_salt/sd-devices.sls
+++ b/securedrop_salt/sd-devices.sls
@@ -35,18 +35,6 @@ sd-devices-dvm:
     - require:
       - qvm: sd-large-{{ sdvars.distribution }}-template
 
-# Ensure the Qubes menu is populated with relevant app entries,
-# so that Nautilus/Files can be started via GUI interactions.
-sd-devices-template-sync-appmenus:
-  cmd.run:
-    - name: >
-        qvm-start --skip-if-running sd-large-{{ sdvars.distribution }}-template &&
-        qvm-sync-appmenus --force-root sd-large-{{ sdvars.distribution }}-template
-    - require:
-      - qvm: sd-large-{{ sdvars.distribution }}-template
-    - onchanges:
-      - qvm: sd-large-{{ sdvars.distribution }}-template
-
 sd-devices-create-named-dispvm:
   qvm.vm:
     - name: sd-devices
@@ -64,5 +52,6 @@ sd-devices-create-named-dispvm:
         - service.securedrop-mime-handling
       - set:
         - vm-config.SD_MIME_HANDLING: sd-devices
+        - menu-items: "org.gnome.Nautilus.desktop org.gnome.DiskUtility.desktop"
     - require:
       - qvm: sd-devices-dvm

--- a/securedrop_salt/sd-whonix.sls
+++ b/securedrop_salt/sd-whonix.sls
@@ -50,3 +50,4 @@ sd-whonix-config:
     - set:
         - vm-config.SD_HIDSERV_HOSTNAME: {{ d.hidserv.hostname }}
         - vm-config.SD_HIDSERV_KEY: {{ d.hidserv.key }}
+        - menu-items: "anon_connection_wizard.desktop tor-control-panel.desktop"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backport https://github.com/freedomofpress/securedrop-workstation/pull/1112

## Testing

- [ ] CI passes
- [ ] base is release/1.0.0
- [ ] only changes from https://github.com/freedomofpress/securedrop-workstation/pull/1112

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing pilot instances
2. New installs

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation