### PR TITLE
Fix Updater only restarting sys-* qubes

### DIFF
--- a/sdw_updater/Updater.py
+++ b/sdw_updater/Updater.py
@@ -159,7 +159,7 @@ def apply_updates_templates(templates=current_templates, progress_callback=None)
 def _start_qubes_updater_proc(templates):
     update_cmd = [
         "qubes-vm-update",
-        "--restart",  # Enforce app qube restarts
+        "--apply-to-all",  # Enforce app qube restarts
         "--show-output",  # Update transaction details (goes to stdout)
         "--just-print-progress",  # Progress reporting (goes to stderr)
         "--targets",


### PR DESCRIPTION
After [an update to qubes-vm-update](https://github.com/QubesOS/qubes-core-admin-linux/commit/93078d0b) (which the SDW updater uses under the hood) `--restart` was changed to only restart `sys-*` qubes. The new qubes-vm-update flag --apply-to-all has the behavior we intend.

## Status

Ready for review

## Description of Changes

Fixes #1127 by replacing `qubes-vm-update`'s flags from `--restart`  to `--apply-to-all`

## Testing

Run the updater and ensure `sd-app`, `sd-log`, `sd-gpg`, etc. (all app qubes) are restarted after a successful update process.

## Deployment

no special considerations.

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`
  - :warning: not on a prod

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation