### PR TITLE
Remove unecessary nopat kernelopt

### DIFF
--- a/securedrop_salt/sd-sys-whonix-vms.sls
+++ b/securedrop_salt/sd-sys-whonix-vms.sls
@@ -25,7 +25,7 @@ dom0-enabled-apparmor-on-whonix-gw-template:
   qvm.vm:
     - name: whonix-gateway-{{ sd_supported_whonix_version }}
     - prefs:
-      - kernelopts: "nopat apparmor=1 security=apparmor"
+      - kernelopts: "apparmor=1 security=apparmor"
     - require:
       - sls: securedrop_salt.sd-upgrade-templates
       - qvm: whonix-gateway-installed
@@ -35,7 +35,7 @@ dom0-enabled-apparmor-on-whonix-ws-template:
   qvm.vm:
     - name: whonix-workstation-{{ sd_supported_whonix_version }}
     - prefs:
-      - kernelopts: "nopat apparmor=1 security=apparmor"
+      - kernelopts: "apparmor=1 security=apparmor"
     - require:
       - sls: securedrop_salt.sd-upgrade-templates
       - qvm: whonix-gateway-installed

--- a/securedrop_salt/sd-whonix.sls
+++ b/securedrop_salt/sd-whonix.sls
@@ -29,7 +29,7 @@ sd-whonix:
       - provides-network: true
       - netvm: "sys-firewall"
       - autostart: true
-      - kernelopts: "nopat apparmor=1 security=apparmor"
+      - kernelopts: "apparmor=1 security=apparmor"
       - default_dispvm: ""
     - tags:
       - add:

--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -90,7 +90,7 @@ class SD_VM_Tests(unittest.TestCase):
         vm = self.app.domains["sd-whonix"]
         nvm = vm.netvm
         self.assertEqual(nvm.name, "sys-firewall")
-        wanted_kernelopts = "nopat apparmor=1 security=apparmor"
+        wanted_kernelopts = "apparmor=1 security=apparmor"
         self.assertEqual(vm.kernelopts, wanted_kernelopts)
         self.assertEqual(vm.template, "whonix-gateway-17")
         self.assertTrue(vm.provides_network)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #1171, by removing the nopat kernel option

## Testing

1. from the main branch run `sdw-admin --apply` (or `make dev`)
2. in dom0  confirm the `nopat` option is the in the output of `sudo cat /var/lib/qubes/qubes.xml | grep kernelopts`
3. from this branch run `sdw-admin --apply` (or `make dev`)
2. in dom0  confirm the `nopat` option is **no longer** in the in the output of `sudo cat /var/lib/qubes/qubes.xml | grep kernelopts`

## Deployment

No special consideration.

## Checklist

### If you have made changes to the provisioning logic

- [x] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

Documentation is not required.