### PR TITLE
Remove some debug output at the end of provisioning

### DIFF
--- a/files/provision-all
+++ b/files/provision-all
@@ -67,8 +67,7 @@ qvm-check --quiet sd-fedora-40-dvm 2> /dev/null && \
   qvm-shutdown --wait sys-usb && qvm-start sys-usb || \
   sudo qubesctl --show-output --skip-dom0 --targets sys-usb state.highstate
 
-# Shut down all VMs to ensure new configuration takes place, if the user doesn't reboot.
-echo "will shut down the following VMs"
-qvm-ls --tags sd-workstation
+# Shut down all VMs to ensure new configuration takes place, if the user doesn't reboot
+# (primarily CI/dev setups).
 qvm-ls --tags sd-workstation --raw-list | xargs qvm-shutdown --wait
 qvm-shutdown --wait whonix-gateway-17


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

I had added this while we were debugging CI not properly shutting down VMs; we don't need end users to see this.

## Testing

* [ ] Visual review
* [ ] CI passes

## Deployment

Any special considerations for deployment? n/a

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`
