### PR TITLE
Trigger OpenQA from GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,15 @@
 ---
 name: ci
 
-on: [push, pull_request, merge_group]
+on:
+  - push
+  - pull_request
+  - merge_group
+
+# Only build for latest push/PR unless it's main or release/
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith( github.ref, 'refs/heads/release/' ) && !startsWith( github.ref, 'refs/heads/gh-readonly-queue/' ) }}
 
 jobs:
   lint:
@@ -59,3 +67,93 @@ jobs:
       - name: Run launcher tests
         run: |
           make test-launcher
+  # If the most recent commit message contains "skip openqa" (case insensitive), skip the openqa job
+  check-openqa:
+    runs-on: ubuntu-latest
+    outputs:
+      should-skip: ${{ steps.check.outputs.should-skip }}
+    env:
+      COMMIT_MSG: ${{ github.event.head_commit.message }}
+    steps:
+      - name: Check commit message
+        id: check
+        run: |
+          if echo "${COMMIT_MSG}" | grep -iq "skip openqa"; then
+            echo "skipping OpenQA job"
+            echo "should-skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "running OpenQA job"
+            echo "should-skip=false" >> $GITHUB_OUTPUT
+          fi
+  openqa:
+    runs-on: ubuntu-latest
+    # Do not start until all other checks have passed
+    needs:
+      - lint
+      - build-rpm
+      - launcher-tests
+      - check-openqa
+    # Run only if:
+    # 1. This is a push (not pull_request)
+    # 2. We're not on main
+    # 3. We're not on a merge queue branch
+    # 4. The "skip openqa" string isn't present
+    if: |
+      github.event_name == 'push' && github.ref != 'refs/heads/main' && !startsWith( github.ref, 'refs/heads/gh-readonly-queue/' )
+      && needs.check-openqa.outputs.should-skip != 'true'
+    env:
+      OPENQA_HOST: "https://openqa.qubes-os.org/"
+      OPENQA_KEY: ${{ secrets.OPENQA_KEY }}
+      OPENQA_SECRET: ${{ secrets.OPENQA_SECRET }}
+      GIT_REF: ${{ github.event.head_commit.id }}
+    container:
+      image: debian:trixie
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install --yes openqa-client jq
+      - name: Start openQA jobs
+        run: |
+          echo "Queuing openQA jobs for commit ${GIT_REF}"
+          openqa-cli api \
+            --host "$OPENQA_HOST" \
+            --apikey "$OPENQA_KEY" \
+            --apisecret "$OPENQA_SECRET" \
+            isos -X post \
+            VERSION=4.2 \
+            BUILD=$(date +%Y%m%d%H%M)-4.2 \
+            DISTRI=qubesos ARCH=x86_64 \
+            GIT_REF="$GIT_REF" \
+            FLAVOR=securedrop \
+            CASEDIR="https://github.com/deeplow/openqa-tests-qubesos.git#securedrop-basic-functionality"\
+            MAX_JOB_TIME=10800 | tee openqa.json
+      - name: Wait for openQA
+        run: |
+          openqa-cli monitor \
+            --host "$OPENQA_HOST" \
+            --apikey "$OPENQA_KEY" \
+            --apisecret "$OPENQA_SECRET" \
+            $(jq -r '.ids[]' openqa.json)
+      - name: Cancel openQA test (if needed)
+        if: cancelled()
+        run: |
+          # Cancel all the jobs we queued in a best-effort manner
+          for id in $(jq -r '.ids[]' openqa.json); do
+            openqa-cli api \
+              --host "$OPENQA_HOST" \
+              --apikey "$OPENQA_KEY" \
+              --apisecret "$OPENQA_SECRET" \
+              -X POST "jobs/${id}/cancel" ||:
+          done
+      - name: View logs
+        if: always()
+        run: |
+          echo "View the logs for this run at:"
+
+          for id in $(jq -r '.ids[]' openqa.json); do
+            echo "${OPENQA_HOST}tests/${id}"
+          done

--- a/Makefile
+++ b/Makefile
@@ -135,29 +135,39 @@ clean: assert-dom0 prep-dev ## Destroys all SD VMs
 # if clean has already been run.
 	./scripts/sdw-admin.py --uninstall --force
 
+PYTEST_PATH=$(shell command -v pytest)
+COVERAGE_PATH=$(shell command -v coverage) # instead of pytest-cov, check for its dep.
 .PHONY: test-prereqs
 test-prereqs: assert-dom0 ## Checks that test prerequisites are satisfied
 	@echo "Checking prerequisites before running test suite..."
 	test -e config.json || exit 1
 	test -e sd-journalist.sec || exit 1
+ifeq ($(PYTEST_PATH),)
+	@echo 'please install pytest with "sudo qubes-dom0-update python3-pytest"'
+	@false
+endif
+ifeq ($(COVERAGE_PATH),)
+	@echo 'please install pytest with "sudo qubes-dom0-update python3-pytest-cov"'
+	@false
+endif
 
 test: test-prereqs ## Runs all application tests (no integration tests yet)
-	python3 -m unittest discover -v tests
+	pytest -v tests
 
 test-base: test-prereqs ## Runs tests for VMs layout
-	python3 -m unittest discover -v tests -p test_vms_exist.py
+	pytest -v tests/test_vms_exist.py
 
 test-app: test-prereqs ## Runs tests for SD APP VM config
-	python3 -m unittest discover -v tests -p test_app.py
+	pytest -v tests/test_app.py
 
 test-proxy: test-prereqs ## Runs tests for SD Proxy VM
-	python3 -m unittest discover -v tests -p test_proxy_vm.py
+	pytest -v tests/test_proxy_vm.py
 
 test-whonix: test-prereqs ## Runs tests for SD Whonix VM
-	python3 -m unittest discover -v tests -p test_sd_whonix.py
+	pytest -v tests/test_sd_whonix.py
 
 test-gpg: test-prereqs ## Runs tests for SD GPG functionality
-	python3 -m unittest discover -v tests -p test_gpg.py
+	pytest -v tests/test_gpg.py
 
 # Client autologin variables
 XDOTOOL_PATH=$(shell command -v xdotool)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,4 +116,4 @@ exclude = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--cov-report term-missing --cov=sdw_notify --cov=sdw_updater --cov=sdw_util"
+addopts = "--cov-report term-missing --cov=sdw_notify --cov=sdw_updater --cov=sdw_util --junitxml=test-data.xml"

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,6 +1,5 @@
 import json
 import subprocess
-import time
 import unittest
 
 from qubesadmin import Qubes
@@ -55,7 +54,6 @@ class SD_VM_Local_Test(unittest.TestCase):
     def setUp(self):
         self.app = Qubes()
         self.vm = self.app.domains[self.vm_name]
-        # self._reboot()
         if self.vm.is_running():
             pass
         else:
@@ -69,33 +67,6 @@ class SD_VM_Local_Test(unittest.TestCase):
         self.lsm = "apparmor"
         # AppArmor profiles that should be enforced.
         self.enforced_apparmor_profiles = set()
-
-    # def tearDown(self):
-    #     self.vm.shutdown()
-
-    def _reboot(self):
-        # The for-loop below should be couched in a try/except block.
-        # Further testing required to determine which specific exceptions
-        # to catch; a few ideas:
-        #
-        #   * CalledProcessorError
-        #   * QubesVMError (from qubesadmin.base)
-        #   * QubesVMNotStartedError (from qubesadmin.base)
-        for v in list(self.vm.connected_vms.values()):
-            if v.is_running():
-                msg = f"Need to halt connected VM {v}" " before testing"
-                print(msg)
-                v.shutdown()
-                while v.is_running():
-                    time.sleep(1)
-
-        if self.vm.is_running():
-            self.vm.shutdown()
-
-        while self.vm.is_running():
-            time.sleep(1)
-
-        self.vm.start()
 
     def _run(self, cmd, user=""):
         full_cmd = ["qvm-run", "-p"]
@@ -134,17 +105,6 @@ class SD_VM_Local_Test(unittest.TestCase):
             else:
                 raise e
         return results == "active"
-
-    def assertFilesMatch(self, remote_path, local_path):
-        remote_content = self._get_file_contents(remote_path)
-
-        content = False
-        with open(local_path) as f:
-            content = f.read()
-        import difflib
-
-        print("".join(difflib.unified_diff(remote_content, content)), end="")
-        self.assertEqual(remote_content, content)
 
     def assertFileHasLine(self, remote_path, wanted_line):
         remote_content = self._get_file_contents(remote_path)

--- a/tests/base.py
+++ b/tests/base.py
@@ -61,10 +61,6 @@ class SD_VM_Local_Test(unittest.TestCase):
         else:
             self.vm.start()
 
-        # Make the dom0 "config.json" available to tests.
-        with open("config.json") as config_file:
-            self.dom0_config = json.load(config_file)
-
         # A VM shouldn't have any configuration keys it doesn't explicitly
         # expect.
         self.expected_config_keys = set()

--- a/tests/base.py
+++ b/tests/base.py
@@ -147,31 +147,31 @@ class SD_VM_Local_Test(unittest.TestCase):
         """
         actual = set(self._run("qubesdb-list /vm-config/").split("\n"))
         actual.discard("")  # if "qubesdb-list" returned nothing
-        self.assertEqual(actual, set(expected))
+        assert actual == set(expected)
 
     def logging_configured(self):
         """
         Make sure rsyslog is configured to send in data to sd-log vm.
         """
         # Logging is not disabled
-        self.assertFalse(self._fileExists("/var/run/qubes-service/securedrop-logging-disabled"))
+        assert not self._fileExists("/var/run/qubes-service/securedrop-logging-disabled")
 
-        self.assertTrue(self._package_is_installed("securedrop-log"))
-        self.assertTrue(self._fileExists("/usr/sbin/sd-rsyslog"))
-        self.assertTrue(self._fileExists("/etc/rsyslog.d/sdlog.conf"))
-        self.assertTrue(self._fileExists("/etc/sd-rsyslog.conf"))
+        assert self._package_is_installed("securedrop-log")
+        assert self._fileExists("/usr/sbin/sd-rsyslog")
+        assert self._fileExists("/etc/rsyslog.d/sdlog.conf")
+        assert self._fileExists("/etc/sd-rsyslog.conf")
         # Then we check the configuration inside of the file.
         file_content = self._get_file_contents("/etc/sd-rsyslog.conf")
         static_content = """[sd-rsyslog]
 remotevm = sd-log
 """
-        self.assertEqual(file_content, static_content)
+        assert file_content == static_content
         # Check for evidence of misconfigured logging in syslog,
         # fail if matching events found
         # Several VMs show this error message even though they're shipping logs,
         # so let's investigate further.
         # cmd_output = self._run("sudo grep -F \"action 'action-0-omprog' suspended (module 'omprog')\" /var/log/syslog | wc -l").strip()  # noqa
-        # self.assertEqual(cmd_output, "0")
+        # assert cmd_output == "0"
 
     def mailcap_hardened(self):
         """
@@ -182,8 +182,8 @@ remotevm = sd-log
         # Ensure that mailcap configuration files are present in the expected
         # locations and contain the expected contents. Rules in `~/.mailcap`
         # take precedence over those in `/etc/mailcap`.
-        self.assertTrue(self._fileExists("/home/user/.mailcap"))
-        self.assertTrue(self._fileExists("/opt/sdw/mailcap.default"))
+        assert self._fileExists("/home/user/.mailcap")
+        assert self._fileExists("/opt/sdw/mailcap.default")
         self.assertFileHasLine("/home/user/.mailcap", '*/*; logger "Mailcap is disabled."')
 
         # Because we target an AppVM, we cannot easily use the Pyhton tempfile
@@ -200,7 +200,7 @@ remotevm = sd-log
         self._run(f"rm {tmpfile_name}")
 
         # Ensure that the wildcard rule worked as expected.
-        self.assertEqual(mailcap_result, f'logger "Mailcap is disabled." <{tmpfile_name}')
+        assert mailcap_result == f'logger "Mailcap is disabled." <{tmpfile_name}'
 
     def test_vm_config_keys(self):
         """Every VM should check that it has only the configuration keys it
@@ -211,13 +211,13 @@ remotevm = sd-log
     def test_lsm_enabled(self):
         """Check that the expected LSM is enabled"""
         if self.lsm == "apparmor":
-            self.assertTrue(self._package_is_installed("apparmor"))
+            assert self._package_is_installed("apparmor")
             # returns error code if AppArmor not enabled
             self._run("sudo aa-status --enabled")
         elif self.lsm == "selinux":
             sestatus = self._run("sudo sestatus")
-            self.assertIn("SELinux status:                 enabled\n", sestatus)
-            self.assertIn("Current mode:                   enforcing\n", sestatus)
+            assert "SELinux status:                 enabled\n" in sestatus
+            assert "Current mode:                   enforcing\n" in sestatus
         else:
             raise ValueError(f"Unsupported LSM: {self.lsm}")
 
@@ -227,7 +227,7 @@ remotevm = sd-log
             raise unittest.SkipTest(f"No enforced AppArmor profiles in {self.vm_name}")
         results = json.loads(self._run("sudo aa-status --json"))
         for profile in self.enforced_apparmor_profiles:
-            self.assertEqual(results["profiles"][profile], "enforce")
+            assert results["profiles"][profile] == "enforce"
 
 
 class SD_Unnamed_DVM_Local_Test(SD_VM_Local_Test):

--- a/tests/base.py
+++ b/tests/base.py
@@ -47,58 +47,66 @@ def get_qubes_version():
     return version
 
 
-# base class for per-VM testing
+class QubeWrapper:
+    def __init__(
+        self,
+        name,
+        expected_config_keys=set(),
+        linux_security_modules="apparmor",
+        enforced_apparmor_profiles=set(),
+    ):
+        """
+        QubesVM test helper.
 
+        Keyword arguments:
+            expected_config_keys -- QubesDB's vm-config expected keys
+            linux_security_modules -- Linux Security Module (LSM) expected
+            enforced_apparmor_profiles -- AppArmor profiles expected
+        """
 
-class SD_VM_Local_Test(unittest.TestCase):
-    def setUp(self):
+        self.name = name
         self.app = Qubes()
-        self.vm = self.app.domains[self.vm_name]
+        self.vm = self.app.domains[self.name]
         if self.vm.is_running():
             pass
         else:
             self.vm.start()
 
-        # A VM shouldn't have any configuration keys it doesn't explicitly
-        # expect.
-        self.expected_config_keys = set()
+        self.expected_config_keys = expected_config_keys
+        self.linux_security_modules = linux_security_modules
+        self.enforced_apparmor_profiles = enforced_apparmor_profiles
 
-        # Which Linux Security Module (LSM) should be enabled
-        self.lsm = "apparmor"
-        # AppArmor profiles that should be enforced.
-        self.enforced_apparmor_profiles = set()
-
-    def _run(self, cmd, user=""):
+    def run(self, cmd, user=""):
         full_cmd = ["qvm-run", "-p"]
         if user:
             full_cmd += ["-u", user]
-        full_cmd += [self.vm_name, cmd]
+        full_cmd += [self.name, cmd]
         return subprocess.check_output(full_cmd).decode("utf-8").strip()
 
-    def _get_file_contents(self, path):
-        cmd = ["qvm-run", "-p", self.vm_name, f"sudo /bin/cat {path}"]
+    def get_file_contents(self, path):
+        cmd = ["qvm-run", "-p", self.name, f"sudo /bin/cat {path}"]
         return subprocess.check_output(cmd).decode("utf-8")
 
-    def _get_symlink_location(self, path):
-        cmd = ["qvm-run", "-p", self.vm_name, f"/usr/bin/readlink -f {path}"]
+    def get_symlink_location(self, path):
+        cmd = ["qvm-run", "-p", self.name, f"/usr/bin/readlink -f {path}"]
         return subprocess.check_output(cmd).decode("utf-8").strip()
 
-    def _package_is_installed(self, pkg):
+    def package_is_installed(self, pkg):
         """
         Confirms that a given package is installed inside the VM.
         """
         # dpkg --verify will exit non-zero for a non-installed pkg,
         # catch that and return False
         try:
-            subprocess.check_call(["qvm-run", "-a", "-q", self.vm_name, f"dpkg --verify {pkg}"])
+            subprocess.check_call(["qvm-run", "-a", "-q", self.name, f"dpkg --verify {pkg}"])
         except subprocess.CalledProcessError:
             return False
 
         return True
 
-    def _service_is_active(self, service):
+    def service_is_active(self, service):
         try:
-            results = self._run(f"sudo systemctl is-active {service}")
+            results = self.run(f"sudo systemctl is-active {service}")
         except subprocess.CalledProcessError as e:
             if e.returncode == 3:
                 return False  # exit code 3 == inactive
@@ -107,7 +115,7 @@ class SD_VM_Local_Test(unittest.TestCase):
         return results == "active"
 
     def assertFileHasLine(self, remote_path, wanted_line):
-        remote_content = self._get_file_contents(remote_path)
+        remote_content = self.get_file_contents(remote_path)
         lines = remote_content.splitlines()
         for line in lines:
             if line == wanted_line:
@@ -115,37 +123,37 @@ class SD_VM_Local_Test(unittest.TestCase):
         msg = f"File {remote_path} does not contain expected line {wanted_line}"
         raise AssertionError(msg)
 
-    def _fileExists(self, remote_path):
+    def fileExists(self, remote_path):
         # ls will return non-zero if the file doesn't exists
         # and error will be propagated to the unittest
         # ls will return non-zero and an exception will be thrown if the file
         # does not exist, so we return false in that case.
         try:
-            subprocess.check_call(["qvm-run", "-a", "-q", self.vm_name, f"ls {remote_path}"])
+            subprocess.check_call(["qvm-run", "-a", "-q", self.name, f"ls {remote_path}"])
         except subprocess.CalledProcessError:
             return False
 
         return True
 
-    def _qubes_service_enabled(self, service):
+    def qubes_service_enabled(self, service):
         """Check whether the named Qubes service is enabled on this
         VM."""
-        return self._fileExists(f"/var/run/qubes-service/{service}")
+        return self.fileExists(f"/var/run/qubes-service/{service}")
 
-    def _vm_config_read(self, key):
+    def vm_config_read(self, key):
         """Read `key` from the QubesDB `/vm-config/` hierarchy and return its
         value if set, otherwise `None`.
         """
         try:
-            return self._run(f"qubesdb-read /vm-config/{key}")
+            return self.run(f"qubesdb-read /vm-config/{key}")
         except subprocess.CalledProcessError:
             return None
 
-    def _vm_config_check(self, expected):
+    def vm_config_check(self, expected):
         """Check that the set of expected by the VM keys equals the set of keys
         actually configured.
         """
-        actual = set(self._run("qubesdb-list /vm-config/").split("\n"))
+        actual = set(self.run("qubesdb-list /vm-config/").split("\n"))
         actual.discard("")  # if "qubesdb-list" returned nothing
         assert actual == set(expected)
 
@@ -154,14 +162,14 @@ class SD_VM_Local_Test(unittest.TestCase):
         Make sure rsyslog is configured to send in data to sd-log vm.
         """
         # Logging is not disabled
-        assert not self._fileExists("/var/run/qubes-service/securedrop-logging-disabled")
+        assert not self.fileExists("/var/run/qubes-service/securedrop-logging-disabled")
 
-        assert self._package_is_installed("securedrop-log")
-        assert self._fileExists("/usr/sbin/sd-rsyslog")
-        assert self._fileExists("/etc/rsyslog.d/sdlog.conf")
-        assert self._fileExists("/etc/sd-rsyslog.conf")
+        assert self.package_is_installed("securedrop-log")
+        assert self.fileExists("/usr/sbin/sd-rsyslog")
+        assert self.fileExists("/etc/rsyslog.d/sdlog.conf")
+        assert self.fileExists("/etc/sd-rsyslog.conf")
         # Then we check the configuration inside of the file.
-        file_content = self._get_file_contents("/etc/sd-rsyslog.conf")
+        file_content = self.get_file_contents("/etc/sd-rsyslog.conf")
         static_content = """[sd-rsyslog]
 remotevm = sd-log
 """
@@ -170,7 +178,7 @@ remotevm = sd-log
         # fail if matching events found
         # Several VMs show this error message even though they're shipping logs,
         # so let's investigate further.
-        # cmd_output = self._run("sudo grep -F \"action 'action-0-omprog' suspended (module 'omprog')\" /var/log/syslog | wc -l").strip()  # noqa
+        # cmd_output = self.run("sudo grep -F \"action 'action-0-omprog' suspended (module 'omprog')\" /var/log/syslog | wc -l").strip()  # noqa
         # assert cmd_output == "0"
 
     def mailcap_hardened(self):
@@ -182,76 +190,51 @@ remotevm = sd-log
         # Ensure that mailcap configuration files are present in the expected
         # locations and contain the expected contents. Rules in `~/.mailcap`
         # take precedence over those in `/etc/mailcap`.
-        assert self._fileExists("/home/user/.mailcap")
-        assert self._fileExists("/opt/sdw/mailcap.default")
+        assert self.fileExists("/home/user/.mailcap")
+        assert self.fileExists("/opt/sdw/mailcap.default")
         self.assertFileHasLine("/home/user/.mailcap", '*/*; logger "Mailcap is disabled."')
 
         # Because we target an AppVM, we cannot easily use the Pyhton tempfile
         # module here without relying on a helper script. Instead, we use the
         # mktemp utility to create a test file with the OpenDocument extension.
-        tmpfile_name = self._run("mktemp -t XXXXXX.odt")
+        tmpfile_name = self.run("mktemp -t XXXXXX.odt")
 
         # The --norun argument ensures that we do not launch any application,
         # regardless of the result of this invocation.
-        mailcap_result = self._run(f"run-mailcap --norun {tmpfile_name}")
+        mailcap_result = self.run(f"run-mailcap --norun {tmpfile_name}")
 
         # For simplicity, we remove the tempfile here instead of in a separate
         # teardown method.
-        self._run(f"rm {tmpfile_name}")
+        self.run(f"rm {tmpfile_name}")
 
         # Ensure that the wildcard rule worked as expected.
         assert mailcap_result == f'logger "Mailcap is disabled." <{tmpfile_name}'
 
-    def test_vm_config_keys(self):
+
+class Test_SD_VM_Local:
+    def test_vm_config_keys(self, qube):
         """Every VM should check that it has only the configuration keys it
         expects.
         """
-        self._vm_config_check(self.expected_config_keys)
+        qube.vm_config_check(qube.expected_config_keys)
 
-    def test_lsm_enabled(self):
+    def test_lsm_enabled(self, qube):
         """Check that the expected LSM is enabled"""
-        if self.lsm == "apparmor":
-            assert self._package_is_installed("apparmor")
+        if qube.linux_security_modules == "apparmor":
+            assert qube.package_is_installed("apparmor")
             # returns error code if AppArmor not enabled
-            self._run("sudo aa-status --enabled")
-        elif self.lsm == "selinux":
-            sestatus = self._run("sudo sestatus")
+            qube.run("sudo aa-status --enabled")
+        elif qube.linux_security_modules == "selinux":
+            sestatus = qube.run("sudo sestatus")
             assert "SELinux status:                 enabled\n" in sestatus
             assert "Current mode:                   enforcing\n" in sestatus
         else:
-            raise ValueError(f"Unsupported LSM: {self.lsm}")
+            raise ValueError(f"Unsupported LSM: {qube.linux_security_modules}")
 
-    def test_enforced_apparmor_profiles(self):
+    def test_enforced_apparmor_profiles(self, qube):
         """Check the expected AppArmor profiles are enforced"""
-        if not self.enforced_apparmor_profiles:
-            raise unittest.SkipTest(f"No enforced AppArmor profiles in {self.vm_name}")
-        results = json.loads(self._run("sudo aa-status --json"))
-        for profile in self.enforced_apparmor_profiles:
+        if not qube.enforced_apparmor_profiles:
+            raise unittest.SkipTest(f"No enforced AppArmor profiles in {qube.name}")
+        results = json.loads(qube.run("sudo aa-status --json"))
+        for profile in qube.enforced_apparmor_profiles:
             assert results["profiles"][profile] == "enforce"
-
-
-class SD_Unnamed_DVM_Local_Test(SD_VM_Local_Test):
-    """Tests disposables based on the provided DVM template"""
-
-    @classmethod
-    def _kill_test_vm(cls):
-        subprocess.run(["qvm-kill", cls.vm_name], check=True)
-
-    @classmethod
-    def setUpClass(cls, dispvm_template_name):
-        cls.app = Qubes()
-        cls.vm_name = f"{dispvm_template_name}-disposable"
-
-        # VM was running and needs a restart to test on the latest version
-        if cls.vm_name in cls.app.domains:
-            cls._kill_test_vm()
-        # Create disposable based on specified template
-        cmd_create_disp = (
-            f"qvm-create --disp --property auto_cleanup=True "
-            f"--template {dispvm_template_name} {cls.vm_name}"
-        )
-        subprocess.run(cmd_create_disp.split(), check=True)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls._kill_test_vm()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import json
+from pathlib import Path
+
+import pytest
+
+PROJ_ROOT = Path(__file__).parent.parent
+
+
+@pytest.fixture
+def dom0_config():
+    """Make the dom0 "config.json" available to tests."""
+    with open(PROJ_ROOT / "config.json") as config_file:
+        return json.load(config_file)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,50 +1,65 @@
-from tests.base import SD_VM_Local_Test
+import pytest
+
+from tests.base import (
+    QubeWrapper,
+    Test_SD_VM_Local,  # noqa: F401 [HACK: import so base tests run]
+)
 
 
-class SD_App_Tests(SD_VM_Local_Test):
-    def setUp(self):
-        self.vm_name = "sd-app"
-        super().setUp()
-        self.expected_config_keys = {
+@pytest.fixture(scope="module")
+def qube():
+    return QubeWrapper(
+        "sd-app",
+        expected_config_keys={
             "QUBES_GPG_DOMAIN",
             "SD_SUBMISSION_KEY_FPR",
             "SD_MIME_HANDLING",
-        }
-        self.enforced_apparmor_profiles = {"/usr/bin/securedrop-client"}
+        },
+        enforced_apparmor_profiles={
+            "/usr/bin/securedrop-client",
+        },
+    )
 
-    def test_open_in_dvm_desktop(self):
-        contents = self._get_file_contents("/usr/share/applications/open-in-dvm.desktop")
-        expected_contents = [
-            "TryExec=/usr/bin/qvm-open-in-vm",
-            "Exec=/usr/bin/qvm-open-in-vm --view-only @dispvm:sd-viewer %f",
-        ]
-        for line in expected_contents:
-            assert line in contents
 
-    def test_mimeapps(self):
-        results = self._run("cat /usr/share/applications/mimeapps.list")
-        for line in results.splitlines():
-            if line.startswith(("#", "[Default")):
-                # Skip comments and the leading [Default Applications]
-                continue
-            mime, target = line.split("=", 1)
-            assert target == "open-in-dvm.desktop;"
-            # Now functionally test it
-            actual_app = self._run(f"xdg-mime query default {mime}")
-            assert actual_app == "open-in-dvm.desktop"
+def test_open_in_dvm_desktop(qube):
+    contents = qube.get_file_contents("/usr/share/applications/open-in-dvm.desktop")
+    expected_contents = [
+        "TryExec=/usr/bin/qvm-open-in-vm",
+        "Exec=/usr/bin/qvm-open-in-vm --view-only @dispvm:sd-viewer %f",
+    ]
+    for line in expected_contents:
+        assert line in contents
 
-    def test_mailcap_hardened(self):
-        self.mailcap_hardened()
 
-    def test_sd_client_package_installed(self):
-        assert self._package_is_installed("securedrop-client")
+def test_mimeapps(qube):
+    results = qube.run("cat /usr/share/applications/mimeapps.list")
+    for line in results.splitlines():
+        if line.startswith(("#", "[Default")):
+            # Skip comments and the leading [Default Applications]
+            continue
+        mime, target = line.split("=", 1)
+        assert target == "open-in-dvm.desktop;"
+        # Now functionally test it
+        actual_app = qube.run(f"xdg-mime query default {mime}")
+        assert actual_app == "open-in-dvm.desktop"
 
-    def test_sd_client_dependencies_installed(self):
-        assert self._package_is_installed("python3-pyqt5")
-        assert self._package_is_installed("python3-pyqt5.qtsvg")
 
-    def test_sd_client_config(self, dom0_config):
-        assert dom0_config["submission_key_fpr"] == self._vm_config_read("SD_SUBMISSION_KEY_FPR")
+def test_mailcap_hardened(qube):
+    qube.mailcap_hardened()
 
-    def test_logging_configured(self):
-        self.logging_configured()
+
+def test_sd_client_package_installed(qube):
+    assert qube.package_is_installed("securedrop-client")
+
+
+def test_sd_client_dependencies_installed(qube):
+    assert qube.package_is_installed("python3-pyqt5")
+    assert qube.package_is_installed("python3-pyqt5.qtsvg")
+
+
+def test_sd_client_config(dom0_config, qube):
+    assert dom0_config["submission_key_fpr"] == qube.vm_config_read("SD_SUBMISSION_KEY_FPR")
+
+
+def test_logging_configured(qube):
+    qube.logging_configured()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,6 @@
 import unittest
 
-from base import SD_VM_Local_Test
+from tests.base import SD_VM_Local_Test
 
 
 class SD_App_Tests(SD_VM_Local_Test):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -43,9 +43,9 @@ class SD_App_Tests(SD_VM_Local_Test):
         self.assertTrue(self._package_is_installed("python3-pyqt5"))
         self.assertTrue(self._package_is_installed("python3-pyqt5.qtsvg"))
 
-    def test_sd_client_config(self):
+    def test_sd_client_config(self, dom0_config):
         self.assertEqual(
-            self.dom0_config["submission_key_fpr"], self._vm_config_read("SD_SUBMISSION_KEY_FPR")
+            dom0_config["submission_key_fpr"], self._vm_config_read("SD_SUBMISSION_KEY_FPR")
         )
 
     def test_logging_configured(self):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,3 @@
-import unittest
-
 from tests.base import SD_VM_Local_Test
 
 
@@ -52,7 +50,3 @@ class SD_App_Tests(SD_VM_Local_Test):
 
     def test_logging_configured(self):
         self.logging_configured()
-
-
-def load_tests(loader, tests, pattern):
-    return unittest.TestLoader().loadTestsFromTestCase(SD_App_Tests)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -19,7 +19,7 @@ class SD_App_Tests(SD_VM_Local_Test):
             "Exec=/usr/bin/qvm-open-in-vm --view-only @dispvm:sd-viewer %f",
         ]
         for line in expected_contents:
-            self.assertIn(line, contents)
+            assert line in contents
 
     def test_mimeapps(self):
         results = self._run("cat /usr/share/applications/mimeapps.list")
@@ -28,25 +28,23 @@ class SD_App_Tests(SD_VM_Local_Test):
                 # Skip comments and the leading [Default Applications]
                 continue
             mime, target = line.split("=", 1)
-            self.assertEqual(target, "open-in-dvm.desktop;")
+            assert target == "open-in-dvm.desktop;"
             # Now functionally test it
             actual_app = self._run(f"xdg-mime query default {mime}")
-            self.assertEqual(actual_app, "open-in-dvm.desktop")
+            assert actual_app == "open-in-dvm.desktop"
 
     def test_mailcap_hardened(self):
         self.mailcap_hardened()
 
     def test_sd_client_package_installed(self):
-        self.assertTrue(self._package_is_installed("securedrop-client"))
+        assert self._package_is_installed("securedrop-client")
 
     def test_sd_client_dependencies_installed(self):
-        self.assertTrue(self._package_is_installed("python3-pyqt5"))
-        self.assertTrue(self._package_is_installed("python3-pyqt5.qtsvg"))
+        assert self._package_is_installed("python3-pyqt5")
+        assert self._package_is_installed("python3-pyqt5.qtsvg")
 
     def test_sd_client_config(self, dom0_config):
-        self.assertEqual(
-            dom0_config["submission_key_fpr"], self._vm_config_read("SD_SUBMISSION_KEY_FPR")
-        )
+        assert dom0_config["submission_key_fpr"] == self._vm_config_read("SD_SUBMISSION_KEY_FPR")
 
     def test_logging_configured(self):
         self.logging_configured()

--- a/tests/test_dom0_rpm_repo.py
+++ b/tests/test_dom0_rpm_repo.py
@@ -53,7 +53,3 @@ class SD_Dom0_Rpm_Repo_Tests(unittest.TestCase):
             found_lines = [x.strip() for x in f.readlines()]
 
         self.assertEqual(found_lines, wanted_lines)
-
-
-def load_tests(loader, tests, pattern):
-    return unittest.TestLoader().loadTestsFromTestCase(SD_Dom0_Rpm_Repo_Tests)

--- a/tests/test_dom0_rpm_repo.py
+++ b/tests/test_dom0_rpm_repo.py
@@ -36,7 +36,7 @@ class SD_Dom0_Rpm_Repo_Tests(unittest.TestCase):
         with open(self.pubkey_wanted) as f:
             pubkey_wanted_contents = f.readlines()
 
-        self.assertEqual(pubkey_actual_contents, pubkey_wanted_contents)
+        assert pubkey_actual_contents == pubkey_wanted_contents
 
     def test_rpm_repo_config(self):
         repo_file = "/etc/yum.repos.d/securedrop-workstation-dom0.repo"
@@ -52,4 +52,4 @@ class SD_Dom0_Rpm_Repo_Tests(unittest.TestCase):
         with open(repo_file) as f:
             found_lines = [x.strip() for x in f.readlines()]
 
-        self.assertEqual(found_lines, wanted_lines)
+        assert found_lines == wanted_lines

--- a/tests/test_dom0_salt_config.py
+++ b/tests/test_dom0_salt_config.py
@@ -17,7 +17,3 @@ class SD_Dom0_Salt_Config_Tests(unittest.TestCase):
 
         except subprocess.CalledProcessError:
             self.fail("Error checking topfiles")
-
-
-def load_tests(loader, tests, pattern):
-    return unittest.TestLoader().loadTestsFromTestCase(SD_Dom0_Salt_Config_Tests)

--- a/tests/test_dom0_validate.py
+++ b/tests/test_dom0_validate.py
@@ -3,6 +3,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import pytest
+
 from files.validate_config import SDWConfigValidator, ValidationError
 
 
@@ -22,10 +24,10 @@ class SD_Dom0_Validate_Tests(unittest.TestCase):
 
     def test_missing_config(self):
         with tempfile.TemporaryDirectory() as dir:
-            with self.assertRaises(ValidationError) as err:  # noqa: PT027
+            with pytest.raises(ValidationError) as exc_info:
                 SDWConfigValidator(dir)
 
-            assert "Config file does not exist" in str(err.exception)
+            assert "Config file does not exist" in exc_info.exconly()
 
     def test_config_malformed_key(self):
         with tempfile.TemporaryDirectory() as dir:
@@ -34,11 +36,11 @@ class SD_Dom0_Validate_Tests(unittest.TestCase):
                 f"{self.test_resources}/files/example_key.asc.malformed", f"{dir}/sd-journalist.sec"
             )
 
-            with self.assertRaises(ValidationError) as err:  # noqa: PT027
+            with pytest.raises(ValidationError) as exc_info:
                 SDWConfigValidator(dir)
 
-            assert "PGP secret key file provided is not an armored private key" in str(
-                err.exception
+            assert (
+                "PGP secret key file provided is not an armored private key" in exc_info.exconly()
             )
 
     def test_config_malformed_onion_json(self):
@@ -48,10 +50,10 @@ class SD_Dom0_Validate_Tests(unittest.TestCase):
             )
             shutil.copy(f"{self.test_resources}/files/example_key.asc", f"{dir}/sd-journalist.sec")
 
-            with self.assertRaises(ValidationError) as err:  # noqa: PT027
+            with pytest.raises(ValidationError) as exc_info:
                 SDWConfigValidator(dir)
 
-            assert "Invalid hidden service hostname specified" in str(err.exception)
+            assert "Invalid hidden service hostname specified" in exc_info.exconly()
 
     def test_config_malformed_fpr_json(self):
         with tempfile.TemporaryDirectory() as dir:
@@ -60,7 +62,7 @@ class SD_Dom0_Validate_Tests(unittest.TestCase):
             )
             shutil.copy(f"{self.test_resources}/files/example_key.asc", f"{dir}/sd-journalist.sec")
 
-            with self.assertRaises(ValidationError) as err:  # noqa: PT027
+            with pytest.raises(ValidationError) as exc_info:
                 SDWConfigValidator(dir)
 
-            assert "Invalid PGP key fingerprint specified" in str(err.exception)
+            assert "Invalid PGP key fingerprint specified" in exc_info.exconly()

--- a/tests/test_dom0_validate.py
+++ b/tests/test_dom0_validate.py
@@ -64,7 +64,3 @@ class SD_Dom0_Validate_Tests(unittest.TestCase):
                 SDWConfigValidator(dir)
 
             assert "Invalid PGP key fingerprint specified" in str(err.exception)
-
-
-def load_tests(loader, tests, pattern):
-    return unittest.TestLoader().loadTestsFromTestCase(SD_Dom0_Validate_Tests)

--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -2,15 +2,23 @@ import re
 import subprocess
 import tempfile
 
+import pytest
+
 from tests.base import SD_VM_Local_Test
+
+
+@pytest.fixture
+def fingerprint(dom0_config):
+    """
+    Obtain the fingerprint explicitly configured in dom0 and injected into VMs.
+    """
+    return dom0_config["submission_key_fpr"]
 
 
 class SD_GPG_Tests(SD_VM_Local_Test):
     def setUp(self):
         self.vm_name = "sd-gpg"
         super().setUp()
-        # Obtain the fingerprint explicitly configured in dom0 and injected into VMs.
-        self.fingerprint = self.dom0_config["submission_key_fpr"]
 
     def get_dom0_fingerprint(self):
         """

--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -1,7 +1,6 @@
 import re
 import subprocess
 import tempfile
-import unittest
 
 from tests.base import SD_VM_Local_Test
 
@@ -49,20 +48,16 @@ class SD_GPG_Tests(SD_VM_Local_Test):
         line = "export QUBES_GPG_AUTOACCEPT=28800"
         self.assertFileHasLine("/home/user/.profile", line)
 
-    def test_local_key_in_remote_keyring(self):
+    def test_local_key_in_remote_keyring(self, fingerprint):
         """Verify the key present in dom0 and sd-gpg matches what's configured in config.json"""
         local_fp = self.get_dom0_fingerprint()
         remote_fp = self.get_vm_fingerprint()
 
         # This also verifies only one secret key is in the keyring
-        self.assertEqual(local_fp, [self.fingerprint])
-        self.assertEqual(remote_fp, [self.fingerprint])
+        self.assertEqual(local_fp, [fingerprint])
+        self.assertEqual(remote_fp, [fingerprint])
 
     def test_logging_disabled(self):
         # Logging to sd-log should be disabled on sd-gpg
         self.assertFalse(self._fileExists("/etc/rsyslog.d/sdlog.conf"))
         self.assertTrue(self._fileExists("/var/run/qubes-service/securedrop-logging-disabled"))
-
-
-def load_tests(loader, tests, pattern):
-    return unittest.TestLoader().loadTestsFromTestCase(SD_GPG_Tests)

--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -3,7 +3,7 @@ import subprocess
 import tempfile
 import unittest
 
-from base import SD_VM_Local_Test
+from tests.base import SD_VM_Local_Test
 
 
 class SD_GPG_Tests(SD_VM_Local_Test):

--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -62,10 +62,10 @@ class SD_GPG_Tests(SD_VM_Local_Test):
         remote_fp = self.get_vm_fingerprint()
 
         # This also verifies only one secret key is in the keyring
-        self.assertEqual(local_fp, [fingerprint])
-        self.assertEqual(remote_fp, [fingerprint])
+        assert local_fp == [fingerprint]
+        assert remote_fp == [fingerprint]
 
     def test_logging_disabled(self):
         # Logging to sd-log should be disabled on sd-gpg
-        self.assertFalse(self._fileExists("/etc/rsyslog.d/sdlog.conf"))
-        self.assertTrue(self._fileExists("/var/run/qubes-service/securedrop-logging-disabled"))
+        assert not self._fileExists("/etc/rsyslog.d/sdlog.conf")
+        assert self._fileExists("/var/run/qubes-service/securedrop-logging-disabled")

--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -4,68 +4,78 @@ import tempfile
 
 import pytest
 
-from tests.base import SD_VM_Local_Test
+from tests.base import (
+    QubeWrapper,
+    Test_SD_VM_Local,  # noqa: F401 [HACK: import so base tests run]
+)
+
+
+@pytest.fixture(scope="module")
+def qube():
+    return QubeWrapper("sd-gpg")
+
+
+def _extract_fingerprints(gpg_output):
+    """Helper method to extract fingerprints from GPG command output"""
+    return re.findall(r"[A-F0-9]{40}", gpg_output.decode())
 
 
 @pytest.fixture
-def fingerprint(dom0_config):
+def config_fingerprint(dom0_config):
     """
     Obtain the fingerprint explicitly configured in dom0 and injected into VMs.
     """
     return dom0_config["submission_key_fpr"]
 
 
-class SD_GPG_Tests(SD_VM_Local_Test):
-    def setUp(self):
-        self.vm_name = "sd-gpg"
-        super().setUp()
+@pytest.fixture
+def dom0_fingerprint():
+    """
+    Obtain the fingerprint of the key actually present in dom0.
+    """
+    with tempfile.TemporaryDirectory() as d:
+        gpg_env = {"GNUPGHOME": d}
+        subprocess.check_call(
+            ["gpg", "--import", "sd-journalist.sec"],
+            env=gpg_env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        local_results = subprocess.check_output(["gpg", "--list-secret-keys"], env=gpg_env)
+        return _extract_fingerprints(local_results)
 
-    def get_dom0_fingerprint(self):
-        """
-        Obtain the fingerprint of the key actually present in dom0.
-        """
-        with tempfile.TemporaryDirectory() as d:
-            gpg_env = {"GNUPGHOME": d}
-            subprocess.check_call(
-                ["gpg", "--import", "sd-journalist.sec"],
-                env=gpg_env,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-            )
-            local_results = subprocess.check_output(["gpg", "--list-secret-keys"], env=gpg_env)
-            return self._extract_fingerprints(local_results)
 
-    def get_vm_fingerprint(self):
-        """
-        Obtain fingerprints for all keys actually present in GPG VM
-        """
-        cmd = [
-            "qvm-run",
-            "-p",
-            self.vm_name,
-            "/usr/bin/gpg --list-secret-keys",
-        ]
-        remote_results = subprocess.check_output(cmd)
-        return self._extract_fingerprints(remote_results)
+@pytest.fixture
+def vm_fingerprint(qube):
+    """
+    Obtain fingerprints for all keys actually present in GPG VM
+    """
+    cmd = [
+        "qvm-run",
+        "-p",
+        qube.name,
+        "/usr/bin/gpg --list-secret-keys",
+    ]
+    remote_results = subprocess.check_output(cmd)
+    return _extract_fingerprints(remote_results)
 
-    def _extract_fingerprints(self, gpg_output):
-        """Helper method to extract fingerprints from GPG command output"""
-        return re.findall(r"[A-F0-9]{40}", gpg_output.decode())
 
-    def test_sd_gpg_timeout(self):
-        line = "export QUBES_GPG_AUTOACCEPT=28800"
-        self.assertFileHasLine("/home/user/.profile", line)
+def test_sd_gpg_timeout(qube):
+    line = "export QUBES_GPG_AUTOACCEPT=28800"
+    qube.assertFileHasLine("/home/user/.profile", line)
 
-    def test_local_key_in_remote_keyring(self, fingerprint):
-        """Verify the key present in dom0 and sd-gpg matches what's configured in config.json"""
-        local_fp = self.get_dom0_fingerprint()
-        remote_fp = self.get_vm_fingerprint()
 
-        # This also verifies only one secret key is in the keyring
-        assert local_fp == [fingerprint]
-        assert remote_fp == [fingerprint]
+def test_local_key_in_remote_keyring(config_fingerprint, dom0_fingerprint, vm_fingerprint):
+    """
+    Verify the key present in dom0 and sd-gpg matches what's configured in config.json
 
-    def test_logging_disabled(self):
-        # Logging to sd-log should be disabled on sd-gpg
-        assert not self._fileExists("/etc/rsyslog.d/sdlog.conf")
-        assert self._fileExists("/var/run/qubes-service/securedrop-logging-disabled")
+    This also verifies only one secret key is in the keyring.
+    """
+    assert dom0_fingerprint == [config_fingerprint]
+    assert vm_fingerprint == [config_fingerprint]
+
+
+def test_logging_disabled(qube):
+    # Logging to sd-log should be disabled on sd-gpg
+    assert not qube.fileExists("/etc/rsyslog.d/sdlog.conf")
+    assert qube.fileExists("/var/run/qubes-service/securedrop-logging-disabled")

--- a/tests/test_log_vm.py
+++ b/tests/test_log_vm.py
@@ -11,24 +11,24 @@ class SD_Log_Tests(SD_VM_Local_Test):
         super().setUp()
 
     def test_sd_log_package_installed(self):
-        self.assertTrue(self._package_is_installed("securedrop-log"))
+        assert self._package_is_installed("securedrop-log")
 
     def test_sd_log_redis_is_installed(self):
-        self.assertTrue(self._package_is_installed("redis"))
-        self.assertTrue(self._package_is_installed("redis-server"))
+        assert self._package_is_installed("redis")
+        assert self._package_is_installed("redis-server")
 
     def test_log_utility_installed(self):
-        self.assertTrue(self._fileExists("/usr/sbin/securedrop-log-saver"))
-        self.assertTrue(self._fileExists("/etc/qubes-rpc/securedrop.Log"))
+        assert self._fileExists("/usr/sbin/securedrop-log-saver")
+        assert self._fileExists("/etc/qubes-rpc/securedrop.Log")
 
     def test_sd_log_has_no_custom_rsyslog(self):
-        self.assertFalse(self._fileExists("/etc/rsyslog.d/sdlog.conf"))
+        assert not self._fileExists("/etc/rsyslog.d/sdlog.conf")
 
     def test_sd_log_service_running(self):
-        self.assertTrue(self._service_is_active("securedrop-log-server"))
+        assert self._service_is_active("securedrop-log-server")
 
     def test_redis_service_running(self):
-        self.assertTrue(self._service_is_active("redis"))
+        assert self._service_is_active("redis")
 
     def test_logs_are_flowing(self):
         """
@@ -60,12 +60,12 @@ class SD_Log_Tests(SD_VM_Local_Test):
                 continue
             syslog = f"/home/user/QubesIncomingLogs/{vm_name}/syslog.log"
             if vm_name in no_log_vms:
-                self.assertFalse(self._fileExists(syslog))
+                assert not self._fileExists(syslog)
             else:
-                self.assertIn(token, self._get_file_contents(syslog))
+                assert token in self._get_file_contents(syslog)
 
     def test_log_dirs_properly_named(self):
         cmd_output = self._run("ls -1 /home/user/QubesIncomingLogs")
         log_dirs = cmd_output.split("\n")
         # Confirm we don't have 'host' entries from Whonix VMs
-        self.assertNotIn("host", log_dirs)
+        assert "host" not in log_dirs

--- a/tests/test_log_vm.py
+++ b/tests/test_log_vm.py
@@ -3,7 +3,7 @@ import string
 import subprocess
 import unittest
 
-from base import CURRENT_DEBIAN_VERSION, SD_VM_Local_Test
+from tests.base import CURRENT_DEBIAN_VERSION, SD_VM_Local_Test
 
 
 class SD_Log_Tests(SD_VM_Local_Test):

--- a/tests/test_log_vm.py
+++ b/tests/test_log_vm.py
@@ -1,7 +1,6 @@
 import secrets
 import string
 import subprocess
-import unittest
 
 from tests.base import CURRENT_DEBIAN_VERSION, SD_VM_Local_Test
 
@@ -70,7 +69,3 @@ class SD_Log_Tests(SD_VM_Local_Test):
         log_dirs = cmd_output.split("\n")
         # Confirm we don't have 'host' entries from Whonix VMs
         self.assertNotIn("host", log_dirs)
-
-
-def load_tests(loader, tests, pattern):
-    return unittest.TestLoader().loadTestsFromTestCase(SD_Log_Tests)

--- a/tests/test_log_vm.py
+++ b/tests/test_log_vm.py
@@ -2,70 +2,83 @@ import secrets
 import string
 import subprocess
 
-from tests.base import CURRENT_DEBIAN_VERSION, SD_VM_Local_Test
+import pytest
+
+from tests.base import (
+    CURRENT_DEBIAN_VERSION,
+    QubeWrapper,
+    Test_SD_VM_Local,  # noqa: F401 [HACK: import so base tests run]
+)
 
 
-class SD_Log_Tests(SD_VM_Local_Test):
-    def setUp(self):
-        self.vm_name = "sd-log"
-        super().setUp()
+@pytest.fixture(scope="module")
+def qube():
+    return QubeWrapper("sd-log")
 
-    def test_sd_log_package_installed(self):
-        assert self._package_is_installed("securedrop-log")
 
-    def test_sd_log_redis_is_installed(self):
-        assert self._package_is_installed("redis")
-        assert self._package_is_installed("redis-server")
+def test_sd_log_package_installed(qube):
+    assert qube.package_is_installed("securedrop-log")
 
-    def test_log_utility_installed(self):
-        assert self._fileExists("/usr/sbin/securedrop-log-saver")
-        assert self._fileExists("/etc/qubes-rpc/securedrop.Log")
 
-    def test_sd_log_has_no_custom_rsyslog(self):
-        assert not self._fileExists("/etc/rsyslog.d/sdlog.conf")
+def test_sd_log_redis_is_installed(qube):
+    assert qube.package_is_installed("redis")
+    assert qube.package_is_installed("redis-server")
 
-    def test_sd_log_service_running(self):
-        assert self._service_is_active("securedrop-log-server")
 
-    def test_redis_service_running(self):
-        assert self._service_is_active("redis")
+def test_log_utility_installed(qube):
+    assert qube.fileExists("/usr/sbin/securedrop-log-saver")
+    assert qube.fileExists("/etc/qubes-rpc/securedrop.Log")
 
-    def test_logs_are_flowing(self):
-        """
-        To test that logs work, we run a unique command in each VM we care
-        about that gets logged, and then check for that string in the logs.
-        """
-        # Random string, to avoid collisions with other test runs
-        token = "".join(secrets.choice(string.ascii_uppercase) for _ in range(10))
 
-        # All @tag:sd-workstation VMs
-        all_vms = [vm.name for vm in self.app.domains if "sd-workstation" in vm.tags]
-        # base template doesn't have sd-log configured
-        # TODO: test a sd-viewer based dispVM
-        skip = [f"sd-base-{CURRENT_DEBIAN_VERSION}-template", "sd-viewer"]
-        # VMs we expect logs will not go to
-        no_log_vms = ["sd-gpg", "sd-log", "sd-whonix"]
+def test_sd_log_has_no_custom_rsyslog(qube):
+    assert not qube.fileExists("/etc/rsyslog.d/sdlog.conf")
 
-        # We first run the command in each VM, and then do a second loop to
-        # look for the token in the log entry, so there's enough time for the
-        # log entry to get written.
-        for vm_name in all_vms:
-            if vm_name in skip:
-                continue
-            # The sudo call will make it into syslog
-            subprocess.check_call(["qvm-run", vm_name, f"sudo echo {token}"])
 
-        for vm_name in all_vms:
-            if vm_name in skip:
-                continue
-            syslog = f"/home/user/QubesIncomingLogs/{vm_name}/syslog.log"
-            if vm_name in no_log_vms:
-                assert not self._fileExists(syslog)
-            else:
-                assert token in self._get_file_contents(syslog)
+def test_sd_log_service_running(qube):
+    assert qube.service_is_active("securedrop-log-server")
 
-    def test_log_dirs_properly_named(self):
-        cmd_output = self._run("ls -1 /home/user/QubesIncomingLogs")
-        log_dirs = cmd_output.split("\n")
-        # Confirm we don't have 'host' entries from Whonix VMs
-        assert "host" not in log_dirs
+
+def test_redis_service_running(qube):
+    assert qube.service_is_active("redis")
+
+
+def test_logs_are_flowing(qube):
+    """
+    To test that logs work, we run a unique command in each VM we care
+    about that gets logged, and then check for that string in the logs.
+    """
+    # Random string, to avoid collisions with other test runs
+    token = "".join(secrets.choice(string.ascii_uppercase) for _ in range(10))
+
+    # All @tag:sd-workstation VMs
+    all_vms = [vm.name for vm in qube.app.domains if "sd-workstation" in vm.tags]
+    # base template doesn't have sd-log configured
+    # TODO: test a sd-viewer based dispVM
+    skip = [f"sd-base-{CURRENT_DEBIAN_VERSION}-template", "sd-viewer"]
+    # VMs we expect logs will not go to
+    no_log_vms = ["sd-gpg", "sd-log", "sd-whonix"]
+
+    # We first run the command in each VM, and then do a second loop to
+    # look for the token in the log entry, so there's enough time for the
+    # log entry to get written.
+    for vm_name in all_vms:
+        if vm_name in skip:
+            continue
+        # The sudo call will make it into syslog
+        subprocess.check_call(["qvm-run", vm_name, f"sudo echo {token}"])
+
+    for vm_name in all_vms:
+        if vm_name in skip:
+            continue
+        syslog = f"/home/user/QubesIncomingLogs/{vm_name}/syslog.log"
+        if vm_name in no_log_vms:
+            assert not qube.fileExists(syslog)
+        else:
+            assert token in qube.get_file_contents(syslog)
+
+
+def test_log_dirs_properly_named(qube):
+    cmd_output = qube.run("ls -1 /home/user/QubesIncomingLogs")
+    log_dirs = cmd_output.split("\n")
+    # Confirm we don't have 'host' entries from Whonix VMs
+    assert "host" not in log_dirs

--- a/tests/test_proxy_vm.py
+++ b/tests/test_proxy_vm.py
@@ -18,9 +18,9 @@ class SD_Proxy_Tests(SD_VM_Local_Test):
     def test_sd_proxy_package_installed(self):
         self.assertTrue(self._package_is_installed("securedrop-proxy"))
 
-    def test_sd_proxy_config(self):
+    def test_sd_proxy_config(self, dom0_config):
         self.assertEqual(
-            f"http://{self.dom0_config['hidserv']['hostname']}",
+            f"http://{dom0_config['hidserv']['hostname']}",
             self._vm_config_read("SD_PROXY_ORIGIN"),
         )
 

--- a/tests/test_proxy_vm.py
+++ b/tests/test_proxy_vm.py
@@ -1,6 +1,6 @@
 import unittest
 
-from base import SD_VM_Local_Test
+from tests.base import SD_VM_Local_Test
 
 
 class SD_Proxy_Tests(SD_VM_Local_Test):

--- a/tests/test_proxy_vm.py
+++ b/tests/test_proxy_vm.py
@@ -1,5 +1,3 @@
-import unittest
-
 from tests.base import SD_VM_Local_Test
 
 
@@ -54,7 +52,3 @@ class SD_Proxy_Tests(SD_VM_Local_Test):
 
     def test_mailcap_hardened(self):
         self.mailcap_hardened()
-
-
-def load_tests(loader, tests, pattern):
-    return unittest.TestLoader().loadTestsFromTestCase(SD_Proxy_Tests)

--- a/tests/test_proxy_vm.py
+++ b/tests/test_proxy_vm.py
@@ -16,12 +16,11 @@ class SD_Proxy_Tests(SD_VM_Local_Test):
         assert not self._fileExists("/usr/bin/do-not-open-here")
 
     def test_sd_proxy_package_installed(self):
-        self.assertTrue(self._package_is_installed("securedrop-proxy"))
+        assert self._package_is_installed("securedrop-proxy")
 
     def test_sd_proxy_config(self, dom0_config):
-        self.assertEqual(
-            f"http://{dom0_config['hidserv']['hostname']}",
-            self._vm_config_read("SD_PROXY_ORIGIN"),
+        assert f"http://{dom0_config['hidserv']['hostname']}" == self._vm_config_read(
+            "SD_PROXY_ORIGIN"
         )
 
     def test_whonix_ws_repo_absent(self):
@@ -45,10 +44,10 @@ class SD_Proxy_Tests(SD_VM_Local_Test):
                 # Skip comments and the leading [Default Applications]
                 continue
             mime, target = line.split("=", 1)
-            self.assertEqual(target, "open-in-dvm.desktop;")
+            assert target == "open-in-dvm.desktop;"
             # Now functionally test it
             actual_app = self._run(f"xdg-mime query default {mime}")
-            self.assertEqual(actual_app, "open-in-dvm.desktop")
+            assert actual_app == "open-in-dvm.desktop"
 
     def test_mailcap_hardened(self):
         self.mailcap_hardened()

--- a/tests/test_qubes_rpc.py
+++ b/tests/test_qubes_rpc.py
@@ -42,37 +42,31 @@ class SD_Qubes_Rpc_Tests(unittest.TestCase):
         vms_with_tag, _ = self._get_running_vms_with_and_without_tag("sd-workstation")
         for vm in vms_with_tag:
             if vm != "sd-log":
-                self.assertEqual(self._qrexec(vm, "sd-log", "securedrop.Log"), RETURNCODE_SUCCESS)
+                assert self._qrexec(vm, "sd-log", "securedrop.Log") == RETURNCODE_SUCCESS
 
     # securedrop.Log from anything else to sd-log should be denied
     def test_sdlog_from_other_to_sdlog_denied(self):
         _, vms_without_tag = self._get_running_vms_with_and_without_tag("sd-workstation")
         for vm in vms_without_tag:
             if vm != "sd-log":
-                self.assertEqual(self._qrexec(vm, "sd-log", "securedrop.Log"), RETURNCODE_DENIED)
+                assert self._qrexec(vm, "sd-log", "securedrop.Log") == RETURNCODE_DENIED
 
     # securedrop.Proxy from sd-app to sd-proxy should be allowed
     def test_sdproxy_from_sdapp_to_sdproxy_allowed(self):
         # proxy RPC returns an error due to malformed input, but it still goes through
         # (i.e. not DENIED)
-        self.assertEqual(self._qrexec("sd-app", "sd-proxy", "securedrop.Proxy"), RETURNCODE_ERROR)
+        assert self._qrexec("sd-app", "sd-proxy", "securedrop.Proxy") == RETURNCODE_ERROR
 
     # securedrop.Proxy from anything else to sd-proxy should be denied
     def test_sdproxy_from_other_to_sdproxy_denied(self):
-        self.assertEqual(self._qrexec("sys-net", "sd-proxy", "securedrop.Proxy"), RETURNCODE_DENIED)
-        self.assertEqual(
-            self._qrexec("sys-firewall", "sd-proxy", "securedrop.Proxy"),
-            RETURNCODE_DENIED,
-        )
+        assert self._qrexec("sys-net", "sd-proxy", "securedrop.Proxy") == RETURNCODE_DENIED
+        assert self._qrexec("sys-firewall", "sd-proxy", "securedrop.Proxy") == RETURNCODE_DENIED
 
     # qubes.Gpg, qubes.GpgImportKey, and qubes.Gpg2 from anything else to sd-gpg should be denied
     def test_qubesgpg_from_other_to_sdgpg_denied(self):
-        self.assertEqual(self._qrexec("sys-net", "sd-gpg", "qubes.Gpg"), RETURNCODE_DENIED)
-        self.assertEqual(self._qrexec("sys-firewall", "sd-gpg", "qubes.Gpg"), RETURNCODE_DENIED)
-        self.assertEqual(self._qrexec("sys-net", "sd-gpg", "qubes.GpgImportKey"), RETURNCODE_DENIED)
-        self.assertEqual(
-            self._qrexec("sys-firewall", "sd-gpg", "qubes.GpgImportKey"),
-            RETURNCODE_DENIED,
-        )
-        self.assertEqual(self._qrexec("sys-net", "sd-gpg", "qubes.Gpg2"), RETURNCODE_DENIED)
-        self.assertEqual(self._qrexec("sys-firewall", "sd-gpg", "qubes.Gpg2"), RETURNCODE_DENIED)
+        assert self._qrexec("sys-net", "sd-gpg", "qubes.Gpg") == RETURNCODE_DENIED
+        assert self._qrexec("sys-firewall", "sd-gpg", "qubes.Gpg") == RETURNCODE_DENIED
+        assert self._qrexec("sys-net", "sd-gpg", "qubes.GpgImportKey") == RETURNCODE_DENIED
+        assert self._qrexec("sys-firewall", "sd-gpg", "qubes.GpgImportKey") == RETURNCODE_DENIED
+        assert self._qrexec("sys-net", "sd-gpg", "qubes.Gpg2") == RETURNCODE_DENIED
+        assert self._qrexec("sys-firewall", "sd-gpg", "qubes.Gpg2") == RETURNCODE_DENIED

--- a/tests/test_qubes_rpc.py
+++ b/tests/test_qubes_rpc.py
@@ -76,7 +76,3 @@ class SD_Qubes_Rpc_Tests(unittest.TestCase):
         )
         self.assertEqual(self._qrexec("sys-net", "sd-gpg", "qubes.Gpg2"), RETURNCODE_DENIED)
         self.assertEqual(self._qrexec("sys-firewall", "sd-gpg", "qubes.Gpg2"), RETURNCODE_DENIED)
-
-
-def load_tests(loader, tests, pattern):
-    return unittest.TestLoader().loadTestsFromTestCase(SD_Qubes_Rpc_Tests)

--- a/tests/test_qubes_vms.py
+++ b/tests/test_qubes_vms.py
@@ -1,7 +1,8 @@
 import unittest
 
-from base import CURRENT_FEDORA_DVM, CURRENT_FEDORA_TEMPLATE, CURRENT_WHONIX_VERSION
 from qubesadmin import Qubes
+
+from tests.base import CURRENT_FEDORA_DVM, CURRENT_FEDORA_TEMPLATE, CURRENT_WHONIX_VERSION
 
 
 class SD_Qubes_VM_Tests(unittest.TestCase):

--- a/tests/test_qubes_vms.py
+++ b/tests/test_qubes_vms.py
@@ -52,7 +52,3 @@ class SD_Qubes_VM_Tests(unittest.TestCase):
             vm = self.app.domains[whonix_vm]
             self.assertTrue(vm.template.name.startswith("whonix-"))
             self.assertTrue(vm.template.name.endswith("-" + CURRENT_WHONIX_VERSION))
-
-
-def load_tests(loader, tests, pattern):
-    return unittest.TestLoader().loadTestsFromTestCase(SD_Qubes_VM_Tests)

--- a/tests/test_qubes_vms.py
+++ b/tests/test_qubes_vms.py
@@ -35,11 +35,10 @@ class SD_Qubes_VM_Tests(unittest.TestCase):
                 else:
                     wanted_templates.append(CURRENT_FEDORA_DVM)
 
-            self.assertTrue(
-                vm.template.name in wanted_templates,
+            assert vm.template.name in wanted_templates, (
                 f"Unexpected template for {sys_vm}\n"
                 + f"Current: {vm.template.name}\n"
-                + "Expected: {}".format(", ".join(wanted_templates)),
+                + "Expected: {}".format(", ".join(wanted_templates))
             )
 
     def test_current_whonix_vms(self):
@@ -50,5 +49,5 @@ class SD_Qubes_VM_Tests(unittest.TestCase):
         whonix_vms = ["sys-whonix", "anon-whonix"]
         for whonix_vm in whonix_vms:
             vm = self.app.domains[whonix_vm]
-            self.assertTrue(vm.template.name.startswith("whonix-"))
-            self.assertTrue(vm.template.name.endswith("-" + CURRENT_WHONIX_VERSION))
+            assert vm.template.name.startswith("whonix-")
+            assert vm.template.name.endswith("-" + CURRENT_WHONIX_VERSION)

--- a/tests/test_sd_devices.py
+++ b/tests/test_sd_devices.py
@@ -10,14 +10,14 @@ class SD_Devices_Tests(SD_VM_Local_Test):
         self.expected_config_keys = {"SD_MIME_HANDLING"}
 
     def test_files_are_properly_copied(self):
-        self.assertTrue(self._fileExists("/usr/bin/send-to-usb"))
-        self.assertTrue(self._fileExists("/usr/share/applications/send-to-usb.desktop"))
-        self.assertTrue(self._fileExists("/usr/share/mime/packages/application-x-sd-export.xml"))
+        assert self._fileExists("/usr/bin/send-to-usb")
+        assert self._fileExists("/usr/share/applications/send-to-usb.desktop")
+        assert self._fileExists("/usr/share/mime/packages/application-x-sd-export.xml")
 
     def test_sd_export_package_installed(self):
-        self.assertTrue(self._package_is_installed("udisks2"))
-        self.assertTrue(self._package_is_installed("securedrop-export"))
-        self.assertTrue(self._package_is_installed("gnome-disk-utility"))
+        assert self._package_is_installed("udisks2")
+        assert self._package_is_installed("securedrop-export")
+        assert self._package_is_installed("gnome-disk-utility")
 
     def test_logging_configured(self):
         self.logging_configured()
@@ -33,7 +33,7 @@ class SD_Devices_Tests(SD_VM_Local_Test):
                     mime_type = line.split("=")[0]
                     expected_app = line.split("=")[1].split(";")[0]
                     actual_app = self._run(f"xdg-mime query default {mime_type}")
-                    self.assertEqual(actual_app, expected_app)
+                    assert actual_app == expected_app
 
     def test_mailcap_hardened(self):
         self.mailcap_hardened()
@@ -45,4 +45,4 @@ class SD_Devices_Tests(SD_VM_Local_Test):
             "Exec=/usr/bin/qvm-open-in-vm --view-only @dispvm:sd-viewer %f",
         ]
         for line in expected_contents:
-            self.assertIn(line, contents)
+            assert line in contents

--- a/tests/test_sd_devices.py
+++ b/tests/test_sd_devices.py
@@ -1,5 +1,4 @@
 import os
-import unittest
 
 from tests.base import SD_VM_Local_Test
 
@@ -47,7 +46,3 @@ class SD_Devices_Tests(SD_VM_Local_Test):
         ]
         for line in expected_contents:
             self.assertIn(line, contents)
-
-
-def load_tests(loader, tests, pattern):
-    return unittest.TestLoader().loadTestsFromTestCase(SD_Devices_Tests)

--- a/tests/test_sd_devices.py
+++ b/tests/test_sd_devices.py
@@ -1,48 +1,57 @@
 import os
 
-from tests.base import SD_VM_Local_Test
+import pytest
+
+from tests.base import (
+    QubeWrapper,
+    Test_SD_VM_Local,  # noqa: F401 [HACK: import so base tests run]
+)
 
 
-class SD_Devices_Tests(SD_VM_Local_Test):
-    def setUp(self):
-        self.vm_name = "sd-devices"
-        super().setUp()
-        self.expected_config_keys = {"SD_MIME_HANDLING"}
+@pytest.fixture(scope="module")
+def qube():
+    return QubeWrapper("sd-devices", expected_config_keys={"SD_MIME_HANDLING"})
 
-    def test_files_are_properly_copied(self):
-        assert self._fileExists("/usr/bin/send-to-usb")
-        assert self._fileExists("/usr/share/applications/send-to-usb.desktop")
-        assert self._fileExists("/usr/share/mime/packages/application-x-sd-export.xml")
 
-    def test_sd_export_package_installed(self):
-        assert self._package_is_installed("udisks2")
-        assert self._package_is_installed("securedrop-export")
-        assert self._package_is_installed("gnome-disk-utility")
+def test_files_are_properly_copied(qube):
+    assert qube.fileExists("/usr/bin/send-to-usb")
+    assert qube.fileExists("/usr/share/applications/send-to-usb.desktop")
+    assert qube.fileExists("/usr/share/mime/packages/application-x-sd-export.xml")
 
-    def test_logging_configured(self):
-        self.logging_configured()
 
-    def test_mime_types(self):
-        filepath = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), "vars", "sd-devices.mimeapps"
-        )
-        with open(filepath) as f:
-            lines = f.readlines()
-            for line in lines:
-                if line != "[Default Applications]\n" and not line.startswith("#"):
-                    mime_type = line.split("=")[0]
-                    expected_app = line.split("=")[1].split(";")[0]
-                    actual_app = self._run(f"xdg-mime query default {mime_type}")
-                    assert actual_app == expected_app
+def test_sd_export_package_installed(qube):
+    assert qube.package_is_installed("udisks2")
+    assert qube.package_is_installed("securedrop-export")
+    assert qube.package_is_installed("gnome-disk-utility")
 
-    def test_mailcap_hardened(self):
-        self.mailcap_hardened()
 
-    def test_open_in_dvm_desktop(self):
-        contents = self._get_file_contents("/usr/share/applications/open-in-dvm.desktop")
-        expected_contents = [
-            "TryExec=/usr/bin/qvm-open-in-vm",
-            "Exec=/usr/bin/qvm-open-in-vm --view-only @dispvm:sd-viewer %f",
-        ]
-        for line in expected_contents:
-            assert line in contents
+def test_logging_configured(qube):
+    qube.logging_configured()
+
+
+def test_mime_types(qube):
+    filepath = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "vars", "sd-devices.mimeapps"
+    )
+    with open(filepath) as f:
+        lines = f.readlines()
+        for line in lines:
+            if line != "[Default Applications]\n" and not line.startswith("#"):
+                mime_type = line.split("=")[0]
+                expected_app = line.split("=")[1].split(";")[0]
+                actual_app = qube.run(f"xdg-mime query default {mime_type}")
+                assert actual_app == expected_app
+
+
+def test_mailcap_hardened(qube):
+    qube.mailcap_hardened()
+
+
+def test_open_in_dvm_desktop(qube):
+    contents = qube.get_file_contents("/usr/share/applications/open-in-dvm.desktop")
+    expected_contents = [
+        "TryExec=/usr/bin/qvm-open-in-vm",
+        "Exec=/usr/bin/qvm-open-in-vm --view-only @dispvm:sd-viewer %f",
+    ]
+    for line in expected_contents:
+        assert line in contents

--- a/tests/test_sd_devices.py
+++ b/tests/test_sd_devices.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-from base import SD_VM_Local_Test
+from tests.base import SD_VM_Local_Test
 
 
 class SD_Devices_Tests(SD_VM_Local_Test):

--- a/tests/test_sd_whonix.py
+++ b/tests/test_sd_whonix.py
@@ -1,47 +1,60 @@
-from tests.base import SD_VM_Local_Test
+import pytest
+
+from tests.base import (
+    QubeWrapper,
+    Test_SD_VM_Local,  # noqa: F401 [HACK: import so base tests run]
+)
 
 
-class SD_Whonix_Tests(SD_VM_Local_Test):
-    def setUp(self):
-        self.vm_name = "sd-whonix"
-        self.whonix_apt_list = "/etc/apt/sources.list.d/derivative.list"
-        super().setUp()
-        self.expected_config_keys = {"SD_HIDSERV_HOSTNAME", "SD_HIDSERV_KEY"}
+@pytest.fixture
+def whonix_apt_list():
+    return "/etc/apt/sources.list.d/derivative.list"
 
-    def test_sd_whonix_config_enabled(self):
-        assert self._qubes_service_enabled("securedrop-whonix-config")
 
-    def test_sd_whonix_config(self, dom0_config):
-        assert dom0_config["hidserv"]["hostname"] == self._vm_config_read("SD_HIDSERV_HOSTNAME")
-        assert dom0_config["hidserv"]["key"] == self._vm_config_read("SD_HIDSERV_KEY")
+@pytest.fixture(scope="module")
+def qube():
+    return QubeWrapper("sd-whonix", expected_config_keys={"SD_HIDSERV_HOSTNAME", "SD_HIDSERV_KEY"})
 
-    def test_v3_auth_private_file(self):
-        hidserv_hostname = self._vm_config_read("SD_HIDSERV_HOSTNAME")
-        hidserv_key = self._vm_config_read("SD_HIDSERV_KEY")
-        line = f"{hidserv_hostname}:descriptor:x25519:{hidserv_key}"
 
-        self.assertFileHasLine("/var/lib/tor/authdir/app-journalist.auth_private", line)
+def test_sd_whonix_config_enabled(qube):
+    assert qube.qubes_service_enabled("securedrop-whonix-config")
 
-    def test_sd_whonix_repo_enabled(self):
-        """
-        During Whonix 14 -> 15 migration, we removed the apt list file
-        (because the repo wasn't serving, due to EOL status). Let's
-        make sure it's there, since we're past 14 now.
-        """
-        assert self._fileExists(self.whonix_apt_list)
 
-    def test_sd_whonix_verify_tor_config(self):
-        # User must be debian-tor for v3 Onion, due to restrictive
-        # mode on the client keys directory.
-        self._run("tor --verify-config", user="debian-tor")
+def test_sd_whonix_config(qube, dom0_config):
+    assert dom0_config["hidserv"]["hostname"] == qube.vm_config_read("SD_HIDSERV_HOSTNAME")
+    assert dom0_config["hidserv"]["key"] == qube.vm_config_read("SD_HIDSERV_KEY")
 
-    def test_whonix_torrc(self):
-        """
-        Ensure Whonix-maintained torrc files don't contain duplicate entries.
-        """
-        torrc_contents = self._get_file_contents("/etc/tor/torrc")
-        duplicate_includes = """%include /etc/torrc.d/
+
+def test_v3_auth_private_file(qube):
+    hidserv_hostname = qube.vm_config_read("SD_HIDSERV_HOSTNAME")
+    hidserv_key = qube.vm_config_read("SD_HIDSERV_KEY")
+    line = f"{hidserv_hostname}:descriptor:x25519:{hidserv_key}"
+
+    qube.assertFileHasLine("/var/lib/tor/authdir/app-journalist.auth_private", line)
+
+
+def test_sd_whonix_repo_enabled(qube, whonix_apt_list):
+    """
+    During Whonix 14 -> 15 migration, we removed the apt list file
+    (because the repo wasn't serving, due to EOL status). Let's
+    make sure it's there, since we're past 14 now.
+    """
+    assert qube.fileExists(whonix_apt_list)
+
+
+def test_sd_whonix_verify_tor_config(qube):
+    # User must be debian-tor for v3 Onion, due to restrictive
+    # mode on the client keys directory.
+    qube.run("tor --verify-config", user="debian-tor")
+
+
+def test_whonix_torrc(qube):
+    """
+    Ensure Whonix-maintained torrc files don't contain duplicate entries.
+    """
+    torrc_contents = qube.get_file_contents("/etc/tor/torrc")
+    duplicate_includes = """%include /etc/torrc.d/
 %include /etc/torrc.d/95_whonix.conf"""
-        assert (
-            duplicate_includes not in torrc_contents
-        ), r"Whonix GW torrc contains duplicate %\include lines"
+    assert (
+        duplicate_includes not in torrc_contents
+    ), r"Whonix GW torrc contains duplicate %\include lines"

--- a/tests/test_sd_whonix.py
+++ b/tests/test_sd_whonix.py
@@ -11,11 +11,11 @@ class SD_Whonix_Tests(SD_VM_Local_Test):
     def test_sd_whonix_config_enabled(self):
         assert self._qubes_service_enabled("securedrop-whonix-config")
 
-    def test_sd_whonix_config(self):
+    def test_sd_whonix_config(self, dom0_config):
         self.assertEqual(
-            self.dom0_config["hidserv"]["hostname"], self._vm_config_read("SD_HIDSERV_HOSTNAME")
+            dom0_config["hidserv"]["hostname"], self._vm_config_read("SD_HIDSERV_HOSTNAME")
         )
-        self.assertEqual(self.dom0_config["hidserv"]["key"], self._vm_config_read("SD_HIDSERV_KEY"))
+        self.assertEqual(dom0_config["hidserv"]["key"], self._vm_config_read("SD_HIDSERV_KEY"))
 
     def test_v3_auth_private_file(self):
         hidserv_hostname = self._vm_config_read("SD_HIDSERV_HOSTNAME")

--- a/tests/test_sd_whonix.py
+++ b/tests/test_sd_whonix.py
@@ -1,6 +1,6 @@
 import unittest
 
-from base import SD_VM_Local_Test
+from tests.base import SD_VM_Local_Test
 
 
 class SD_Whonix_Tests(SD_VM_Local_Test):

--- a/tests/test_sd_whonix.py
+++ b/tests/test_sd_whonix.py
@@ -12,10 +12,8 @@ class SD_Whonix_Tests(SD_VM_Local_Test):
         assert self._qubes_service_enabled("securedrop-whonix-config")
 
     def test_sd_whonix_config(self, dom0_config):
-        self.assertEqual(
-            dom0_config["hidserv"]["hostname"], self._vm_config_read("SD_HIDSERV_HOSTNAME")
-        )
-        self.assertEqual(dom0_config["hidserv"]["key"], self._vm_config_read("SD_HIDSERV_KEY"))
+        assert dom0_config["hidserv"]["hostname"] == self._vm_config_read("SD_HIDSERV_HOSTNAME")
+        assert dom0_config["hidserv"]["key"] == self._vm_config_read("SD_HIDSERV_KEY")
 
     def test_v3_auth_private_file(self):
         hidserv_hostname = self._vm_config_read("SD_HIDSERV_HOSTNAME")
@@ -44,8 +42,6 @@ class SD_Whonix_Tests(SD_VM_Local_Test):
         torrc_contents = self._get_file_contents("/etc/tor/torrc")
         duplicate_includes = """%include /etc/torrc.d/
 %include /etc/torrc.d/95_whonix.conf"""
-        self.assertNotIn(
-            duplicate_includes,
-            torrc_contents,
-            "Whonix GW torrc contains duplicate %include lines",
-        )
+        assert (
+            duplicate_includes not in torrc_contents
+        ), r"Whonix GW torrc contains duplicate %\include lines"

--- a/tests/test_sd_whonix.py
+++ b/tests/test_sd_whonix.py
@@ -1,5 +1,3 @@
-import unittest
-
 from tests.base import SD_VM_Local_Test
 
 
@@ -51,7 +49,3 @@ class SD_Whonix_Tests(SD_VM_Local_Test):
             torrc_contents,
             "Whonix GW torrc contains duplicate %include lines",
         )
-
-
-def load_tests(loader, tests, pattern):
-    return unittest.TestLoader().loadTestsFromTestCase(SD_Whonix_Tests)

--- a/tests/test_sys_usb.py
+++ b/tests/test_sys_usb.py
@@ -1,6 +1,6 @@
 import unittest
 
-from base import SD_VM_Local_Test
+from tests.base import SD_VM_Local_Test
 
 
 class SD_SysUSB_Tests(SD_VM_Local_Test):

--- a/tests/test_sys_usb.py
+++ b/tests/test_sys_usb.py
@@ -8,5 +8,5 @@ class SD_SysUSB_Tests(SD_VM_Local_Test):
         self.lsm = "selinux"
 
     def test_files_are_properly_copied(self):
-        self.assertTrue(self._fileExists("/etc/udev/rules.d/99-sd-devices.rules"))
-        self.assertTrue(self._fileExists("/usr/local/bin/sd-attach-export-device"))
+        assert self._fileExists("/etc/udev/rules.d/99-sd-devices.rules")
+        assert self._fileExists("/usr/local/bin/sd-attach-export-device")

--- a/tests/test_sys_usb.py
+++ b/tests/test_sys_usb.py
@@ -1,5 +1,3 @@
-import unittest
-
 from tests.base import SD_VM_Local_Test
 
 
@@ -12,7 +10,3 @@ class SD_SysUSB_Tests(SD_VM_Local_Test):
     def test_files_are_properly_copied(self):
         self.assertTrue(self._fileExists("/etc/udev/rules.d/99-sd-devices.rules"))
         self.assertTrue(self._fileExists("/usr/local/bin/sd-attach-export-device"))
-
-
-def load_tests(loader, tests, pattern):
-    return unittest.TestLoader().loadTestsFromTestCase(SD_SysUSB_Tests)

--- a/tests/test_sys_usb.py
+++ b/tests/test_sys_usb.py
@@ -1,12 +1,16 @@
-from tests.base import SD_VM_Local_Test
+import pytest
+
+from tests.base import (
+    QubeWrapper,
+    Test_SD_VM_Local,  # noqa: F401 [HACK: import so base tests run]
+)
 
 
-class SD_SysUSB_Tests(SD_VM_Local_Test):
-    def setUp(self):
-        self.vm_name = "sys-usb"
-        super().setUp()
-        self.lsm = "selinux"
+@pytest.fixture(scope="module")
+def qube():
+    return QubeWrapper("sys-usb", linux_security_modules="selinux")
 
-    def test_files_are_properly_copied(self):
-        assert self._fileExists("/etc/udev/rules.d/99-sd-devices.rules")
-        assert self._fileExists("/usr/local/bin/sd-attach-export-device")
+
+def test_files_are_properly_copied(qube):
+    assert qube.fileExists("/etc/udev/rules.d/99-sd-devices.rules")
+    assert qube.fileExists("/usr/local/bin/sd-attach-export-device")

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -1,5 +1,4 @@
 import os
-import unittest
 
 from tests.base import SD_Unnamed_DVM_Local_Test
 
@@ -69,7 +68,3 @@ class SD_Viewer_Tests(SD_Unnamed_DVM_Local_Test):
         self.assertTrue(self._fileExists(".local/share/applications/mimeapps.list"))
         symlink_location = self._get_symlink_location(".local/share/applications/mimeapps.list")
         assert symlink_location == "/opt/sdw/mimeapps.list.sd-viewer"
-
-
-def load_tests(loader, tests, pattern):
-    return unittest.TestLoader().loadTestsFromTestCase(SD_Viewer_Tests)

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-from base import SD_Unnamed_DVM_Local_Test
+from tests.base import SD_Unnamed_DVM_Local_Test
 
 
 class SD_Viewer_Tests(SD_Unnamed_DVM_Local_Test):

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -24,15 +24,15 @@ class SD_Viewer_Tests(SD_Unnamed_DVM_Local_Test):
         }
 
     def test_sd_viewer_metapackage_installed(self):
-        self.assertTrue(self._package_is_installed("securedrop-workstation-viewer"))
-        self.assertFalse(self._package_is_installed("securedrop-workstation-svs-disp"))
+        assert self._package_is_installed("securedrop-workstation-viewer")
+        assert not self._package_is_installed("securedrop-workstation-svs-disp")
 
     def test_sd_viewer_evince_installed(self):
         pkg = "evince"
-        self.assertTrue(self._package_is_installed(pkg))
+        assert self._package_is_installed(pkg)
 
     def test_sd_viewer_libreoffice_installed(self):
-        self.assertTrue(self._package_is_installed("libreoffice"))
+        assert self._package_is_installed("libreoffice")
 
     def test_logging_configured(self):
         self.logging_configured()
@@ -42,8 +42,8 @@ class SD_Viewer_Tests(SD_Unnamed_DVM_Local_Test):
         Only the log collector, i.e. sd-log, needs redis, so redis will be
         present in small template, but not in large.
         """
-        self.assertFalse(self._package_is_installed("redis"))
-        self.assertFalse(self._package_is_installed("redis-server"))
+        assert not self._package_is_installed("redis")
+        assert not self._package_is_installed("redis-server")
 
     def test_mime_types(self):
         filepath = os.path.join(
@@ -56,7 +56,7 @@ class SD_Viewer_Tests(SD_Unnamed_DVM_Local_Test):
                     mime_type = line.split("=")[0]
                     expected_app = line.split("=")[1].rstrip()
                     actual_app = self._run(f"xdg-mime query default {mime_type}")
-                    self.assertEqual(actual_app, expected_app)
+                    assert actual_app == expected_app
 
     def test_mimetypes_service(self):
         self._service_is_active("securedrop-mime-handling")
@@ -65,6 +65,6 @@ class SD_Viewer_Tests(SD_Unnamed_DVM_Local_Test):
         self.mailcap_hardened()
 
     def test_mimetypes_symlink(self):
-        self.assertTrue(self._fileExists(".local/share/applications/mimeapps.list"))
+        assert self._fileExists(".local/share/applications/mimeapps.list")
         symlink_location = self._get_symlink_location(".local/share/applications/mimeapps.list")
         assert symlink_location == "/opt/sdw/mimeapps.list.sd-viewer"

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -1,18 +1,47 @@
 import os
+import subprocess
 
-from tests.base import SD_Unnamed_DVM_Local_Test
+import pytest
+from qubesadmin import Qubes
+
+from tests.base import (
+    QubeWrapper,
+    Test_SD_VM_Local,  # noqa: F401 [HACK: import so base tests run]
+)
 
 
-class SD_Viewer_Tests(SD_Unnamed_DVM_Local_Test):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass("sd-viewer")
+def _create_test_qube(dispvm_template_name):
+    # VM was running and needs a restart to test on the latest version
+    if dispvm_template_name in Qubes().domains:
+        _kill_test_qube(dispvm_template_name)
 
-    def setUp(self):
-        super().setUp()
-        self.expected_config_keys = {"SD_MIME_HANDLING"}
+    # Create disposable based on specified template
+    qube_name = f"{dispvm_template_name}-disposable"
+    cmd_create_disp = (
+        f"qvm-create --disp --property auto_cleanup=True "
+        f"--template {dispvm_template_name} {qube_name}"
+    )
+    subprocess.run(cmd_create_disp.split(), check=True)
+
+    return qube_name
+
+
+def _kill_test_qube(qube_name):
+    subprocess.run(["qvm-kill", qube_name], check=True)
+
+
+@pytest.fixture(scope="module")
+def qube():
+    """
+    Handles the creation of disposable qubes based on the provided DVM template
+    """
+    temp_qube_name = _create_test_qube("sd-viewer")
+
+    yield QubeWrapper(
+        temp_qube_name,
+        expected_config_keys={"SD_MIME_HANDLING"},
         # this is not a comprehensive list, just a few that users are likely to use
-        self.enforced_apparmor_profiles = {
+        enforced_apparmor_profiles={
             "/usr/bin/evince",
             "/usr/bin/evince-previewer",
             "/usr/bin/evince-previewer//sanitized_helper",
@@ -21,50 +50,63 @@ class SD_Viewer_Tests(SD_Unnamed_DVM_Local_Test):
             "/usr/bin/totem-audio-preview",
             "/usr/bin/totem-video-thumbnailer",
             "/usr/bin/totem//sanitized_helper",
-        }
+        },
+    )
 
-    def test_sd_viewer_metapackage_installed(self):
-        assert self._package_is_installed("securedrop-workstation-viewer")
-        assert not self._package_is_installed("securedrop-workstation-svs-disp")
+    # Tear Down
+    _kill_test_qube(temp_qube_name)
 
-    def test_sd_viewer_evince_installed(self):
-        pkg = "evince"
-        assert self._package_is_installed(pkg)
 
-    def test_sd_viewer_libreoffice_installed(self):
-        assert self._package_is_installed("libreoffice")
+def test_sd_viewer_metapackage_installed(qube):
+    assert qube.package_is_installed("securedrop-workstation-viewer")
+    assert not qube.package_is_installed("securedrop-workstation-svs-disp")
 
-    def test_logging_configured(self):
-        self.logging_configured()
 
-    def test_redis_packages_not_installed(self):
-        """
-        Only the log collector, i.e. sd-log, needs redis, so redis will be
-        present in small template, but not in large.
-        """
-        assert not self._package_is_installed("redis")
-        assert not self._package_is_installed("redis-server")
+def test_sd_viewer_evince_installed(qube):
+    pkg = "evince"
+    assert qube.package_is_installed(pkg)
 
-    def test_mime_types(self):
-        filepath = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), "vars", "sd-viewer.mimeapps"
-        )
-        with open(filepath) as f:
-            lines = f.readlines()
-            for line in lines:
-                if line != "[Default Applications]\n" and not line.startswith("#"):
-                    mime_type = line.split("=")[0]
-                    expected_app = line.split("=")[1].rstrip()
-                    actual_app = self._run(f"xdg-mime query default {mime_type}")
-                    assert actual_app == expected_app
 
-    def test_mimetypes_service(self):
-        self._service_is_active("securedrop-mime-handling")
+def test_sd_viewer_libreoffice_installed(qube):
+    assert qube.package_is_installed("libreoffice")
 
-    def test_mailcap_hardened(self):
-        self.mailcap_hardened()
 
-    def test_mimetypes_symlink(self):
-        assert self._fileExists(".local/share/applications/mimeapps.list")
-        symlink_location = self._get_symlink_location(".local/share/applications/mimeapps.list")
-        assert symlink_location == "/opt/sdw/mimeapps.list.sd-viewer"
+def test_logging_configured(qube):
+    qube.logging_configured()
+
+
+def test_redis_packages_not_installed(qube):
+    """
+    Only the log collector, i.e. sd-log, needs redis, so redis will be
+    present in small template, but not in large.
+    """
+    assert not qube.package_is_installed("redis")
+    assert not qube.package_is_installed("redis-server")
+
+
+def test_mime_types(qube):
+    filepath = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "vars", "sd-viewer.mimeapps"
+    )
+    with open(filepath) as f:
+        lines = f.readlines()
+        for line in lines:
+            if line != "[Default Applications]\n" and not line.startswith("#"):
+                mime_type = line.split("=")[0]
+                expected_app = line.split("=")[1].rstrip()
+                actual_app = qube.run(f"xdg-mime query default {mime_type}")
+                assert actual_app == expected_app
+
+
+def test_mimetypes_service(qube):
+    qube.service_is_active("securedrop-mime-handling")
+
+
+def test_mailcap_hardened(qube):
+    qube.mailcap_hardened()
+
+
+def test_mimetypes_symlink(qube):
+    assert qube.fileExists(".local/share/applications/mimeapps.list")
+    symlink_location = qube.get_symlink_location(".local/share/applications/mimeapps.list")
+    assert symlink_location == "/opt/sdw/mimeapps.list.sd-viewer"

--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -2,7 +2,10 @@ import json
 import subprocess
 import unittest
 
-from base import (
+from qubesadmin import Qubes
+
+from sdw_util import Util
+from tests.base import (
     CURRENT_WHONIX_VERSION,
     SD_DVM_TEMPLATES,
     SD_TEMPLATE_BASE,
@@ -12,9 +15,6 @@ from base import (
     SD_UNTAGGED_DEPRECATED_VMS,
     SD_VMS,
 )
-from qubesadmin import Qubes
-
-from sdw_util import Util
 
 with open("config.json") as f:
     CONFIG = json.load(f)

--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -34,11 +34,11 @@ class SD_VM_Tests(unittest.TestCase):
     def test_expected(self):
         sdw_tagged_vm_names = [vm.name for vm in self.sdw_tagged_vms]
         expected_vms = set(SD_VMS + SD_DVM_TEMPLATES + SD_TEMPLATES)
-        self.assertEqual(set(sdw_tagged_vm_names), set(expected_vms))
+        assert set(sdw_tagged_vm_names) == set(expected_vms)
 
         # Check for untagged VMs
         for vm_name in SD_UNTAGGED_DEPRECATED_VMS:
-            self.assertNotIn(vm_name, self.app.domains)
+            assert vm_name not in self.app.domains
 
     @unittest.skipIf(CONFIG["environment"] != "prod", "Skipping on non-prod system")
     def test_internal(self):
@@ -46,7 +46,7 @@ class SD_VM_Tests(unittest.TestCase):
 
         for vm_name in internal:
             vm = self.app.domains[vm_name]
-            self.assertEqual(vm.features.get("internal"), "1")
+            assert vm.features.get("internal") == "1"
 
     def test_grsec_kernel(self):
         """
@@ -60,8 +60,8 @@ class SD_VM_Tests(unittest.TestCase):
             if vm.name in exceptions:
                 continue
             # Running custom kernel in PVH mode requires pvgrub2-pvh
-            self.assertEqual(vm.virt_mode, "pvh")
-            self.assertEqual(vm.kernel, "pvgrub2-pvh")
+            assert vm.virt_mode == "pvh"
+            assert vm.kernel == "pvgrub2-pvh"
 
             # Check running kernel is grsecurity-patched
             stdout, stderr = vm.run("uname -r")
@@ -82,165 +82,165 @@ class SD_VM_Tests(unittest.TestCase):
                 service_status = "inactive"
             else:
                 raise e
-        self.assertEqual(service_status, "active" if running else "inactive")
+        assert service_status == "active" if running else "inactive"
 
     def test_default_dispvm(self):
         """Verify the default DispVM is none for all except sd-app and sd-devices"""
         for vm in self.sdw_tagged_vms:
             if vm.name == "sd-app":
-                self.assertEqual(vm.default_dispvm.name, "sd-viewer")
+                assert vm.default_dispvm.name == "sd-viewer"
             else:
-                self.assertIsNone(vm.default_dispvm, f"{vm.name} has dispVM set")
+                assert vm.default_dispvm is None, f"{vm.name} has dispVM set"
 
     def test_sd_whonix_config(self):
         vm = self.app.domains["sd-whonix"]
         nvm = vm.netvm
-        self.assertEqual(nvm.name, "sys-firewall")
+        assert nvm.name == "sys-firewall"
         wanted_kernelopts = "apparmor=1 security=apparmor"
-        self.assertEqual(vm.kernelopts, wanted_kernelopts)
-        self.assertTrue(vm.provides_network)
-        self.assertTrue(vm.autostart)
-        self.assertFalse(vm.template_for_dispvms)
-        self.assertIn("sd-workstation", vm.tags)
+        assert vm.kernelopts == wanted_kernelopts
+        assert vm.provides_network
+        assert vm.autostart
+        assert not vm.template_for_dispvms
+        assert "sd-workstation" in vm.tags
 
-        # Whonix version checking
-        self.assertEqual(
-            Util.get_whonix_version(),  # If mismatch, whonix may have been updated.
-            int(CURRENT_WHONIX_VERSION),  # Fix the test by bumping CURRENT_WHONIX_VERSION
-        )
-        self.assertEqual(vm.template.features.get("os-version"), CURRENT_WHONIX_VERSION)
+        # Whonix version checking:
+        #   If mismatch, whonix may have been updated.
+        #   Fix the test by bumping CURRENT_WHONIX_VERSION
+        assert Util.get_whonix_version() == int(CURRENT_WHONIX_VERSION)
+
+        assert vm.template.features.get("os-version") == CURRENT_WHONIX_VERSION
 
     def test_sd_proxy_config(self):
         vm = self.app.domains["sd-proxy"]
-        self.assertEqual(vm.template, "sd-proxy-dvm")
-        self.assertEqual(vm.klass, "DispVM")
-        self.assertEqual(vm.netvm.name, "sd-whonix")
-        self.assertTrue(vm.autostart)
-        self.assertFalse(vm.provides_network)
-        self.assertIsNone(vm.default_dispvm)
-        self.assertIn("sd-workstation", vm.tags)
-        self.assertEqual(vm.features["service.securedrop-mime-handling"], "1")
-        self.assertEqual(vm.features["vm-config.SD_MIME_HANDLING"], "default")
+        assert vm.template == "sd-proxy-dvm"
+        assert vm.klass == "DispVM"
+        assert vm.netvm.name == "sd-whonix"
+        assert vm.autostart
+        assert not vm.provides_network
+        assert vm.default_dispvm is None
+        assert "sd-workstation" in vm.tags
+        assert vm.features["service.securedrop-mime-handling"] == "1"
+        assert vm.features["vm-config.SD_MIME_HANDLING"] == "default"
         self._check_service_running(vm, "securedrop-mime-handling")
 
     def test_sd_proxy_dvm(self):
         vm = self.app.domains["sd-proxy-dvm"]
-        self.assertTrue(vm.template_for_dispvms)
-        self.assertEqual(vm.netvm.name, "sd-whonix")
-        self.assertEqual(vm.template, SD_TEMPLATE_SMALL)
-        self.assertIsNone(vm.default_dispvm)
-        self.assertIn("sd-workstation", vm.tags)
-        self.assertFalse(vm.autostart)
-        self.assertNotIn("service.securedrop-mime-handling", vm.features)
+        assert vm.template_for_dispvms
+        assert vm.netvm.name == "sd-whonix"
+        assert vm.template == SD_TEMPLATE_SMALL
+        assert vm.default_dispvm is None
+        assert "sd-workstation" in vm.tags
+        assert not vm.autostart
+        assert "service.securedrop-mime-handling" not in vm.features
         self._check_service_running(vm, "securedrop-mime-handling", running=False)
 
     def test_sd_app_config(self):
         vm = self.app.domains["sd-app"]
         nvm = vm.netvm
-        self.assertIsNone(nvm)
-        self.assertEqual(vm.template, SD_TEMPLATE_SMALL)
-        self.assertFalse(vm.provides_network)
-        self.assertFalse(vm.template_for_dispvms)
-        self.assertNotIn("service.securedrop-log-server", vm.features)
-        self.assertIn("sd-workstation", vm.tags)
-        self.assertIn("sd-client", vm.tags)
+        assert nvm is None
+        assert vm.template == SD_TEMPLATE_SMALL
+        assert not vm.provides_network
+        assert not vm.template_for_dispvms
+        assert "service.securedrop-log-server" not in vm.features
+        assert "sd-workstation" in vm.tags
+        assert "sd-client" in vm.tags
         # Check the size of the private volume
         # Should be 10GB
         # >>> 1024 * 1024 * 10 * 1024
         size = self.config["vmsizes"]["sd_app"]
         vol = vm.volumes["private"]
-        self.assertEqual(vol.size, size * 1024 * 1024 * 1024)
+        assert vol.size == size * 1024 * 1024 * 1024
 
         # MIME handling
-        self.assertEqual(vm.features["service.securedrop-mime-handling"], "1")
-        self.assertEqual(vm.features["vm-config.SD_MIME_HANDLING"], "sd-app")
+        assert vm.features["service.securedrop-mime-handling"] == "1"
+        assert vm.features["vm-config.SD_MIME_HANDLING"] == "sd-app"
         self._check_service_running(vm, "securedrop-mime-handling")
 
     def test_sd_viewer_config(self):
         vm = self.app.domains["sd-viewer"]
         nvm = vm.netvm
-        self.assertIsNone(nvm)
-        self.assertEqual(vm.template, SD_TEMPLATE_LARGE)
-        self.assertFalse(vm.provides_network)
-        self.assertTrue(vm.template_for_dispvms)
-        self.assertIn("sd-workstation", vm.tags)
+        assert nvm is None
+        assert vm.template == SD_TEMPLATE_LARGE
+        assert not vm.provides_network
+        assert vm.template_for_dispvms
+        assert "sd-workstation" in vm.tags
 
         # MIME handling
-        self.assertEqual(vm.features["service.securedrop-mime-handling"], "1")
-        self.assertEqual(vm.features["vm-config.SD_MIME_HANDLING"], "sd-viewer")
+        assert vm.features["service.securedrop-mime-handling"] == "1"
+        assert vm.features["vm-config.SD_MIME_HANDLING"] == "sd-viewer"
 
     def test_sd_gpg_config(self):
         vm = self.app.domains["sd-gpg"]
         nvm = vm.netvm
-        self.assertIsNone(nvm)
+        assert nvm is None
         # No sd-gpg-template, since keyring is managed in $HOME
-        self.assertEqual(vm.template, SD_TEMPLATE_SMALL)
-        self.assertTrue(vm.autostart)
-        self.assertFalse(vm.provides_network)
-        self.assertFalse(vm.template_for_dispvms)
-        self.assertEqual(vm.features["service.securedrop-logging-disabled"], "1")
-        self.assertIn("sd-workstation", vm.tags)
+        assert vm.template == SD_TEMPLATE_SMALL
+        assert vm.autostart
+        assert not vm.provides_network
+        assert not vm.template_for_dispvms
+        assert vm.features["service.securedrop-logging-disabled"] == "1"
+        assert "sd-workstation" in vm.tags
 
     def test_sd_log_config(self):
         vm = self.app.domains["sd-log"]
         nvm = vm.netvm
-        self.assertIsNone(nvm)
-        self.assertEqual(vm.template, SD_TEMPLATE_SMALL)
-        self.assertTrue(vm.autostart)
-        self.assertFalse(vm.provides_network)
-        self.assertFalse(vm.template_for_dispvms)
+        assert nvm is None
+        assert vm.template == SD_TEMPLATE_SMALL
+        assert vm.autostart
+        assert not vm.provides_network
+        assert not vm.template_for_dispvms
         self._check_service_running(vm, "securedrop-log-server")
-        self.assertEqual(vm.features["service.securedrop-log-server"], "1")
-        self.assertEqual(vm.features["service.securedrop-logging-disabled"], "1")
+        assert vm.features["service.securedrop-log-server"] == "1"
+        assert vm.features["service.securedrop-logging-disabled"] == "1"
         # See sd-log.sls "sd-install-epoch" feature
-        self.assertEqual(vm.features["sd-install-epoch"], "1001")
+        assert vm.features["sd-install-epoch"] == "1001"
 
-        self.assertFalse(vm.template_for_dispvms)
-        self.assertIn("sd-workstation", vm.tags)
+        assert not vm.template_for_dispvms
+        assert "sd-workstation" in vm.tags
         # Check the size of the private volume
         # Should be same of config.json
         # >>> 1024 * 1024 * 5 * 1024
         size = self.config["vmsizes"]["sd_log"]
         vol = vm.volumes["private"]
-        self.assertEqual(vol.size, size * 1024 * 1024 * 1024)
+        assert vol.size == size * 1024 * 1024 * 1024
 
     def test_sd_export_dvm(self):
         vm = self.app.domains["sd-devices-dvm"]
         nvm = vm.netvm
-        self.assertIsNone(nvm)
-        self.assertIn("sd-workstation", vm.tags)
-        self.assertTrue(vm.template_for_dispvms)
+        assert nvm is None
+        assert "sd-workstation" in vm.tags
+        assert vm.template_for_dispvms
 
-        self.assertNotIn("service.avahi", vm.features)
+        assert "service.avahi" not in vm.features
         # MIME handling (dvm does NOT setup mime, only its disposables do)
-        self.assertNotIn("service.securedrop-mime-handling", vm.features)
+        assert "service.securedrop-mime-handling" not in vm.features
         self._check_service_running(vm, "securedrop-mime-handling", running=False)
 
     def test_sd_export(self):
         vm = self.app.domains["sd-devices"]
         nvm = vm.netvm
-        self.assertIsNone(nvm)
+        assert nvm is None
         vm_type = vm.klass
-        self.assertEqual(vm_type, "DispVM")
-        self.assertIn("sd-workstation", vm.tags)
+        assert vm_type == "DispVM"
+        assert "sd-workstation" in vm.tags
 
-        self.assertEqual(vm.features["service.avahi"], "1")
+        assert vm.features["service.avahi"] == "1"
 
         # MIME handling
-        self.assertEqual(vm.features["service.securedrop-mime-handling"], "1")
-        self.assertEqual(vm.features["vm-config.SD_MIME_HANDLING"], "sd-devices")
+        assert vm.features["service.securedrop-mime-handling"] == "1"
+        assert vm.features["vm-config.SD_MIME_HANDLING"] == "sd-devices"
         self._check_service_running(vm, "securedrop-mime-handling")
 
     def test_sd_small_template(self):
         # Kernel check is handled in test_grsec_kernel
         vm = self.app.domains[SD_TEMPLATE_SMALL]
         nvm = vm.netvm
-        self.assertIsNone(nvm)
-        self.assertIn("sd-workstation", vm.tags)
+        assert nvm is None
+        assert "sd-workstation" in vm.tags
 
     def test_sd_large_template(self):
         # Kernel check is handled in test_grsec_kernel
         vm = self.app.domains[SD_TEMPLATE_LARGE]
         nvm = vm.netvm
-        self.assertIsNone(nvm)
-        self.assertIn("sd-workstation", vm.tags)
+        assert nvm is None
+        assert "sd-workstation" in vm.tags

--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -244,7 +244,3 @@ class SD_VM_Tests(unittest.TestCase):
         nvm = vm.netvm
         self.assertIsNone(nvm)
         self.assertIn("sd-workstation", vm.tags)
-
-
-def load_tests(loader, tests, pattern):
-    return unittest.TestLoader().loadTestsFromTestCase(SD_VM_Tests)

--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -4,14 +4,15 @@ import re
 import subprocess
 import unittest
 
-from base import (
+from qubesadmin import Qubes
+
+from tests.base import (
     CURRENT_FEDORA_TEMPLATE,
     CURRENT_WHONIX_VERSION,
     SD_TEMPLATE_LARGE,
     SD_TEMPLATE_SMALL,
     SD_VMS,
 )
-from qubesadmin import Qubes
 
 BOOKWORM_STRING = "Debian GNU/Linux 12 (bookworm)"
 

--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -51,7 +51,7 @@ class SD_VM_Platform_Tests(unittest.TestCase):
         SUPPORTED_SD_DEBIAN_DIST based.
         """
         platform = self._get_platform_info(vm)
-        self.assertIn(SUPPORTED_SD_DEBIAN_DIST, platform)
+        assert SUPPORTED_SD_DEBIAN_DIST in platform
 
     def _validate_apt_sources(self, vm):
         """
@@ -78,11 +78,11 @@ class SD_VM_Platform_Tests(unittest.TestCase):
         stdout, stderr = vm.run(f"cat {filename}")
         contents = stdout.decode("utf-8").rstrip("\n")
 
-        self.assertIn(f"Components: {component}\n", contents, f"{vm.name} wrong component")
-        self.assertIn(f"URIs: {url}\n", contents, f"{vm.name} wrong URL")
-        self.assertIn(
-            f"Suites: {SUPPORTED_SD_DEBIAN_DIST}\n", contents, f"{vm.name} wrong suite/codename"
-        )
+        assert f"Components: {component}\n" in contents, f"{vm.name} wrong component"
+        assert f"URIs: {url}\n" in contents, f"{vm.name} wrong URL"
+        assert (
+            f"Suites: {SUPPORTED_SD_DEBIAN_DIST}\n" in contents
+        ), f"{vm.name} wrong suite/codename"
 
     def _ensure_packages_up_to_date(self, vm, fedora=False):
         """
@@ -99,7 +99,7 @@ class SD_VM_Platform_Tests(unittest.TestCase):
             results = stdout.rstrip().decode("utf-8")
             # `apt list` will always print "Listing..." to stdout,
             # so expect only that string.
-            self.assertEqual(results, "Listing...", fail_msg)
+            assert results == "Listing...", fail_msg
         else:
             cmd = "sudo dnf check-update"
             # Will raise CalledProcessError if updates available
@@ -117,7 +117,7 @@ class SD_VM_Platform_Tests(unittest.TestCase):
                 if not x.startswith("Warning: Enforcing GPG signature check")
             ]
             results = "".join(stdout_lines)
-            self.assertEqual(results, "", fail_msg)
+            assert results == "", fail_msg
 
     @unittest.skipIf(IS_CI, "Skipping on CI")
     def test_all_sd_vms_uptodate(self):
@@ -179,7 +179,7 @@ class SD_VM_Platform_Tests(unittest.TestCase):
         """
         cmd = ["qubes-prefs", "default_dispvm"]
         result = subprocess.check_output(cmd).decode("utf-8").rstrip("\n")
-        self.assertEqual(result, "sd-viewer")
+        assert result == "sd-viewer"
 
     def test_sd_vm_apt_sources(self):
         """
@@ -195,20 +195,20 @@ class SD_VM_Platform_Tests(unittest.TestCase):
             self._validate_apt_sources(vm)
             stdout, stderr = vm.run("apt-get indextargets")
             contents = stdout.decode().strip()
-            self.assertIn(
-                "Description: https://apt.freedom.press bookworm/main amd64 Packages\n", contents
+            assert (
+                "Description: https://apt.freedom.press bookworm/main amd64 Packages\n" in contents
             )
             if self.config["environment"] == "prod":
                 # prod setups shouldn't have any apt-test sources
-                self.assertNotIn("apt-test.freedom.press", contents)
+                assert "apt-test.freedom.press" not in contents
             else:
                 # staging/dev
                 test_components = ["main"]
                 if self.config["environment"] == "dev":
                     test_components.append("nightlies")
                 for component in test_components:
-                    self.assertIn(
+                    assert (
                         f"Description: https://apt-test.freedom.press bookworm/{component} "
-                        "amd64 Packages\n",
-                        contents,
+                        + "amd64 Packages\n"
+                        in contents
                     )

--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -212,7 +212,3 @@ class SD_VM_Platform_Tests(unittest.TestCase):
                         "amd64 Packages\n",
                         contents,
                     )
-
-
-def load_tests(loader, tests, pattern):
-    return unittest.TestLoader().loadTestsFromTestCase(SD_VM_Platform_Tests)

--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -3,8 +3,8 @@ import os
 import re
 import subprocess
 import unittest
-import pytest
 
+import pytest
 from qubesadmin import Qubes
 
 from tests.base import (

--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -3,6 +3,7 @@ import os
 import re
 import subprocess
 import unittest
+import pytest
 
 from qubesadmin import Qubes
 
@@ -106,7 +107,7 @@ class SD_VM_Platform_Tests(unittest.TestCase):
             try:
                 stdout, stderr = vm.run(cmd)
             except subprocess.CalledProcessError:
-                self.assertTrue(False, fail_msg)
+                pytest.fail(fail_msg)
             # 'stdout' will contain timestamped progress info; ignore it
             results = stderr.rstrip().decode("utf-8")
             stdout_lines = results.split("\n")


### PR DESCRIPTION
## Status

Ready for review; depends on #1329.

## Description of Changes

Trigger OpenQA from GitHub Actions
    
A GHA job will trigger our jobs in OpenQA and then monitor them until
they finish.

The OpenQA job will only be started if it is a direct push that is to a
branch that isn't `main` nor part of the GH merge queue. This is to
avoid duplicate jobs while it's still quite slow; eventually this should
be a pre-merge check.

Because this is a slow job running on Qubes hardware, it's trivial to
skip running it if the latest commit message mentions the string "skip"
and "openqa" separated by a single space, case insensitive. This is
what the `check-openqa` job does and is based off the "skip" "ci"
keywords that GHA itself supports.

When the GHA job is cancelled, we'll also send off requests to cancel
the openQA jobs in a best-effort manner.

Finally we include links to the openQA logs at the bottom just to make
it easy for humans to hunt down failures.

This work was initially based off of
https://github.com/os-autoinst/os-autoinst-distri-example/blob/main/.github/workflows/openqa.yml
and deeplow's example in #1319.

Note that the `openqa-cli monitor` command is only available in trixie.

Fixes #1319

## Testing

* [ ] CI correctly executes the openQA jobs as expected
* [ ] using the `skip openqa` magic string in a commit works (no tests are run)
* [ ] cancelling a workflow also stops the jobs in openQA.

