### PR TITLE
Replace salt updater in sd-sys-vms

### DIFF
--- a/securedrop_salt/sd-sys-vms.sls
+++ b/securedrop_salt/sd-sys-vms.sls
@@ -32,7 +32,7 @@ set-fedora-template-as-default-mgmt-dvm:
 # If the VM has just been installed via package manager, update it immediately
 update-fedora-template-if-new:
   cmd.wait:
-    - name: qubes-vm-update --quiet --force-update --targets {{ sd_supported_fedora_version }}
+    - name: qubes-vm-update --quiet --force-update --targets {{ sd_fedora_base_template }}
     - require:
       - cmd: dom0-install-fedora-template
       # Update the mgmt-dvm setting first, to avoid problems during first update

--- a/securedrop_salt/sd-sys-vms.sls
+++ b/securedrop_salt/sd-sys-vms.sls
@@ -32,7 +32,7 @@ set-fedora-template-as-default-mgmt-dvm:
 # If the VM has just been installed via package manager, update it immediately
 update-fedora-template-if-new:
   cmd.wait:
-    - name: sudo qubesctl --skip-dom0 --targets {{ sd_supported_fedora_version }} state.sls update.qubes-vm
+    - name: qubes-vm-update --quiet --force-update --targets {{ sd_supported_fedora_version }}
     - require:
       - cmd: dom0-install-fedora-template
       # Update the mgmt-dvm setting first, to avoid problems during first update


### PR DESCRIPTION
Replace salt updater with qubes-vm-update in sd-sys-vms

## Status

Work in progress

## Description of Changes

Fixes #1166.

Changes proposed in this pull request:

## Testing

Run `make dev` and ensure when running sd-sys-vms step the qube started and fully updated.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing pilot instances
2. New installs

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation