### PR TITLE
Fix test_vms_exist unnecessarily complex assertion

### DIFF
--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -35,7 +35,7 @@ class SD_VM_Tests(unittest.TestCase):
 
         # Check for untagged VMs
         for vm_name in SD_UNTAGGED_DEPRECATED_VMS:
-            self.assertRaises(KeyError, lambda: self.app.domains[vm_name])  # noqa: PT027
+            self.assertNotIn(vm_name, self.app.domains)
 
     @unittest.skipIf(CONFIG["environment"] != "prod", "Skipping on non-prod system")
     def test_internal(self):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Per [Kunal's suggestion](https://github.com/freedomofpress/securedrop-workstation/pull/1285#discussion_r2044982047).

Co-authored-by: Kunal Mehta <legoktm@debian.org>

## Testing

dom0's `make test` is enough 

## Checklist

### If you have made changes to the provisioning logic

- [x] All tests (`make test`) pass in `dom0`
