### PR TITLE
build(`test*`): check prerequisites before running test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,22 +131,28 @@ clean: assert-dom0 prep-dev ## Destroys all SD VMs
 # if clean has already been run.
 	./scripts/sdw-admin.py --uninstall --force
 
-test: assert-dom0 ## Runs all application tests (no integration tests yet)
+.PHONY: test-prereqs
+test-prereqs: assert-dom0 ## Checks that test prerequisites are satisfied
+	@echo "Checking prerequisites before running test suite..."
+	test -e config.json || exit 1
+	test -e sd-journalist.sec || exit 1
+
+test: test-prereqs ## Runs all application tests (no integration tests yet)
 	python3 -m unittest discover -v tests
 
-test-base: assert-dom0 ## Runs tests for VMs layout
+test-base: test-prereqs ## Runs tests for VMs layout
 	python3 -m unittest discover -v tests -p test_vms_exist.py
 
-test-app: assert-dom0 ## Runs tests for SD APP VM config
+test-app: test-prereqs ## Runs tests for SD APP VM config
 	python3 -m unittest discover -v tests -p test_app.py
 
-test-proxy: assert-dom0 ## Runs tests for SD Proxy VM
+test-proxy: test-prereqs ## Runs tests for SD Proxy VM
 	python3 -m unittest discover -v tests -p test_proxy_vm.py
 
-test-whonix: assert-dom0 ## Runs tests for SD Whonix VM
+test-whonix: test-prereqs ## Runs tests for SD Whonix VM
 	python3 -m unittest discover -v tests -p test_sd_whonix.py
 
-test-gpg: assert-dom0 ## Runs tests for SD GPG functionality
+test-gpg: test-prereqs ## Runs tests for SD GPG functionality
 	python3 -m unittest discover -v tests -p test_gpg.py
 
 validate: assert-dom0 ## Checks for local requirements in dev env


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Revises the `test*` Make targets so that they error out early if `config.json` and `sd-journalist.sec` are not available.

## Testing

Something like:

```sh-session
$ cd securedrop-workstation
$ make test  # passes
$ rm config.json
$ rm sd-journalist.sec
$ make test  # fails
$ cp /usr/share/securedrop-workstation-dom0-config/config.json . && make test  # fails
$ rm config.json
$ cp /usr/share/securedrop-workstation-dom0-config/sd-journalist.sec . && make test  # fails
$ cp /usr/share/securedrop-workstation-dom0-config/config.json . && make test  # passes
```

## Deployment

Test-only.

## Checklist

### If you have made changes to the provisioning logic

- [x] All tests (`make test`) pass in `dom0`