### PR TITLE
Add avahi service to sd-devices (for driverless printing)

### DIFF
--- a/securedrop_salt/sd-devices.sls
+++ b/securedrop_salt/sd-devices.sls
@@ -57,6 +57,7 @@ sd-devices-create-named-dispvm:
     - features:
       - enable:
         - service.securedrop-mime-handling
+        - service.avahi
       - set:
         - vm-config.SD_MIME_HANDLING: sd-devices
         - menu-items: "org.gnome.Nautilus.desktop org.gnome.DiskUtility.desktop"

--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -209,6 +209,8 @@ class SD_VM_Tests(unittest.TestCase):
         self.assertEqual(vm_type, "DispVM")
         self.assertIn("sd-workstation", vm.tags)
 
+        self.assertEqual(vm.features["service.avahi"], "1")
+
         # MIME handling
         self.assertEqual(vm.features["service.securedrop-mime-handling"], "1")
         self.assertEqual(vm.features["vm-config.SD_MIME_HANDLING"], "sd-devices")

--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -197,7 +197,6 @@ class SD_VM_Tests(unittest.TestCase):
         self.assertIn("sd-workstation", vm.tags)
         self.assertTrue(vm.template_for_dispvms)
 
-
         self.assertNotIn("service.avahi", vm.features)
         # MIME handling (dvm does NOT setup mime, only its disposables do)
         self.assertNotIn("service.securedrop-mime-handling", vm.features)

--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -197,6 +197,8 @@ class SD_VM_Tests(unittest.TestCase):
         self.assertIn("sd-workstation", vm.tags)
         self.assertTrue(vm.template_for_dispvms)
 
+
+        self.assertNotIn("service.avahi", vm.features)
         # MIME handling (dvm does NOT setup mime, only its disposables do)
         self.assertNotIn("service.securedrop-mime-handling", vm.features)
         self._check_service_running(vm, "securedrop-mime-handling", running=False)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #1233

Changes proposed in this pull request:

## Testing
- **Scenario:** Upgrading existing instances
  - deploy from main (`make dev`)
  - deploy from this branch
  - run `make test` in dom0 and ensure no failures
  - ensure manually that `sd-devices` settings has the `avahi` service
  - ensure manually that `sd-devices-dvm` settings does not have the `avahi` service
- **Scenario:** New installs
  - (if you have the workstation deployed,  please uninstall it `sdw-admin --uninstall`
  - clone this branch
  - `make dev`
  - run `make test` in dom0 and ensure no failures (beware of https://github.com/freedomofpress/securedrop-workstation/issues/919)
  - ensure manually that `sd-devices` settings has the `avahi` service
  - ensure manually that `sd-devices-dvm` settings does not have the `avahi` service

## Deployment

Any special considerations for deployment? No

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation