### PR TITLE
Clear salt cache on package install

### DIFF
--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -148,6 +148,9 @@ install -m 644 files/securedrop-user-xfce-icon-size.service %{buildroot}/%{_user
 %license LICENSE
 
 %post
+# Update Salt Configuration
+qubesctl saltutil.clear_cache -l quiet --out quiet > /dev/null || true
+qubesctl saltutil.sync_all refresh=true -l quiet --out quiet > /dev/null || true
 qubesctl top.enable securedrop_salt.sd-workstation > /dev/null ||:
 
 # Force full run of all Salt states - uncomment in release branch


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Releases updating dom0 salt states without shipping a migration flag would would not clear the salt cache before deploying. Apparently salt does refresh the cache before running `saltstate.highstate`, but we should err on the side of caution and refresh the cache explicitly on package reinstall.
    
Fixes #1286

## Testing


- modify in dev environment some `.sls` file (e.g. change a state's name)
- build and install RPM in dom0
- inspecting `/var/cache/salt/minion/files/base/securedrop_salt/*` should have the latest salt code or at least be empty.


## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing pilot instances
2. New installs

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation