### PR TITLE
fix(`update-fedora-template-if-new`): run as GUI user

### DIFF
--- a/securedrop_salt/sd-sys-vms.sls
+++ b/securedrop_salt/sd-sys-vms.sls
@@ -14,6 +14,8 @@ include:
 {% set sd_supported_fedora_version = 'fedora-41' %}
 {% set sd_fedora_base_template = sd_supported_fedora_version + '-xfce' %}
 
+{% set gui_user = salt['cmd.shell']('groupmems -l -g qubes') %}
+
 # Install latest templates required for SDW VMs.
 dom0-install-fedora-template:
   cmd.run:
@@ -33,6 +35,7 @@ set-fedora-template-as-default-mgmt-dvm:
 update-fedora-template-if-new:
   cmd.wait:
     - name: qubes-vm-update --quiet --force-update --targets {{ sd_fedora_base_template }}
+    - runas: {{ gui_user }}
     - require:
       - cmd: dom0-install-fedora-template
       # Update the mgmt-dvm setting first, to avoid problems during first update


### PR DESCRIPTION
## Status

Ready for review (but drafted without testing)

## Description of Changes

Fixes the case where a new template's update log in `/var/log/qubes/update-${TEMPLATE}.log` is owned by (Salt running as) `root:qubes`, breaking subsequent updates that expect to be able to write to it as `user:qubes`.


## Testing

```sh-session
$ sudo qubesctl state.sls securedrop_salt.sd-sys-vms
$ qubes-vm-update --apply-to-all --force-update --show-output --just-print-progress --targets fedora-41-xfce
$ ls -l /var/log/qubes/update-fedora-41-xfce.log
-rw-r--r-- 1 user qubes 44456 Feb 27 10:37 /var/log/qubes/update-fedora-41-xfce.log
             ^^^^^^^^^^
```

- [ ] Succeeds with `gui_user == "user"`
- [ ] Succeeds with `gui_user != "user"`


## Deployment

- Clean installation on Qubes 4.2.4 (`fedora-41-xfce` already present)
- Upgrade: `fedora-41-xfce` already installed via `qvm-template`, and then `securedrop-workstation-dom0-config` 1.1.1 is installed
- Upgrade: `securedrop-workstation-dom0-config` 1.0.2→1.1.1 installs `fedora-41-xfce`


## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`