### PR TITLE
updater: start up sd-proxy vm before launching app

### DIFF
--- a/sdw_updater/UpdaterApp.py
+++ b/sdw_updater/UpdaterApp.py
@@ -18,6 +18,7 @@ def launch_securedrop_client():
     """
     try:
         logger.info("Launching SecureDrop client")
+        subprocess.Popen(["qvm-start", "sd-proxy"])
         subprocess.Popen(["qvm-run", "sd-app", "gtk-launch press.freedom.SecureDropClient"])
     except subprocess.CalledProcessError as e:
         logger.error("Error while launching SecureDrop client")


### PR DESCRIPTION
## Status

Ready for review / Work in progress

## Description of Changes

Fixes #1330 

Changes proposed in this pull request: 

- start up sd-proxy vm before launching SecureDrop Client

## Testing

- [ ] Close SecureDrop client and shut down `sd-proxy` VM
- [ ] Start up SecureDrop client 
- [ ] Ensure `sd-proxy` VM is running

## Deployment

Any special considerations for deployment? 

## Checklist

### If you have made changes to the provisioning logic

- [x] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation