### PR TITLE
Force shut down dependent VMs passed via `restart` parameter

### DIFF
--- a/files/sdw-admin.py
+++ b/files/sdw-admin.py
@@ -166,8 +166,10 @@ def configure(step_description: str, targets: list[str], restart: list[str] | No
     run_cmd(["qvm-shutdown", "--wait", "--"] + targets)
 
     if restart:
-        run_cmd(["qvm-shutdown", "--wait", "--"] + restart)
-        run_cmd(["qvm-start", "--"] + restart)
+        for domain in restart:
+            if domain in Qubes().domains:
+                run_cmd(["qvm-shutdown", "--force", "--wait", "--"] + [domain])
+                run_cmd(["qvm-start", "--"] + [domain])
 
 
 def qubesctl_call(step_description: str, args: list[str]):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes https://github.com/freedomofpress/securedrop-workstation/issues/1247

Changes proposed in this pull request:
Ensure VMs passed via `restart` parameter in sdw-admin's `configure` method exist before restarting them, then force-shutdown instead of just shutting down.

The `configure` method allows for configuring a given VM, and offers the possibility to pass a list of other dependent VMs that should be rebooted upon changes (basically, as soon as a template is changed, restart a set of VMs based on it). Right now we use that on sd-log and sys-usb when we change their templates.

## Testing

- [ ] Visual Review
- [ ] CI (dom0 tests)

## Deployment

n/a

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation