### PR TITLE
Force template updates always

### DIFF
--- a/sdw_updater/Updater.py
+++ b/sdw_updater/Updater.py
@@ -160,6 +160,7 @@ def _start_qubes_updater_proc(templates):
     update_cmd = [
         "qubes-vm-update",
         "--apply-to-all",  # Enforce app qube restarts
+        "--force-update",  # Bypass Qubes' staleness-dection and update all
         "--show-output",  # Update transaction details (goes to stdout)
         "--just-print-progress",  # Progress reporting (goes to stderr)
         "--targets",


### PR DESCRIPTION
Qubes' qubes-vm-update tool recently added the flage --force-update and made --targets conditional on how recently the qubes had been updated. This essentially bypassed SDW's targetting. This fixes the issue by forcing the update of all templates because SDW keeps track of how recently things were updated and Qubes' default is 7 days, which is not enough for us (8 hours, currently).



## Status

Ready for review

## Description of Changes

Fixes freedomofpress/securedrop-workstation#1140

## Testing


1.  Be on Qubes 4.2.2-rc1
2. Run the securedrop updater. Templates should be started and updated
3. Rollback one of the templates with `qvm-volume revert <TEMPLATE>:root`
4. Run securedrop updater again (by editing it's 'last updated" file) and confirm that some of the templates are skipped due to said behavior.

## Deployment
no considerations.

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

(no dev system / couldn't test)

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation