### PR TITLE
sdw-admin: add --configure to import submission key + workstation config

### DIFF
--- a/files/sdw-admin.py
+++ b/files/sdw-admin.py
@@ -295,7 +295,6 @@ def extract_secret_key_fingerprints(gpg_output):
     lines = gpg_output.strip().split("\n")
     fingerprints = []
 
-    primary_key = True
     for idx, line in enumerate(lines):
         if not line.strip():
             continue


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #942 

Changes proposed in this pull request:

Adds `--configure` option to `sdw-admin` which (1) checks for submission key in `dom0` and, if not found, prompts the user to insert submission key drive + handles import, and (2) checks for valid `config.json` and, if not found, prompts user to insert workstation drive and imports Journalist Interface config.

## Testing

If you made non-trivial code changes, include a test plan and validated it for this PR.

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation