### PR TITLE
Add 1.2.0-rc1 changelog entry to RPM spec

### DIFF
--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -181,6 +181,9 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Thu May 8 2025 SecureDrop Team <securedrop@freedom.press> - 1.2.0-rc1
+- See changelog.md
+
 * Tue Apr 15 2025 SecureDrop Team <securedrop@freedom.press> - 1.1.2
 - See changelog.md
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This repo's `./update-script.sh` does not seem to update the `.spec` like the debian one does. I have file an issue for that (https://github.com/freedomofpress/securedrop-workstation/issues/1306). This adds that missing entry.

## Testing

If you made non-trivial code changes, include a test plan and validated it for this PR.

## Deployment

Any special considerations for deployment? Consider both:

1. Upgrading existing pilot instances
2. New installs

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation