### PR TITLE
Automatically log into the client application

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,6 @@ CONTAINER := $(if $(shell grep "Thirty Seven" /etc/fedora-release),,./scripts/co
 
 HOST=$(shell hostname)
 
-# Client autologin variables
-CLIENT_TOTP=$(shell oathtool --totp --base32 JHCOGO7VCER3EJ4L --start-time "$(shell date -d "+5 seconds" +"%Y-%m-%d %H:%M:%S")")
-XDOTOOL_PATH=$(shell command -v xdotool)
-OATHTOOL_PATH=$(shell command -v oathtool)
-
 assert-dom0: ## Confirms command is being run under dom0
 ifneq ($(HOST),dom0)
 	@echo "     ------ Some targets of securedrop-workstation's makefile must be used only on dom0! ------"
@@ -160,6 +155,10 @@ test-whonix: test-prereqs ## Runs tests for SD Whonix VM
 test-gpg: test-prereqs ## Runs tests for SD GPG functionality
 	python3 -m unittest discover -v tests -p test_gpg.py
 
+# Client autologin variables
+CLIENT_TOTP=$(shell oathtool --totp --base32 JHCOGO7VCER3EJ4L --start-time "$(shell date -d "+5 seconds" +"%Y-%m-%d %H:%M:%S")")
+XDOTOOL_PATH=$(shell command -v xdotool)
+OATHTOOL_PATH=$(shell command -v oathtool)
 PHONY: run-client
 run-client: assert-dom0 ## Run client application (automatic login)
 ifeq ($(XDOTOOL_PATH),)

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ ifeq ($(OATHTOOL_PATH),)
 	@echo 'please install oathtool with "sudo qubes-dom0-update oathtool"'
 	@false
 endif
-	sdw-updater
+	qvm-run --service sd-app qubes.StartApp+press.freedom.SecureDropClient
 	@sleep 3
 	@xdotool type "journalist"
 	@xdotool key Tab


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Most of the time we're developing the client, we are not testing the login screen, and just want to quickly log in. With a combination of xdotool and oathtool, we can script typing the correct values and login.

It's a bit fragile for two reasons. First, we're just blindly typing, so if some other window takes focus or switch, it'll be typed into that window. Second, we're kicking off a background process that sleeps, launching the window in the foreground, and then the background process will do the typing into the foreground.

Adapted from work by @legoktm: https://github.com/freedomofpress/securedrop-client/pull/2237/

## Testing

- [ ] visual review
- [ ] run `make run-client`
- [ ] confirm that it asks you to install dependencies in dom0
- [ ] install dependencies (`xdotool` and `oathtool`)
- [ ] run again `make run-client`

## Deployment

dev-facing - no deployment considerations 

## Checklist

### If you have made changes to the provisioning logic

- [x] All tests (`make test`) pass in `dom0`

### If documentation is required

- [x] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation