### PR TITLE
Remove remaining hardcoded references to Whonix version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,10 +92,6 @@ sd-app: prep-dev ## Provisions SD APP VM
 	sudo qubesctl --show-output state.sls securedrop_salt.sd-app
 	sudo qubesctl --show-output --skip-dom0 --targets sd-small-bookworm-template,sd-app state.highstate
 
-sd-whonix: prep-dev ## Provisions SD Whonix VM
-	sudo qubesctl --show-output state.sls securedrop_salt.sd-whonix
-	sudo qubesctl --show-output --skip-dom0 --targets whonix-gateway-17,sd-whonix state.highstate
-
 sd-viewer: prep-dev ## Provisions SD Submission Viewing VM
 	sudo qubesctl --show-output state.sls securedrop_salt.sd-viewer
 	sudo qubesctl --show-output --skip-dom0 --targets sd-large-bookworm-template,sd-viewer state.highstate

--- a/files/sdw-admin.py
+++ b/files/sdw-admin.py
@@ -12,6 +12,8 @@ import sys
 
 from qubesadmin import Qubes
 
+from sdw_util import Util
+
 # The max concurrency reduction (4->2) was required to avoid "did not return clean data"
 # errors from qubesctl. It may be possible to raise this again.
 MAX_CONCURRENCY = 2
@@ -91,7 +93,7 @@ def provision_and_configure():
     provision("Provisioning base template", "securedrop_salt.sd-base-template")
     configure("Configuring base template", ["sd-base-bookworm-template"])
     provision_all()
-    configure("Enabling Whonix customizations", ["whonix-gateway-17"])
+    configure("Enabling Whonix customizations", [f"whonix-gateway-{Util.get_whonix_version()}"])
     configure(
         "Configure all SecureDrop Workstation VMs with service-specific configs",
         [q.name for q in Qubes().domains if "sd-workstation" in q.tags],
@@ -193,9 +195,10 @@ def sync_appmenus():
     run_cmd(["qvm-sync-appmenus", "sd-large-bookworm-template"])
     run_cmd(["qvm-shutdown", "sd-large-bookworm-template"])
 
-    run_cmd(["qvm-start", "--skip-if-running", "whonix-gateway-17"])
-    run_cmd(["qvm-sync-appmenus", "whonix-gateway-17"])
-    run_cmd(["qvm-shutdown", "whonix-gateway-17"])
+    whonix_gateway = f"whonix-gateway-{Util.get_whonix_version()}"
+    run_cmd(["qvm-start", "--skip-if-running", whonix_gateway])
+    run_cmd(["qvm-sync-appmenus", whonix_gateway])
+    run_cmd(["qvm-shutdown", whonix_gateway])
 
     # These are the ones we show in prod VMs, so sync explicitly
     run_cmd(["qvm-sync-appmenus", "--regenerate-only", "sd-devices"])

--- a/launcher/tests/test_util.py
+++ b/launcher/tests/test_util.py
@@ -20,6 +20,7 @@ CONFLICTING_PROCESS_REGEX = r"Conflicting process .* is currently running."
 FIXTURES_PATH = Path(__file__).parent / "fixtures"
 
 DEBIAN_VERSION = "bookworm"
+WHONIX_VERSION = 17
 
 
 @mock.patch("sdw_util.Util.sdlog.error")
@@ -303,3 +304,14 @@ def test_is_sdapp_halted_error(patched_subprocess, os_release_fixture, version_c
     """
 
     assert not Util.is_sdapp_halted()
+
+
+@mock.patch("subprocess.check_output", return_value=str(WHONIX_VERSION))
+def test_get_whonix_version(patched_subprocess):
+    assert Util.get_whonix_version() == WHONIX_VERSION
+
+
+@mock.patch("subprocess.check_output", side_effect=subprocess.CalledProcessError(1, "check_output"))
+def test_get_whonix_version__on_error(patched_subprocess):
+    with pytest.raises(RuntimeError, match="Whonix version could not be obtained"):
+        Util.get_whonix_version()

--- a/sdw_updater/Updater.py
+++ b/sdw_updater/Updater.py
@@ -33,27 +33,31 @@ DETAIL_LOGGER_PREFIX = "detail"  # For detailed logs such as Salt states
 # logic to leverage the Qubes Python API.
 MIGRATION_DIR = "/tmp/sdw-migrations"
 
-DEBIAN_VERSION = "bookworm"
-WHONIX_VERSION = Util.get_whonix_version()
-
 sdlog = Util.get_logger(module=__name__)
 detail_log = Util.get_logger(prefix=DETAIL_LOGGER_PREFIX, module=__name__)
 
-# The are the TemplateVMs that require full patch level at boot in order to start the client,
-# as well as their associated TemplateVMs.
-# In the future, we could use qvm-prefs to extract this information.
-current_vms = {
-    "fedora": "fedora-41-xfce",
-    "sd-viewer": f"sd-large-{DEBIAN_VERSION}-template",
-    "sd-app": f"sd-small-{DEBIAN_VERSION}-template",
-    "sd-log": f"sd-small-{DEBIAN_VERSION}-template",
-    "sd-devices": f"sd-large-{DEBIAN_VERSION}-template",
-    "sd-proxy": f"sd-small-{DEBIAN_VERSION}-template",
-    "sd-whonix": f"whonix-gateway-{WHONIX_VERSION}",
-    "sd-gpg": f"sd-small-{DEBIAN_VERSION}-template",
-}
 
-current_templates = set([val for key, val in current_vms.items() if key != "dom0"])
+def _get_current_vms():
+    debian_version = "bookworm"
+    whonix_version = Util.get_whonix_version()
+
+    # The are the TemplateVMs that require full patch level at boot in order to start the client,
+    # as well as their associated TemplateVMs.
+    # In the future, we could use qvm-prefs to extract this information.
+    return {
+        "fedora": "fedora-41-xfce",
+        "sd-viewer": f"sd-large-{debian_version}-template",
+        "sd-app": f"sd-small-{debian_version}-template",
+        "sd-log": f"sd-small-{debian_version}-template",
+        "sd-devices": f"sd-large-{debian_version}-template",
+        "sd-proxy": f"sd-small-{debian_version}-template",
+        "sd-whonix": f"whonix-gateway-{whonix_version}",
+        "sd-gpg": f"sd-small-{debian_version}-template",
+    }
+
+
+def _get_current_templates():
+    return set([val for key, val in _get_current_vms().items() if key != "dom0"])
 
 
 def get_dom0_path(folder):
@@ -118,10 +122,11 @@ def apply_updates_dom0():
     return upgrade_results
 
 
-def apply_updates_templates(templates=current_templates, progress_callback=None):
+def apply_updates_templates(progress_callback=None):
     """
     Apply updates to all TemplateVMs.
     """
+    templates = _get_current_templates()
     sdlog.info(f"Applying all updates to VMs: {', '.join(templates)}")
     try:
         proc = _start_qubes_updater_proc(templates)

--- a/sdw_updater/Updater.py
+++ b/sdw_updater/Updater.py
@@ -34,6 +34,7 @@ DETAIL_LOGGER_PREFIX = "detail"  # For detailed logs such as Salt states
 MIGRATION_DIR = "/tmp/sdw-migrations"
 
 DEBIAN_VERSION = "bookworm"
+WHONIX_VERSION = Util.get_whonix_version()
 
 sdlog = Util.get_logger(module=__name__)
 detail_log = Util.get_logger(prefix=DETAIL_LOGGER_PREFIX, module=__name__)
@@ -48,7 +49,7 @@ current_vms = {
     "sd-log": f"sd-small-{DEBIAN_VERSION}-template",
     "sd-devices": f"sd-large-{DEBIAN_VERSION}-template",
     "sd-proxy": f"sd-small-{DEBIAN_VERSION}-template",
-    "sd-whonix": "whonix-gateway-17",
+    "sd-whonix": f"whonix-gateway-{WHONIX_VERSION}",
     "sd-gpg": f"sd-small-{DEBIAN_VERSION}-template",
 }
 

--- a/sdw_updater/UpdaterApp.py
+++ b/sdw_updater/UpdaterApp.py
@@ -5,7 +5,7 @@ from PyQt5.QtCore import QThread, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import QDialog
 
 from sdw_updater import Updater, strings
-from sdw_updater.Updater import UpdateStatus, current_templates
+from sdw_updater.Updater import UpdateStatus
 from sdw_updater.UpdaterAppUiQt5 import Ui_UpdaterDialog
 from sdw_util import Util
 
@@ -282,7 +282,6 @@ class UpgradeThread(QThread):
             )
 
         results["templates"] = Updater.apply_updates_templates(
-            current_templates,
             templates_progress_callback,
         )
 

--- a/sdw_util/Util.py
+++ b/sdw_util/Util.py
@@ -174,10 +174,8 @@ def get_whonix_version():
             universal_newlines=True,
         )
         whonix_version = int(output.strip())
-    except subprocess.CalledProcessError:
-        return None
-    except (AttributeError, ValueError):
-        return None
+    except (AttributeError, ValueError, subprocess.CalledProcessError):
+        raise RuntimeError("Whonix version could not be obtained")
 
     return whonix_version
 

--- a/sdw_util/Util.py
+++ b/sdw_util/Util.py
@@ -158,6 +158,8 @@ def get_whonix_version():
         {{ whonix.whonix_version }}
 
     This function extracts this value so that it can be on this script.
+
+    NOTE: function takes a few seconds to run
     """
 
     try:

--- a/sdw_util/Util.py
+++ b/sdw_util/Util.py
@@ -148,6 +148,40 @@ def get_qubes_version():
     return version
 
 
+def get_whonix_version():
+    """
+    Obtain Whonix version from /srv/formulas/base/virtual-machine-formula/qvm/whonix.jinja
+
+    In '.sls' files the whonix version is obtained with
+
+        {% import "qvm/whonix.jinja" as whonix %}
+        {{ whonix.whonix_version }}
+
+    This function extracts this value so that it can be on this script.
+    """
+
+    try:
+        output = subprocess.check_output(
+            [
+                "sudo",
+                "qubesctl",
+                "jinja.load_map",
+                "qvm/whonix.jinja",
+                "whonix_version",
+                "--out",
+                "newline_values_only",
+            ],  # avoid "local:" prefix
+            universal_newlines=True,
+        )
+        whonix_version = int(output.strip())
+    except subprocess.CalledProcessError:
+        return None
+    except (AttributeError, ValueError):
+        return None
+
+    return whonix_version
+
+
 def get_logger(prefix=SD_LOGGER_PREFIX, module=None):
     if module is None:
         return logging.getLogger(prefix)

--- a/securedrop_salt/sd-clean-all.sls
+++ b/securedrop_salt/sd-clean-all.sls
@@ -2,6 +2,7 @@
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 
 {% import_json "securedrop_salt/config.json" as d %}
+{% import "qvm/whonix.jinja" as whonix %}
 
 set-fedora-as-default-dispvm:
   cmd.run:
@@ -77,8 +78,8 @@ sd-cleanup-sys-firewall:
 sd-cleanup-whonix-gateway:
   cmd.run:
     - names:
-      - qvm-run whonix-gateway-17 'sudo apt purge --yes securedrop-keyring securedrop-qubesdb-tools securedrop-whonix-config'
-      - qvm-run whonix-gateway-17 'sudo rm -f /etc/apt/sources.list.d/apt-test_freedom_press.sources'
+      - qvm-run whonix-gateway-{{ whonix.whonix_version }} 'sudo apt purge --yes securedrop-keyring securedrop-qubesdb-tools securedrop-whonix-config'
+      - qvm-run whonix-gateway-{{ whonix.whonix_version }} 'sudo rm -f /etc/apt/sources.list.d/apt-test_freedom_press.sources'
 
 # Reset desktop icon size to its original value
 dom0-reset-icon-size-xfce:

--- a/securedrop_salt/sd-sys-whonix-vms.sls
+++ b/securedrop_salt/sd-sys-whonix-vms.sls
@@ -6,8 +6,7 @@
 # and ensure sys-whonix and anon-whonix use latest version.
 ##
 
-{%- import "qvm/whonix.jinja" as whonix -%}
-{% set whonix_version = salt['pillar.get']('qvm:whonix:version', whonix.whonix_version) %}
+{% import "qvm/whonix.jinja" as whonix %}
 
 include:
   - qvm.anon-whonix
@@ -23,20 +22,20 @@ include:
 # by a single `qvm.vm` state, but to avoid possible bugs and guarantee
 # we are configuring the template, explicitly require qvm.template_installed
 # with the expected template name.
-whonix-{{ component }}-{{ whonix_version }}-installed:
+whonix-{{ component }}-{{ whonix.whonix_version }}-installed:
   qvm.template_installed:
-    - name: whonix-{{ component }}-{{ whonix_version }}
+    - name: whonix-{{ component }}-{{ whonix.whonix_version }}
     - fromrepo: {{ whonix.whonix_repo }}
     - require:
       - sls: qvm.template-whonix-{{ component }}
 
-whonix-{{ component }}-{{ whonix_version }}-apparmor:
+whonix-{{ component }}-{{ whonix.whonix_version }}-apparmor:
   qvm.vm:
-    - name: whonix-{{ component }}-{{ whonix_version }}
+    - name: whonix-{{ component }}-{{ whonix.whonix_version }}
     - prefs:
       - kernelopts: "apparmor=1 security=apparmor"
     - require:
-      - qvm: whonix-{{ component }}-{{ whonix_version }}-installed
+      - qvm: whonix-{{ component }}-{{ whonix.whonix_version }}-installed
 
 # The Qubes logic is too polite about enforcing template
 # settings, using "present" rather than "prefs". Below we
@@ -50,18 +49,18 @@ poweroff-{{ vm }}:
     - onlyif:
       - qvm-check --quiet {{ vm }}
     - unless:
-      - qvm-prefs {{ vm }} template | grep -q whonix-{{ component }}-{{ whonix_version }}
+      - qvm-prefs {{ vm }} template | grep -q whonix-{{ component }}-{{ whonix.whonix_version }}
 
 # cmd.run is used instead of qvm.vm to avoid a recursive
 # requisite issue via the "name" parameter of qvm.vm.
 {{ vm }}-upgrade-template:
   cmd.run:
-    - name: qvm-prefs {{ vm }} template whonix-{{ component }}-{{ whonix_version }}
+    - name: qvm-prefs {{ vm }} template whonix-{{ component }}-{{ whonix.whonix_version }}
     - require:
       - qvm: poweroff-{{ vm }}
-      - qvm: whonix-{{ component }}-{{ whonix_version }}-apparmor
+      - qvm: whonix-{{ component }}-{{ whonix.whonix_version }}-apparmor
       - sls: qvm.{{ vm }}
     - unless:
-      - qvm-prefs {{ vm }} template | grep -q whonix-{{ component }}-{{ whonix_version }}
+      - qvm-prefs {{ vm }} template | grep -q whonix-{{ component }}-{{ whonix.whonix_version }}
 
 {% endfor %}

--- a/securedrop_salt/sd-whonix.sls
+++ b/securedrop_salt/sd-whonix.sls
@@ -14,8 +14,7 @@
 # Imports "sdvars" for environment config
 {% from 'securedrop_salt/sd-default-config.sls' import sdvars with context %}
 
-{%- import "qvm/whonix.jinja" as whonix -%}
-{% set whonix_version = salt['pillar.get']('qvm:whonix:version', whonix.whonix_version) %}
+{% import "qvm/whonix.jinja" as whonix %}
 
 include:
   - securedrop_salt.sd-sys-whonix-vms
@@ -30,7 +29,7 @@ poweroff-{{ vm }}:
     - onlyif:
       - qvm-check --quiet {{ vm }}
     - unless:
-      - qvm-prefs sd-whonix template | grep -q whonix-gateway-{{ whonix_version }}
+      - qvm-prefs sd-whonix template | grep -q whonix-gateway-{{ whonix.whonix_version }}
 
 {% endfor %}
 
@@ -39,10 +38,10 @@ sd-whonix:
     - name: sd-whonix
     - present:
       - label: purple
-      - template: whonix-gateway-{{ whonix_version }}
+      - template: whonix-gateway-{{ whonix.whonix_version }}
       - mem: 500
     - prefs:
-      - template: whonix-gateway-{{ whonix_version }}
+      - template: whonix-gateway-{{ whonix.whonix_version }}
       - provides-network: true
       - netvm: "sys-firewall"
       - autostart: true

--- a/securedrop_salt/sd-workstation.top
+++ b/securedrop_salt/sd-workstation.top
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 
+{% import "qvm/whonix.jinja" as whonix %}
+
 base:
   dom0:
     - securedrop_salt.sd-sys-vms
@@ -34,7 +36,7 @@ base:
   'sd-fedora-41-dvm,sys-usb':
     - match: list
     - securedrop_salt.sd-usb-autoattach-add
-  whonix-gateway-17:
+  whonix-gateway-{{ whonix.whonix_version }}:
     - securedrop_salt.sd-whonix-config
 
   # "Placeholder" config to trigger TemplateVM boots,

--- a/tests/base.py
+++ b/tests/base.py
@@ -5,6 +5,8 @@ import unittest
 
 from qubesadmin import Qubes
 
+from sdw_util import Util
+
 # Reusable constant for DRY import across tests
 DEBIAN_VERSION = "bookworm"
 SD_TEMPLATE_BASE = f"sd-base-{DEBIAN_VERSION}-template"
@@ -19,7 +21,7 @@ SD_UNTAGGED_DEPRECATED_VMS = ["sd-retain-logvm"]
 CURRENT_FEDORA_VERSION = "41"
 CURRENT_FEDORA_TEMPLATE = "fedora-" + CURRENT_FEDORA_VERSION + "-xfce"
 CURRENT_FEDORA_DVM = "fedora-" + CURRENT_FEDORA_VERSION + "-dvm"
-CURRENT_WHONIX_VERSION = "17"
+CURRENT_WHONIX_VERSION = str(Util.get_whonix_version())
 CURRENT_DEBIAN_VERSION = "bookworm"
 
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -5,8 +5,6 @@ import unittest
 
 from qubesadmin import Qubes
 
-from sdw_util import Util
-
 # Reusable constant for DRY import across tests
 DEBIAN_VERSION = "bookworm"
 SD_TEMPLATE_BASE = f"sd-base-{DEBIAN_VERSION}-template"
@@ -21,7 +19,7 @@ SD_UNTAGGED_DEPRECATED_VMS = ["sd-retain-logvm"]
 CURRENT_FEDORA_VERSION = "41"
 CURRENT_FEDORA_TEMPLATE = "fedora-" + CURRENT_FEDORA_VERSION + "-xfce"
 CURRENT_FEDORA_DVM = "fedora-" + CURRENT_FEDORA_VERSION + "-dvm"
-CURRENT_WHONIX_VERSION = str(Util.get_whonix_version())
+CURRENT_WHONIX_VERSION = "17"
 CURRENT_DEBIAN_VERSION = "bookworm"
 
 

--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -3,6 +3,7 @@ import subprocess
 import unittest
 
 from base import (
+    CURRENT_WHONIX_VERSION,
     SD_DVM_TEMPLATES,
     SD_TEMPLATE_BASE,
     SD_TEMPLATE_LARGE,
@@ -12,8 +13,6 @@ from base import (
     SD_VMS,
 )
 from qubesadmin import Qubes
-
-from sdw_util import Util
 
 with open("config.json") as f:
     CONFIG = json.load(f)

--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -96,7 +96,7 @@ class SD_VM_Tests(unittest.TestCase):
         self.assertEqual(nvm.name, "sys-firewall")
         wanted_kernelopts = "apparmor=1 security=apparmor"
         self.assertEqual(vm.kernelopts, wanted_kernelopts)
-        self.assertEqual(vm.template, f"whonix-gateway-{Util.get_whonix_version()}")
+        self.assertEqual(vm.template.features.get("os-version"), str(Util.get_whonix_version()))
         self.assertTrue(vm.provides_network)
         self.assertTrue(vm.autostart)
         self.assertFalse(vm.template_for_dispvms)

--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -13,6 +13,8 @@ from base import (
 )
 from qubesadmin import Qubes
 
+from sdw_util import Util
+
 with open("config.json") as f:
     CONFIG = json.load(f)
 
@@ -95,7 +97,7 @@ class SD_VM_Tests(unittest.TestCase):
         self.assertEqual(nvm.name, "sys-firewall")
         wanted_kernelopts = "apparmor=1 security=apparmor"
         self.assertEqual(vm.kernelopts, wanted_kernelopts)
-        self.assertEqual(vm.template, "whonix-gateway-17")
+        self.assertEqual(vm.template, f"whonix-gateway-{Util.get_whonix_version()}")
         self.assertTrue(vm.provides_network)
         self.assertTrue(vm.autostart)
         self.assertFalse(vm.template_for_dispvms)

--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -14,6 +14,8 @@ from base import (
 )
 from qubesadmin import Qubes
 
+from sdw_util import Util
+
 with open("config.json") as f:
     CONFIG = json.load(f)
 
@@ -96,11 +98,17 @@ class SD_VM_Tests(unittest.TestCase):
         self.assertEqual(nvm.name, "sys-firewall")
         wanted_kernelopts = "apparmor=1 security=apparmor"
         self.assertEqual(vm.kernelopts, wanted_kernelopts)
-        self.assertEqual(vm.template.features.get("os-version"), str(Util.get_whonix_version()))
         self.assertTrue(vm.provides_network)
         self.assertTrue(vm.autostart)
         self.assertFalse(vm.template_for_dispvms)
         self.assertIn("sd-workstation", vm.tags)
+
+        # Whonix version checking
+        self.assertEqual(
+            Util.get_whonix_version(),  # If mismatch, whonix may have been updated.
+            CURRENT_WHONIX_VERSION,  # Fix the test by bumping CURRENT_WHONIX_VERSION
+        )
+        self.assertEqual(vm.template.features.get("os-version"), int(CURRENT_WHONIX_VERSION))
 
     def test_sd_proxy_config(self):
         vm = self.app.domains["sd-proxy"]

--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -46,7 +46,7 @@ class SD_VM_Platform_Tests(unittest.TestCase):
         """
         Asserts that the given AppVM is based on an OS listed in the
         SUPPORTED_<XX>_PLATFORMS list, as specified in tests.
-        sd-whonix is based on the whonix-17 template.
+        sd-whonix is based on the whonix-XX template.
         All other workstation-provisioned VMs should be
         SUPPORTED_SD_DEBIAN_DIST based.
         """

--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -16,7 +16,6 @@ from qubesadmin import Qubes
 BOOKWORM_STRING = "Debian GNU/Linux 12 (bookworm)"
 
 SUPPORTED_SD_DEBIAN_DIST = "bookworm"
-SUPPORTED_WHONIX_PLATFORMS = [BOOKWORM_STRING]
 
 IS_CI = os.environ.get("CI") == "true"
 
@@ -51,10 +50,7 @@ class SD_VM_Platform_Tests(unittest.TestCase):
         SUPPORTED_SD_DEBIAN_DIST based.
         """
         platform = self._get_platform_info(vm)
-        if vm.name in ["sd-whonix"]:
-            self.assertIn(platform, SUPPORTED_WHONIX_PLATFORMS)
-        else:
-            self.assertIn(SUPPORTED_SD_DEBIAN_DIST, platform)
+        self.assertIn(SUPPORTED_SD_DEBIAN_DIST, platform)
 
     def _validate_apt_sources(self, vm):
         """


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Removes hardcoded whonix version from remaining code base.

Refs #1060 (partial fix -- still missing Trixie debs being available for SecureDrop packages)


## Testing (ideas)

### Simulate a Whonix 18 upgrade
Apply the following patches:
`/srv/salt/securedrop_salt/sd-sys-whonix-vms.sls`:

   ```diff
   whonix-{{ component }}-{{ whonix.whonix_version }}-installed:
   +  qvm.vm:
   +    - name: whonix-{{component}}-{{ whonix.whonix_version }}
   +    - present:
   +      - label: black
   -  qvm.template_installed:
   -    - name: whonix-{{ component }}-{{ whonix.whonix_version }}
   -    - fromrepo: {{ whonix.whonix_repo }}
   -    - require:
   -      - sls: qvm.template-whonix-{{ component }}
   ```
`/srv/formulas/base/virtual-machines-formula/qvm/template-whonix-workstation.sls`
   ```diff
   template-whonix-gateway-{{ whonix.whonix_version }}:
   -  qvm.template_installed:
   -    - name:     whonix-gateway-{{ whonix.whonix_version_override_template }}
   -    - fromrepo: {{ whonix.whonix_repo }}
   +  qvm.vm:
   +    - name: whonix-gateway-{{ whonix.whonix_version }}
   +    - present:
   +      - label: black
   ```

### Actual test

- [ ] `make test` passes in dom0 (except for `test_sd_whonix_config`)
- [ ] run updater and confirm in logs that whonix-gateway-18 was updated

### Undo changes

- [ ] Don't forget to undo the changes in `/srv/formulas`. The easiest way is to `sudo qubes-dom0-update --action=reinstall qubes-mgmt-salt-dom0-virtual-machines`.


## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing pilot instances
2. New installs

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation