### PR TITLE
Revert marking sd-log as internal

### DIFF
--- a/files/sdw-admin.py
+++ b/files/sdw-admin.py
@@ -203,9 +203,10 @@ def sync_appmenus():
     run_cmd(["qvm-sync-appmenus", "whonix-gateway-17"])
     run_cmd(["qvm-shutdown", "whonix-gateway-17"])
 
-    # These are the two ones we show in prod VMs, so sync explicitly
+    # These are the ones we show in prod VMs, so sync explicitly
     run_cmd(["qvm-sync-appmenus", "--regenerate-only", "sd-devices"])
     run_cmd(["qvm-sync-appmenus", "--regenerate-only", "sd-whonix"])
+    run_cmd(["qvm-sync-appmenus", "--regenerate-only", "sd-log"])
 
 
 def validate_config(path):

--- a/securedrop_salt/sd-log.sls
+++ b/securedrop_salt/sd-log.sls
@@ -32,15 +32,13 @@ sd-log:
       - add:
         - sd-workstation
     - features:
-    {% if d.environment == "prod" %}
-      - set:
-        - internal: 1
-    {% endif %}
       - enable:
         - service.paxctld
         - service.redis
         - service.securedrop-logging-disabled
         - service.securedrop-log-server
+      - set:
+        - menu-items: "org.gnome.Nautilus.desktop"
     - require:
       - qvm: sd-small-{{ sdvars.distribution }}-template
 

--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -34,7 +34,7 @@ class SD_VM_Tests(unittest.TestCase):
 
     @unittest.skipIf(CONFIG["environment"] != "prod", "Skipping on non-prod system")
     def test_internal(self):
-        not_internal = ["sd-proxy", "sd-whonix", "sd-devices"]
+        not_internal = ["sd-proxy", "sd-whonix", "sd-devices", "sd-log"]
 
         for vm_name in SD_VMS:
             if vm_name in not_internal:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Revert sd-log as internal vm; it makes it harder to discover and harder for users to find logs. 
Add nautilus to sd-log application menu so that users can browse to logs via terminal or the gui.

## Testing

- [ ] CI
- [ ] Visual review
 
## Deployment

Any special considerations for deployment? Consider both:

- For existing SDW setups, this will only be applied on full `apply` run. I think that's fine.

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation