### PR TITLE
Make grub2-xen-pvh a dependency of dom0 config rpm

### DIFF
--- a/files/sdw-admin.py
+++ b/files/sdw-admin.py
@@ -60,17 +60,6 @@ def parse_args():
     return parser.parse_args()
 
 
-def install_pvh_support():
-    """
-    Installs grub2-xen-pvh in dom0 - required for PVH with AppVM local kernels
-    TODO: install this via package requirements instead if possible
-    """
-    try:
-        subprocess.check_call(["sudo", "qubes-dom0-update", "-y", "-q", "grub2-xen-pvh"])
-    except subprocess.CalledProcessError:
-        raise SDWAdminException("Error installing grub2-xen-pvh: local PVH not available.")
-
-
 def copy_config():
     """
     Copies config.json and sd-journalist.sec to /srv/salt/securedrop_salt
@@ -302,7 +291,6 @@ def main():
                 sys.exit(0)
         print("Applying configuration...")
         validate_config(SCRIPTS_PATH)
-        install_pvh_support()
         copy_config()
         refresh_salt()
         provision_and_configure()

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -40,6 +40,7 @@ BuildRequires:	systemd-rpm-macros
 # This package installs all standard VMs in Qubes
 Requires:		qubes-mgmt-salt-dom0-virtual-machines
 Requires:		python3-qt5
+Requires:       grub2-xen-pvh
 
 %description
 This package contains VM configuration files for the Qubes-based


### PR DESCRIPTION
## Status

Work in progress (Code-complete but corresponding changes elsewhere are needed, see below)

## Description of Changes
Fixes #1063.

Changes proposed in this pull request:
Make `grub2-xen-pvh` a dependency of the dom0 config rpm. 

This requires the rpm to be installed with network access (i.e. qubes-dom0-update instead of via dnf), so it's blocked on the existence of the securedrop-workstation-keyring package, and of the install mechinism of the dom0 config rpm changing to `sudo qubes-dom0-update securedrop-workstation-dom0-config`.  

(Will require CI changes.)

## Testing

If you made non-trivial code changes, include a test plan and validated it for this PR.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing pilot instances
2. New installs

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation