### PR TITLE
Explicitly unset internalness of sd-app and sd-proxy

### DIFF
--- a/securedrop_salt/sd-app.sls
+++ b/securedrop_salt/sd-app.sls
@@ -32,7 +32,7 @@ sd-app:
     - features:
       - set:
         - vm-config.SD_MIME_HANDLING: sd-app
-        - internal: 0
+        - internal: ""
       - enable:
         - service.paxctld
         - service.securedrop-mime-handling

--- a/securedrop_salt/sd-gpg.sls
+++ b/securedrop_salt/sd-gpg.sls
@@ -34,7 +34,7 @@ sd-gpg:
       - enable:
         - service.securedrop-logging-disabled
       - set:
-        - internal: 0
+        - internal: ""
     - tags:
       - add:
         - sd-workstation

--- a/securedrop_salt/sd-proxy.sls
+++ b/securedrop_salt/sd-proxy.sls
@@ -30,7 +30,7 @@ sd-proxy-dvm:
         {% if d.environment == "prod" %}
         - internal: 1
         {% else %}
-        - internal: 0
+        - internal: ""
         {% endif %}
     - tags:
       - add:
@@ -60,7 +60,7 @@ sd-proxy-create-named-dispvm:
           {% if d.environment == "prod" %}
           - internal: 1
           {% else %}
-          - internal: 0
+          - internal: ""
           {% endif %}
     - tags:
       - add:

--- a/securedrop_salt/sd-viewer.sls
+++ b/securedrop_salt/sd-viewer.sls
@@ -43,7 +43,7 @@ sd-viewer:
         {% if d.environment == "prod" %}
         - internal: 1
         {% else %}
-        - internal: 0
+        - internal: ""
         {% endif %}
       - enable:
         - service.paxctld


### PR DESCRIPTION
With #1219 sd-app and sd-proxy were explicitly as "internal: 0". However, this does not work, as the developer docs warn [1]:

> Some extensions interpret the values as boolean. In this case,
> the empty string means False and non-empty string (commonly '1')
> means True.

To fix this, the internalness of a qube is explicitly set to "".

[1]: https://dev.qubes-os.org/projects/core-admin-client/en/latest/manpages/qvm-features.html#description

## Status

Ready for review

## Description of Changes

Refs #1219

## Testing

- deploy version from main (may be developer environment)
- restart the Applications Menu: `pkill qubes-app-menu && qubes-app-menu)
- ensure `sd-app` and `sd-gpg` is not present (this is the bug)
- deploy this branch via `make dev`
- restart the Applications Menu: `pkill qubes-app-menu && qubes-app-menu)

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing pilot instances
2. New installs

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation