### PR TITLE
Set vm template consistently across Salt files; cleanup unused requisites

### DIFF
--- a/securedrop_salt/sd-app.sls
+++ b/securedrop_salt/sd-app.sls
@@ -14,13 +14,18 @@
 
 include:
   - securedrop_salt.sd-workstation-template
-  - securedrop_salt.sd-upgrade-templates
+  - securedrop_salt.sd-viewer
 
 sd-app:
   qvm.vm:
     - name: sd-app
     - present:
+      # Sets attributes if creating VM for the first time,
+      # otherwise `prefs` must be used.
+      # Label color is set during initial configuration but
+      # not enforced on every Salt run, in case of user customization.
       - label: yellow
+      - template: sd-small-{{ sdvars.distribution }}-template
     - prefs:
       - template: sd-small-{{ sdvars.distribution }}-template
       - netvm: ""
@@ -38,6 +43,7 @@ sd-app:
         - service.securedrop-mime-handling
     - require:
       - qvm: sd-small-{{ sdvars.distribution }}-template
+      - sls: securedrop_salt.sd-viewer
 
 sd-app-config:
   qvm.features:

--- a/securedrop_salt/sd-devices.sls
+++ b/securedrop_salt/sd-devices.sls
@@ -11,14 +11,17 @@
 
 include:
   - securedrop_salt.sd-workstation-template
-  - securedrop_salt.sd-upgrade-templates
 
 sd-devices-dvm:
   qvm.vm:
     - name: sd-devices-dvm
     - present:
-      - template: sd-large-{{ sdvars.distribution }}-template
+      # Sets attributes if creating VM for the first time,
+      # otherwise `prefs` must be used.
+      # Label color is set during initial configuration but
+      # not enforced on every Salt run, in case of user customization.
       - label: red
+      - template: sd-large-{{ sdvars.distribution }}-template
     - prefs:
       - template: sd-large-{{ sdvars.distribution }}-template
       - netvm: ""
@@ -39,11 +42,15 @@ sd-devices-create-named-dispvm:
   qvm.vm:
     - name: sd-devices
     - present:
+      # Sets attributes if creating VM for the first time,
+      # otherwise `prefs` must be used.
+      - label: red
       - template: sd-devices-dvm
       - class: DispVM
-      - label: red
     - prefs:
+      - template: sd-devices-dvm
       - default_dispvm: ""
+      - netvm: ""
     - tags:
       - add:
         - sd-workstation

--- a/securedrop_salt/sd-gpg.sls
+++ b/securedrop_salt/sd-gpg.sls
@@ -23,8 +23,12 @@ sd-gpg:
   qvm.vm:
     - name: sd-gpg
     - present:
-      - template: sd-small-{{ sdvars.distribution }}-template
+      # Sets attributes if creating VM for the first time,
+      # otherwise `prefs` must be used.
+      # Label color is set during initial configuration but
+      # not enforced on every Salt run, in case of user customization.
       - label: purple
+      - template: sd-small-{{ sdvars.distribution }}-template
     - prefs:
       - template: sd-small-{{ sdvars.distribution }}-template
       - netvm: ""

--- a/securedrop_salt/sd-log.sls
+++ b/securedrop_salt/sd-log.sls
@@ -21,8 +21,12 @@ sd-log:
   qvm.vm:
     - name: sd-log
     - present:
-      - template: sd-small-{{ sdvars.distribution }}-template
+      # Sets attributes if creating VM for the first time,
+      # otherwise `prefs` must be used.
+      # Label color is set during initial configuration but
+      # not enforced on every Salt run, in case of user customization.
       - label: red
+      - template: sd-small-{{ sdvars.distribution }}-template
     - prefs:
       - template: sd-small-{{ sdvars.distribution }}-template
       - netvm: ""

--- a/securedrop_salt/sd-log.sls
+++ b/securedrop_salt/sd-log.sls
@@ -15,7 +15,6 @@
 
 include:
   - securedrop_salt.sd-workstation-template
-  - securedrop_salt.sd-upgrade-templates
 
 sd-log:
   qvm.vm:

--- a/securedrop_salt/sd-proxy.sls
+++ b/securedrop_salt/sd-proxy.sls
@@ -12,7 +12,6 @@
 
 include:
   - securedrop_salt.sd-whonix
-  - securedrop_salt.sd-upgrade-templates
   - securedrop_salt.sd-workstation-template
 
 sd-proxy-dvm:

--- a/securedrop_salt/sd-proxy.sls
+++ b/securedrop_salt/sd-proxy.sls
@@ -19,7 +19,12 @@ sd-proxy-dvm:
   qvm.vm:
     - name: sd-proxy-dvm
     - present:
+      # Sets attributes if creating VM for the first time,
+      # otherwise `prefs` must be used.
+      # Label color is set during initial configuration but
+      # not enforced on every Salt run, in case of user customization.
       - label: blue
+      - template: sd-small-{{ sdvars.distribution }}-template
     - prefs:
       - template: sd-small-{{ sdvars.distribution }}-template
       - netvm: sd-whonix
@@ -45,9 +50,10 @@ sd-proxy-create-named-dispvm:
     - name: sd-proxy
     - present:
       - label: blue
-      - class: DispVM
       - template: sd-proxy-dvm
+      - class: DispVM
     - prefs:
+      - template: sd-proxy-dvm
       - netvm: sd-whonix
       - autostart: true
       - default_dispvm: ""

--- a/securedrop_salt/sd-sys-vms.sls
+++ b/securedrop_salt/sd-sys-vms.sls
@@ -68,8 +68,8 @@ create-{{ required_dispvm }}:
   qvm.vm:
     - name: {{ required_dispvm }}
     - present:
-      - template: {{ sd_fedora_base_template }}
       - label: red
+      - template: {{ sd_fedora_base_template }}
     - prefs:
       - template: {{ sd_fedora_base_template }}
       - template_for_dispvms: True

--- a/securedrop_salt/sd-viewer.sls
+++ b/securedrop_salt/sd-viewer.sls
@@ -25,8 +25,12 @@ sd-viewer:
   qvm.vm:
     - name: sd-viewer
     - present:
-      - template: sd-large-{{ sdvars.distribution }}-template
+      # Sets attributes if creating VM for the first time,
+      # otherwise `prefs` must be used.
+      # Label color is set during initial configuration but
+      # not enforced on every Salt run, in case of user customization.
       - label: green
+      - template: sd-large-{{ sdvars.distribution }}-template
     - prefs:
       - template: sd-large-{{ sdvars.distribution }}-template
       - netvm: ""

--- a/securedrop_salt/sd-viewer.sls
+++ b/securedrop_salt/sd-viewer.sls
@@ -19,7 +19,6 @@
 
 include:
   - securedrop_salt.sd-workstation-template
-  - securedrop_salt.sd-upgrade-templates
 
 sd-viewer:
   qvm.vm:

--- a/securedrop_salt/sd-whonix.sls
+++ b/securedrop_salt/sd-whonix.sls
@@ -23,6 +23,7 @@ sd-whonix:
     - name: sd-whonix
     - present:
       - label: purple
+      - template: whonix-gateway-17
       - mem: 500
     - prefs:
       - template: whonix-gateway-17

--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -46,7 +46,7 @@ class SD_VM_Platform_Tests(unittest.TestCase):
         """
         Asserts that the given AppVM is based on an OS listed in the
         SUPPORTED_<XX>_PLATFORMS list, as specified in tests.
-        sd-whonix is based on the whonix-16 template.
+        sd-whonix is based on the whonix-17 template.
         All other workstation-provisioned VMs should be
         SUPPORTED_SD_DEBIAN_DIST based.
         """


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Changes proposed in this pull request:

Refactor-only, this should be effectively a no-op.

- Set template consistently across all vm salt files. Once a VM has been created, `prefs` _must_ be used to update the template's attributes (`present` checks only the vm name and has no other effect).  However, after looking into it a bit I think it's still a good idea to set the preference in `present`, since it's not clear if the vm is briefly created with the default appvm template otherwise.
- Remove unused `include` of `securedrop_salt.sd-upgrade-templates` in VMs where the requisite has been removed. This was in place [from before template consolidation](https://github.com/freedomofpress/securedrop-workstation/pull/619/files#diff-3fc9c3822ab07f6bbf0b11a85d1ff73c27768b70dfa0e0601fcfc300ed615b81), when these files contained not just the VM setup but also the per-VM templates, where `sd-upgrade-templates` was required. 
  - Note: there are still a few files where the requisite _is_ used (sd-gpg, sd-whonix). Since this PR is meant to be a no-op, I have not made changes to those files. I think that should be addressed separately, via #1225 and/or also via https://github.com/freedomofpress/securedrop-workstation/issues/1060 in the case of sd-whonix, since ([per comment](https://github.com/freedomofpress/securedrop-workstation-ci/issues/68#issuecomment-2568141007)) we may want to use the whonix-recommended update strategy, which is not just `apt update`.  
- Include `sd-viewer.sls` as an explicit requisite of sd-app, since sd-app sets sd-viewer as its dispvm 
- Correct whonix version number in test docs (whonix 16 -> whonix 17)
 
## Testing

- [x] Visual review
- [ ] CI

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing pilot instances
2. New installs

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation