### PR TITLE
Remove perl from tests

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -24,18 +24,16 @@ class SD_App_Tests(SD_VM_Local_Test):
             self.assertIn(line, contents)
 
     def test_mimeapps(self):
-        cmd = "perl -F= -lane 'print $F[1]' /usr/share/applications/mimeapps.list | sort | uniq -c"
-        results = self._run(cmd)
-        expected_results = "2 \n    295 open-in-dvm.desktop;"
-        self.assertEqual(results, expected_results)
-
-    def test_mimeapps_functional(self):
-        cmd = "perl -F= -lane 'print $F[0]' /usr/share/applications/mimeapps.list"
-        results = self._run(cmd)
-        for line in results.split("\n"):
-            if line != "[Default Applications]" and not line.startswith("#"):
-                actual_app = self._run(f"xdg-mime query default {line}")
-                self.assertEqual(actual_app, "open-in-dvm.desktop")
+        results = self._run("cat /usr/share/applications/mimeapps.list")
+        for line in results.splitlines():
+            if line.startswith(("#", "[Default")):
+                # Skip comments and the leading [Default Applications]
+                continue
+            mime, target = line.split("=", 1)
+            self.assertEqual(target, "open-in-dvm.desktop;")
+            # Now functionally test it
+            actual_app = self._run(f"xdg-mime query default {mime}")
+            self.assertEqual(actual_app, "open-in-dvm.desktop")
 
     def test_mailcap_hardened(self):
         self.mailcap_hardened()

--- a/tests/test_proxy_vm.py
+++ b/tests/test_proxy_vm.py
@@ -40,13 +40,17 @@ class SD_Proxy_Tests(SD_VM_Local_Test):
     def test_logging_configured(self):
         self.logging_configured()
 
-    def test_mime_types(self):
-        cmd = "perl -F= -lane 'print $F[0]' /usr/share/applications/mimeapps.list"
-        results = self._run(cmd)
-        for line in results.split("\n"):
-            if line != "[Default Applications]" and not line.startswith("#"):
-                actual_app = self._run(f"xdg-mime query default {line}")
-                self.assertEqual(actual_app, "open-in-dvm.desktop")
+    def test_mimeapps(self):
+        results = self._run("cat /usr/share/applications/mimeapps.list")
+        for line in results.splitlines():
+            if line.startswith(("#", "[Default")):
+                # Skip comments and the leading [Default Applications]
+                continue
+            mime, target = line.split("=", 1)
+            self.assertEqual(target, "open-in-dvm.desktop;")
+            # Now functionally test it
+            actual_app = self._run(f"xdg-mime query default {mime}")
+            self.assertEqual(actual_app, "open-in-dvm.desktop")
 
     def test_mailcap_hardened(self):
         self.mailcap_hardened()

--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -1,12 +1,12 @@
 import json
 import os
+import re
 import subprocess
 import unittest
 
 from base import CURRENT_FEDORA_TEMPLATE, SD_VMS
 from qubesadmin import Qubes
 
-BULLSEYE_STRING = "Debian GNU/Linux 11 (bullseye)"
 BOOKWORM_STRING = "Debian GNU/Linux 12 (bookworm)"
 
 SUPPORTED_SD_DEBIAN_DIST = "bookworm"
@@ -28,15 +28,13 @@ class SD_VM_Platform_Tests(unittest.TestCase):
 
     def _get_platform_info(self, vm):
         """
-        Retrieve base OS for running AppVM. Executes command on AppVM
-        and returns the PRETTY_NAME field from /etc/os-release.
+        Retrieve PRETTY_NAME for an AppVM.
         """
-        # Not using `lsb_release` for platform info, because it is not present
-        # on Qubes AppVMs. Rather than install it simply for testing purposes,
-        # let's maintain the default config and retrieve the value elsewise.
-        cmd = "perl -nE '/^PRETTY_NAME=\"(.*)\"$/ and say $1' /etc/os-release"
-        stdout, stderr = vm.run(cmd)
-        return stdout.decode("utf-8").rstrip("\n")
+        stdout, stderr = vm.run("cat /etc/os-release")
+        search = re.search(r'^PRETTY_NAME="(.*)"', stdout.decode())
+        if not search:
+            raise RuntimeError(f"Unable to determine platform for {vm.name}")
+        return search.group(1)
 
     def _validate_vm_platform(self, vm):
         """


### PR DESCRIPTION


## Status

Ready for review

## Description of Changes

There's no reason to use perl here, given that we can do the same manipulations in Python itself in a way that's more maintainable and approachable.

I took the opportunity to consolidate the two mimeapps tests in test_app into one, but decided to just copy it over to test_proxy_vm instead of moving it to the base test to avoid too much refactoring here besides the deperlification.

Refs #988.

## Testing

* [ ] CI passes

## Deployment

Any special considerations for deployment? n/a
## Checklist

- [ ] All tests (`make test`) pass in `dom0`