### PR TITLE
Don't assert printer-driver-* packages will be installed

### DIFF
--- a/tests/test_sd_devices.py
+++ b/tests/test_sd_devices.py
@@ -17,8 +17,6 @@ class SD_Devices_Tests(SD_VM_Local_Test):
 
     def test_sd_export_package_installed(self):
         self.assertTrue(self._package_is_installed("udisks2"))
-        self.assertTrue(self._package_is_installed("printer-driver-brlaser"))
-        self.assertTrue(self._package_is_installed("printer-driver-hpcups"))
         self.assertTrue(self._package_is_installed("securedrop-export"))
         self.assertTrue(self._package_is_installed("gnome-disk-utility"))
 


### PR DESCRIPTION


## Status

Ready for review 

## Description of Changes

As of <https://github.com/freedomofpress/securedrop-client/commit/ebbeef9710dc874f2441918dc0392c55bdf43f53>, we use driverless printing with `ipp-usb` instead of old-school print drivers.

I didn't add a check asserting `ipp-usb` is installed because we trust our packaging more now; if the securedrop-export package is installed, we can assume its dependencies are too.

Fixes #1296.
## Testing

* [ ] SDW CI passes, especially the `test_sd_export_package_installed` test.

## Deployment

Any special considerations for deployment? n/a, test-only

## Checklist

- [ ] All tests (`make test`) pass in `dom0`
