### PR TITLE
Set named dispvm sd-proxy as a servicevm

### DIFF
--- a/securedrop_salt/sd-proxy.sls
+++ b/securedrop_salt/sd-proxy.sls
@@ -54,6 +54,7 @@ sd-proxy-create-named-dispvm:
         - service.securedrop-mime-handling
       - set:
           - vm-config.SD_MIME_HANDLING: default
+          - servicevm: 1
       {% if d.environment == "prod" %}
           - internal: 1
       {% endif %}


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes https://github.com/freedomofpress/securedrop-workstation/issues/1145

Changes proposed in this pull request:

Set named qubes feature `servicevm` for named dispvm sd-proxy during Salt run.

Note: `servicevm` is approximately taken to mean "provides network" (https://github.com/QubesOS/qubes-desktop-linux-menu/blob/1ee90aa09903dbd470f540b22e48d0a500feff6e/qubes_menu/vm_manager.py#L122-L125), so this will show that sd-proxy "provides a network" in the appmenu (the network-connected icon shows up beside the qube). However, unlike qubes that really _do_ provide a network, we don't set the qvm-pref `provides_network` to `True` for sd-proxy, so it won't show up as a networking option when new qubes are created.  (This is good; we wouldn't want that.)

So we may be acting like outliers here by setting the qvm-feature (for menu + restart behaviour) but not the qvm-pref (for what capabilities it advertises to other Qubes).

## Testing

- [ ] CI
- [ ] Visual review
- [ ] Feature name is correct: verify with eg https://github.com/QubesOS/qubes-desktop-linux-menu/blob/1ee90aa09903dbd470f540b22e48d0a500feff6e/qubes_menu/vm_manager.py#L50
- [x] sd-proxy shows in Service section of menu with this feature set (tested via `qvm-features sd-proxy servicevm 1`)

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing pilot instances
2. New installs

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation