### PR TITLE
update_version: Don't add extra newlines after "Version" field

### DIFF
--- a/update_version.py
+++ b/update_version.py
@@ -21,7 +21,7 @@ Path("VERSION").write_text(new_version + "\n")
 spec_lines = spec.read_text().splitlines()
 for i, line in enumerate(spec_lines):
     if line.startswith("Version:"):
-        spec_lines[i] = f"Version:\t{new_version}\n"
+        spec_lines[i] = f"Version:\t{new_version}"
     elif line.startswith("%changelog"):
         current_date = datetime.datetime.now().strftime("%a %b %d %Y")
         changelog_entry = f"* {current_date} {author} - {new_version}\n- {message}\n"


### PR DESCRIPTION


## Status

Ready for review
## Description of Changes

Otherwise it'll keep adding extra newlines as we run the script more often.

## Testing

Run `./update_version.py 1.3.0` and observe the diff is like:
```diff
diff --git a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
index 3aafc63..03fd4ac 100644
--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -1,5 +1,5 @@
 Name:          securedrop-workstation-dom0-config
-Version:       1.3.0rc1
+Version:       1.3.0
 Release:       1%{?dist}
 Summary:       SecureDrop Workstation
```

notably there's no newline being inserted between "Version" and "Release" 
