### PR TITLE
[release/1.1.0] Backport "fix(update-fedora-template-if-new): run as GUI user"

### DIFF
--- a/securedrop_salt/sd-sys-vms.sls
+++ b/securedrop_salt/sd-sys-vms.sls
@@ -14,6 +14,8 @@ include:
 {% set sd_supported_fedora_version = 'fedora-41' %}
 {% set sd_fedora_base_template = sd_supported_fedora_version + '-xfce' %}
 
+{% set gui_user = salt['cmd.shell']('groupmems -l -g qubes') %}
+
 # Install latest templates required for SDW VMs.
 dom0-install-fedora-template:
   cmd.run:
@@ -33,6 +35,7 @@ set-fedora-template-as-default-mgmt-dvm:
 update-fedora-template-if-new:
   cmd.wait:
     - name: qubes-vm-update --quiet --force-update --targets {{ sd_fedora_base_template }}
+    - runas: {{ gui_user }}
     - require:
       - cmd: dom0-install-fedora-template
       # Update the mgmt-dvm setting first, to avoid problems during first update


### PR DESCRIPTION

## Status

Ready for review 

## Description of Changes
Backport "run as gui user" for update-fedora-template-if-new


## Testing

- [x] visual review
- [x] base branch is release/1.1.0
- [x] only commits from https://github.com/freedomofpress/securedrop-workstation/pull/1260
- [x] cherry-pick msg is correct

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing pilot instances
2. New installs

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation