### PR TITLE
[release/1.1.0] Backport "Configure sd-log at the same time as other VMs"

### DIFF
--- a/files/sdw-admin.py
+++ b/files/sdw-admin.py
@@ -91,11 +91,6 @@ def provision_and_configure():
     provision("Provisioning base template", "securedrop_salt.sd-base-template")
     configure("Configuring base template", ["sd-base-bookworm-template"])
     provision_all()
-    configure(
-        "Configuring template for log sink before anything else",
-        ["sd-small-bookworm-template"],
-        restart=["sd-log"],
-    )
     configure("Enabling Whonix customizations", ["whonix-gateway-17"])
     configure(
         "Configure all SecureDrop Workstation VMs with service-specific configs",


### PR DESCRIPTION
Backport #1253

## Status

Ready for review

## Description of Changes

Backport #1253 

## Testing

- [ ] Visual review; base branch is release/1.1.0
- [ ] Only commit from #1253 
- [ ] CI (passed on the PR, ok to merge without waiting imo) 

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing pilot instances
2. New installs

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation