### PR TITLE
Remove unnecessary sd-proxy shutdown comment

### DIFF
--- a/securedrop_salt/securedrop-handle-upgrade
+++ b/securedrop_salt/securedrop-handle-upgrade
@@ -53,9 +53,6 @@ if [[ $TASK == "prepare" ]]; then
         fi
     fi
 
-    # For Whonix VMs, shut them down, so we can upate the TemplateVM settings.
-    # We shut down sd-proxy before sd-whonix, since its netvm is sd-whonix, which won't
-    # shutdown if a client is connected.
     if qvm-check --quiet sd-proxy-dvm; then
         BASE_TEMPLATE=$(qvm-prefs sd-proxy-dvm template)
         if [[ ! $BASE_TEMPLATE =~ "large-bookworm" ]]; then


### PR DESCRIPTION
Condition already ensured in salt [1].

[1]: https://github.com/freedomofpress/securedrop-workstation/pull/1227

## Status

Ready for review

## Description of Changes

Follow-up from https://github.com/freedomofpress/securedrop-workstation/pull/1227#issuecomment-2752090843.

## Testing

* [ ] start sd-proxy
* [ ] `sudo qubesctl state.highstate --show-output`
* [ ] ensure sd-proxy is not shutdown

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing pilot instances
2. New installs

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation