### PR TITLE
docs(readme): link to contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> By contributing to this project, you agree to abide by our [Code of Conduct](https://github.com/freedomofpress/.github/blob/main/CODE_OF_CONDUCT.md).
+> By [contributing](https://developers.securedrop.org/en/latest/contributing.html) to this project, you agree to abide by our [Code of Conduct](https://github.com/freedomofpress/.github/blob/main/CODE_OF_CONDUCT.md).
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/freedomofpress/securedrop)
 


### PR DESCRIPTION
## Status

Ready for review


## Description of Changes

In support of freedomofpress/securedrop-dev-docs#191, link to our contributing guidelines directly from the reade, in lieu of a local `CONTRIBUTING.md`.