### PR TITLE
Configure sd-log at the same time as other VMs

### DIFF
--- a/files/sdw-admin.py
+++ b/files/sdw-admin.py
@@ -91,11 +91,6 @@ def provision_and_configure():
     provision("Provisioning base template", "securedrop_salt.sd-base-template")
     configure("Configuring base template", ["sd-base-bookworm-template"])
     provision_all()
-    configure(
-        "Configuring template for log sink before anything else",
-        ["sd-small-bookworm-template"],
-        restart=["sd-log"],
-    )
     configure("Enabling Whonix customizations", ["whonix-gateway-17"])
     configure(
         "Configure all SecureDrop Workstation VMs with service-specific configs",


### PR DESCRIPTION
Historically sd-log (and its template) was being configured earlier than the remaining qubes so that logs would be captured early in the install process. However, is some cases restarting sd-log hangs due the already-configured templates trying to send logs to it, which starts sd-log, while it is getting shut down (#1247).

The current solution to avoid this race-condition and adhering more to the salt convention of not trying to force order outside of salt, sd-log will no longer be setup early.

After a full system restart sd-log should be capturing logs as it normally would.

## Status

Ready for review

## Description of Changes

Should fix #1247

Changes proposed in this pull request:

## Testing

- [ ] Visual review
- [ ] CI (clean install) completes without error 
- [ ] Upgrade (manual testing): upgrade on existing SDW install completes without error 

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing pilot instances
2. New installs

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation