### PR TITLE
WIP: Configure dom0 rpm repo settings via boostrap rpm package.

### DIFF
--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -41,6 +41,12 @@ BuildRequires:	systemd-rpm-macros
 Requires:		qubes-mgmt-salt-dom0-virtual-machines
 Requires:		python3-qt5
 
+# Require keyring boostrap package.
+# To ensure that production systems can only be provisioned with prod repos,
+# require any non-prod repo configuration to depend on a dev-only virtual package that
+# is built locally
+Requires:       (securedrop-workstation-keyring or ((securedrop-workstation-keyring-staging or securedrop-workstation-keyring-dev or securedrop-workstation-keyring-qa) and sdw-dev))
+
 %description
 This package contains VM configuration files for the Qubes-based
 SecureDrop Workstation project. The package should be installed

--- a/securedrop_salt/sd-default-config.sls
+++ b/securedrop_salt/sd-default-config.sls
@@ -4,6 +4,9 @@
 ##
 # Handles loading of config variables, via environment-specific
 # setting in the config file.
+# These settings apply only to apt repo components used in
+# individual VMs. dom0 rpm settings are managed by the
+# boostrap rpm package; see rpm .spec file.
 
 # Load YAML vars file
 {% load_yaml as sdvars_defaults %}
@@ -27,7 +30,4 @@
   {% set _ = sdvars.update({"component": "main"}) %}
 {% endif %}
 
-# Append repo URL with appropriate dom0 Fedora version
-{% set fedora_repo = "f37" %}
 {% set _ = sdvars.update({"distribution": "bookworm"}) %}
-{% set _ = sdvars.update({"dom0_yum_repo_url": sdvars["dom0_yum_repo_url"] + fedora_repo}) %}

--- a/securedrop_salt/sd-default-config.yml
+++ b/securedrop_salt/sd-default-config.yml
@@ -1,14 +1,9 @@
 ---
-# Both prod.dom0_yum_repo_url and test.dom0_yum_repo_url will be appended to with
-# the respective Fedora release depending on Qubes OS version
-#
 # Production variables, for use with real-world installs
 prod:
-  dom0_yum_repo_url: "https://yum.securedrop.org/workstation/dom0/"
   apt_sources_filename: "apt_freedom_press.sources"
   signing_key_filename: "securedrop-release-signing-pubkey-2021.asc"
 # Staging and Dev variables, for QAing and local development
 test:
-  dom0_yum_repo_url: "https://yum-test.securedrop.org/workstation/dom0/"
   apt_sources_filename: "apt-test_freedom_press.sources"
   signing_key_filename: "apt-test-pubkey.asc"

--- a/securedrop_salt/sd-dom0-files.sls
+++ b/securedrop_salt/sd-dom0-files.sls
@@ -6,47 +6,6 @@
 # over time. These scripts should be ported to an RPM package.
 ##
 
-# Imports "sdvars" for environment config
-{% from 'securedrop_salt/sd-default-config.sls' import sdvars with context %}
-
-dom0-rpm-test-key:
-  file.managed:
-    # We write the pubkey to the repos config location, because the repos
-    # config location is automatically sent to dom0's UpdateVM. Otherwise,
-    # we must place the GPG key inside the fedora TemplateVM, then
-    # restart sys-firewall.
-    - name: /etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation
-    - source: "salt://securedrop_salt/{{ sdvars.signing_key_filename }}"
-    - user: root
-    - group: root
-    - mode: 644
-
-dom0-rpm-test-key-import:
-  cmd.run:
-    - name: sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation
-    - require:
-      - file: dom0-rpm-test-key
-
-dom0-workstation-rpm-repo:
-  # We use file.managed rather than pkgrepo.managed, because Qubes dom0
-  # settings write new repos to /etc/yum.real.repos.d/, but only /etc/yum.repos.d/
-  # is copied to the UpdateVM for fetching dom0 packages.
-  file.managed:
-    - name: /etc/yum.repos.d/securedrop-workstation-dom0.repo
-    - user: root
-    - group: root
-    - mode: 644
-    - contents: |
-        [securedrop-workstation-dom0]
-        gpgcheck=1
-        skip_if_unavailable=False
-        gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-securedrop-workstation
-        enabled=1
-        baseurl={{ sdvars.dom0_yum_repo_url }}
-        name=SecureDrop Workstation Qubes dom0 repo
-    - require:
-      - file: dom0-rpm-test-key
-
 # Ensure debian-12-minimal is present for use as base template
 dom0-install-debian-minimal-template:
   cmd.run:


### PR DESCRIPTION
## Status

Work in progress, pushing in draft mode to discuss approach 
Blocked on release of securedrop-workstation-keyring boostrap rpm (to fpf repos at minimum)

## Description of Changes

Refs #945
Description TK
rpm version check compat todo (for details on rpm constraints, see https://rpm-software-management.github.io/rpm/manual/boolean_dependencies.html )

Changes proposed in this pull request:

## Testing

If you made non-trivial code changes, include a test plan and validated it for this PR.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing pilot instances
2. New installs

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation