### PR TITLE
Fix sd-log vm test

### DIFF
--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -179,7 +179,7 @@ class SD_VM_Tests(unittest.TestCase):
         self.assertEqual(vm.features["service.securedrop-log-server"], "1")
         self.assertEqual(vm.features["service.securedrop-logging-disabled"], "1")
         # See sd-log.sls "sd-install-epoch" feature
-        self.assertEqual(vm.features["sd-install-epoch"], "1")
+        self.assertEqual(vm.features["sd-install-epoch"], "1001")
 
         self.assertFalse(vm.template_for_dispvms)
         self.assertIn("sd-workstation", vm.tags)


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes CI: https://ws-ci-runner.securedrop.org/2025-02-14-201122689405-ffb2a41050a14c9242d85b12d275ed7c6f0c4940-Qubes_4.2_D-update_20250214043418.log.txt

Changes proposed in this pull request:

Fix value for sd-install-epoch 

## Testing

- [ ] CI passes

## Deployment

n/a 

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation