### PR TITLE
Use 'qvm.template_install' and Update Fedora Template Only Upon Install

### DIFF
--- a/securedrop_salt/sd-base-template.sls
+++ b/securedrop_salt/sd-base-template.sls
@@ -24,4 +24,4 @@ sd-base-template:
       - enable:
         - service.paxctld
     - require:
-      - cmd: dom0-install-debian-minimal-template
+      - qvm: dom0-install-debian-minimal-template

--- a/securedrop_salt/sd-dom0-files.sls
+++ b/securedrop_salt/sd-dom0-files.sls
@@ -49,9 +49,8 @@ dom0-workstation-rpm-repo:
 
 # Ensure debian-12-minimal is present for use as base template
 dom0-install-debian-minimal-template:
-  cmd.run:
-    - name: >
-        qvm-template info --machine-readable debian-12-minimal | grep -q "installed|debian-12-minimal|" || qvm-template install debian-12-minimal
+  qvm.template_installed:
+    - name: debian-12-minimal
 
 {% set gui_user = salt['cmd.shell']('groupmems -l -g qubes') %}
 

--- a/securedrop_salt/sd-sys-vms.sls
+++ b/securedrop_salt/sd-sys-vms.sls
@@ -18,9 +18,8 @@ include:
 
 # Install latest templates required for SDW VMs.
 dom0-install-fedora-template:
-  cmd.run:
-    - name: >
-        qvm-template info --machine-readable {{ sd_fedora_base_template }} | grep -q "installed|{{ sd_fedora_base_template }}|" || qvm-template install {{ sd_fedora_base_template }}
+  qvm.template_installed:
+    - name: {{ sd_fedora_base_template }}
 
 # Update the mgmt VM before updating the new Fedora VM. The order is required
 set-fedora-template-as-default-mgmt-dvm:
@@ -29,7 +28,7 @@ set-fedora-template-as-default-mgmt-dvm:
         qvm-shutdown --wait default-mgmt-dvm &&
         qvm-prefs default-mgmt-dvm template {{ sd_fedora_base_template }}
     - require:
-      - cmd: dom0-install-fedora-template
+      - qvm: dom0-install-fedora-template
 
 # If the VM has just been installed via package manager, update it immediately
 update-fedora-template-if-new:
@@ -37,11 +36,11 @@ update-fedora-template-if-new:
     - name: qubes-vm-update --quiet --force-update --targets {{ sd_fedora_base_template }}
     - runas: {{ gui_user }}
     - require:
-      - cmd: dom0-install-fedora-template
+      - qvm: dom0-install-fedora-template
       # Update the mgmt-dvm setting first, to avoid problems during first update
       - cmd: set-fedora-template-as-default-mgmt-dvm
     - watch:
-      - cmd: dom0-install-fedora-template
+      - qvm: dom0-install-fedora-template
 
 # qvm.default-dispvm is not strictly required here, but we want it to be
 # updated as soon as possible to ensure make clean completes successfully, as
@@ -50,7 +49,7 @@ set-fedora-default-template-version:
   cmd.run:
     - name: qubes-prefs default_template {{ sd_fedora_base_template }}
     - require:
-      - cmd: dom0-install-fedora-template
+      - qvm: dom0-install-fedora-template
       - sls: qvm.default-dispvm
 
 # On 4.1, several sys qubes are disposable by default - since we also want to
@@ -80,7 +79,7 @@ create-{{ required_dispvm }}:
       - netvm: ""
 {% endif %}
     - require:
-      - cmd: dom0-install-fedora-template
+      - qvm: dom0-install-fedora-template
 {% endfor %}
 
 # Now proceed with rebooting all the sys-* VMs, since the new template is up to date.
@@ -103,13 +102,13 @@ sd-{{ sys_vm }}-fedora-version-halt:
   qvm.kill:
     - name: {{ sys_vm }}
     - require:
-      - cmd: dom0-install-fedora-template
+      - qvm: dom0-install-fedora-template
 
 sd-{{ sys_vm }}-fedora-version-halt-wait:
   cmd.run:
     - name: sleep 5
     - require:
-      - cmd: dom0-install-fedora-template
+      - qvm: dom0-install-fedora-template
 
 sd-{{ sys_vm }}-fedora-version-update:
   qvm.vm:

--- a/securedrop_salt/sd-sys-vms.sls
+++ b/securedrop_salt/sd-sys-vms.sls
@@ -39,7 +39,7 @@ update-fedora-template-if-new:
       - qvm: dom0-install-fedora-template
       # Update the mgmt-dvm setting first, to avoid problems during first update
       - cmd: set-fedora-template-as-default-mgmt-dvm
-    - watch:
+    - onchanges:
       - qvm: dom0-install-fedora-template
 
 # qvm.default-dispvm is not strictly required here, but we want it to be


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes https://github.com/freedomofpress/securedrop-workstation/issues/1279

Changes proposed in this pull request:
- replaces `cmd.run` and `cmd.wait` where possible with `qvm.template_installed`
- replaces `watch` with `onchanges` for  (actual fix for #https://github.com/freedomofpress/securedrop-workstation/issues/1279)

Longer explanations are present in the commit messages.

## Testing

- [x] Assuming you're running from `main` and have both `debian-12-minimal` and `fedora-41-xfce` setup by the workstation
- [x]  Install RPM
- [x]  `make dev`
  - [ ] command succeeds
  - [x] Confirm in output: "Template fedora-41-xfce version 4.2.0 already installed"
      <details><summary>view output</summary>

     ```
     ----------
          ID: dom0-install-fedora-template
    Function: qvm.template_installed
        Name: fedora-41-xfce
      Result: True
     Comment: Template fedora-41-xfce version 4.2.0 already installed
     Started: 18:25:46.065963
    Duration: 506.453 ms
     Changes:   
     ----------
     ```
     </details>
  - [x] `qubes-vm-update` skipped
     <details><summary>view output</summary>

     ```
     ----------
          ID: update-fedora-template-if-new
    Function: cmd.wait
        Name: qubes-vm-update --quiet --force-update --targets fedora-41-xfce
      Result: True
     Comment: State was not run because none of the onchanges reqs changed
     Started: 16:55:29.534152
    Duration: 0.005 ms
     Changes:
     ----------
     ```
     </details>
  - [x] Confirm debian-12-minimal "already installed" in output:
     <details><summary>view output</summary>

     ```
     ----------
          ID: dom0-install-debian-minimal-template
    Function: qvm.template_installed
        Name: debian-12-minimal
      Result: True
     Comment: Template debian-12-minimal version 4.2.0 already installed
     Started: 18:39:09.307658
    Duration: 240.322 ms
     Changes:
     ----------
     ```
     </details>
- [x] remove fedora-41-xfce (cloning it may make it easier)
- [x] remove debian-12-minimal
- [x] `make dev`
  - [x] command succeeds (may take a long while due to template downloading)
  - [x] Debian template install succeeds
     <details><summary>view output</summary>

     ```
     ----------
          ID: dom0-install-debian-minimal-template
    Function: qvm.template_installed
        Name: debian-12-minimal
      Result: True
     Comment: ('Template debian-12-minimal version 4.2.0 installed',)
     Started: 18:25:48.622764
    Duration: 407704.953 ms
     Changes:   
              ----------
              details:
                  Downloading 'qubes-template-debian-12-minimal-0:4.2.0-202409070311'...
                  Installing template 'debian-12-minimal'...
                  debian-12-minimal: Importing data
              new:
                  ----------
                  buildtime:
                      2024-09-07 08:19:00
                  description:
                      Qubes OS template for debian-12-minimal.
                  epoch:
                      0
                  installtime:
                      2025-03-31 17:32:33
                  license:
                      GPLv3+
                  name:
                      debian-12-minimal
                  release:
                      202409070311
                  reponame:
                      qubes-templates-itl
                  size:
                      1338526557
                  summary:
                      Qubes OS template for debian-12-minimal
                  url:
                      http://www.qubes-os.org
                  version:
                      4.2.0
     ```
     </details>
  - [x] `fedora-41-xfce` template install succeeds
     <details><summary>view output</summary>

     ```
     ----------
          ID: dom0-install-fedora-template
    Function: qvm.template_installed
        Name: fedora-39-xfce
      Result: True
     Comment: ('Template fedora-39-xfce version 4.2.0 installed',)
     Started: 16:32:11.697236
    Duration: 1223500.436 ms
     Changes:   
              ----------
              details:
                  Downloading 'qubes-template-fedora-39-xfce-0:4.2.0-202403100103'...
                  Installing template 'fedora-39-xfce'...
                  fedora-39-xfce: Importing data
              new:
                  ----------
                  buildtime:
                      2024-03-10 02:14:43
                  description:
                      Qubes OS template for fedora-39-xfce.
                  epoch:
                      0
                  installtime:
                      2025-03-31 15:52:33
                  license:
                      GPLv3+
                  name:
                      fedora-39-xfce
                  release:
                      202403100103
                  reponame:
                      qubes-templates-itl
                  size:
                      5371286099
                  summary:
                      Qubes OS template for fedora-39-xfce
                  url:
                      http://www.qubes-os.org
                  version:
                      4.2.0
     ----------
     ```
     </details>

  - [x] Fedora update succeeds (confirms #1279's fix). Confirm in output:
     <details><summary>view output</summary>

     ```
     ----------
          ID: update-fedora-template-if-new
    Function: cmd.wait
        Name: qubes-vm-update --quiet --force-update --targets fedora-41-xfce
      Result: True
     Comment: 
     Started: 16:52:35.772452
    Duration: 0.838 ms
     Changes:   
      ----------
      ```
     </details>

## Deployment

**Any special considerations for deployment?** Should be a no-op for both existing installs and new ones.

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation