### PR TITLE
tests: use policy graph in qubes rpc tests

### DIFF
--- a/tests/test_qubes_rpc.py
+++ b/tests/test_qubes_rpc.py
@@ -1,72 +1,62 @@
-import os
+import functools
 import subprocess
 import unittest
 
 from qubesadmin import Qubes
 
-RETURNCODE_SUCCESS = 0
-RETURNCODE_ERROR = 1
-RETURNCODE_DENIED = 126
-
 
 class SD_Qubes_Rpc_Tests(unittest.TestCase):
-    def _qrexec(self, source_vm, dest_vm, policy_name):
-        cmd = [
-            "qvm-run",
-            "--pass-io",
-            source_vm,
-            f"qrexec-client-vm {dest_vm} {policy_name}",
-        ]
-        p = subprocess.run(cmd, input="test", capture_output=True, text=True, check=False)
-        return p.returncode
+    @classmethod
+    def setUpClass(cls):
+        cls.all_vms = set()
+        cls.vms_by_tag = {}
 
-    def _get_running_vms_with_and_without_tag(self, tag):
-        vms_with_tag = []
-        vms_without_tag = []
         app = Qubes()
-        for vm in app.domains:
-            if vm.name != "dom0" and vm.is_running():
-                if tag in list(vm.tags):
-                    vms_with_tag.append(vm.name)
-                else:
-                    vms_without_tag.append(vm.name)
-        return vms_with_tag, vms_without_tag
+        cls.all_vms = {vm for vm in app.domains if vm.name != "dom0"}
+        cls.sdw_tagged_vms = {vm for vm in app.domains if "sd-workstation" in vm.tags}
 
-    def test_policies_exist(self):
-        """verify the policies are installed"""
-        assert os.path.exists("/etc/qubes/policy.d/31-securedrop-workstation.policy")
-        assert os.path.exists("/etc/qubes/policy.d/32-securedrop-workstation.policy")
+    @functools.cache
+    def _qrexec_policy_graph(self, service):
+        cmd = ["qrexec-policy-graph", "--service", service]
+        p = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        return p.stdout
+
+    def _policy_exists(self, source, target, service):
+        service_policy_graph = self._qrexec_policy_graph(service)
+        policy_str = f'"{source}" -> "{target}" [label="{service}"'
+        return policy_str in service_policy_graph
 
     # securedrop.Log from @tag:sd-workstation to sd-log should be allowed
     def test_sdlog_from_sdw_to_sdlog_allowed(self):
-        vms_with_tag, _ = self._get_running_vms_with_and_without_tag("sd-workstation")
-        for vm in vms_with_tag:
+        for vm in self.sdw_tagged_vms:
             if vm != "sd-log":
-                assert self._qrexec(vm, "sd-log", "securedrop.Log") == RETURNCODE_SUCCESS
+                assert self._policy_exists(vm, "sd-log", "securedrop.Log")
 
     # securedrop.Log from anything else to sd-log should be denied
     def test_sdlog_from_other_to_sdlog_denied(self):
-        _, vms_without_tag = self._get_running_vms_with_and_without_tag("sd-workstation")
-        for vm in vms_without_tag:
+        non_sd_workstation_vms = self.all_vms.difference(self.sdw_tagged_vms)
+        for vm in non_sd_workstation_vms:
             if vm != "sd-log":
-                assert self._qrexec(vm, "sd-log", "securedrop.Log") == RETURNCODE_DENIED
+                assert not self._policy_exists(vm, "sd-log", "securedrop.Log")
 
     # securedrop.Proxy from sd-app to sd-proxy should be allowed
     def test_sdproxy_from_sdapp_to_sdproxy_allowed(self):
-        # proxy RPC returns an error due to malformed input, but it still goes through
-        # (i.e. not DENIED)
-        assert self._qrexec("sd-app", "sd-proxy", "securedrop.Proxy") == RETURNCODE_ERROR
+        assert self._policy_exists("sd-app", "sd-proxy", "securedrop.Proxy")
 
     # securedrop.Proxy from anything else to sd-proxy should be denied
     def test_sdproxy_from_other_to_sdproxy_denied(self):
-        assert self._qrexec("sys-net", "sd-proxy", "securedrop.Proxy") == RETURNCODE_DENIED
-        assert self._qrexec("sys-firewall", "sd-proxy", "securedrop.Proxy") == RETURNCODE_DENIED
+        assert not self._policy_exists("sys-net", "sd-proxy", "securedrop.Proxy")
+        assert not self._policy_exists("sys-firewall", "sd-proxy", "securedrop.Proxy")
 
     # qubes.Gpg, qubes.GpgImportKey, and qubes.Gpg2 from anything else to sd-gpg should be denied
     def test_qubesgpg_from_other_to_sdgpg_denied(self):
-        assert self._qrexec("sys-net", "sd-gpg", "qubes.Gpg") == RETURNCODE_DENIED
-        assert self._qrexec("sys-firewall", "sd-gpg", "qubes.Gpg") == RETURNCODE_DENIED
-        assert self._qrexec("sys-net", "sd-gpg", "qubes.GpgImportKey") == RETURNCODE_DENIED
-        assert self._qrexec("sys-firewall", "sd-gpg", "qubes.GpgImportKey") == RETURNCODE_DENIED
-        assert self._qrexec("sys-net", "sd-gpg", "qubes.Gpg2") == RETURNCODE_DENIED
-        assert self._qrexec("sys-firewall", "sd-gpg", "qubes.Gpg2") == RETURNCODE_DENIED
+        assert not self._policy_exists("sys-net", "sd-gpg", "qubes.Gpg")
+        assert not self._policy_exists("sys-firewall", "sd-gpg", "qubes.Gpg")
+        assert not self._policy_exists("sys-net", "sd-gpg", "qubes.GpgImportKey")
+        assert not self._policy_exists("sys-firewall", "sd-gpg", "qubes.GpgImportKey")
+        assert not self._policy_exists("sys-net", "sd-gpg", "qubes.Gpg2")
+        assert not self._policy_exists("sys-firewall", "sd-gpg", "qubes.Gpg2")
+
+
+def load_tests(loader, tests, pattern):
+    return unittest.TestLoader().loadTestsFromTestCase(SD_Qubes_Rpc_Tests)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #1331 

Changes proposed in this pull request: uses `qrexec-policy-graph` tool for qubes rpc tests to check policies rather than running the VMs + checking return codes.

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`
