### PR TITLE
Rename shared tests: avoid JunitXML OpenQA conflicts

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -211,7 +211,7 @@ remotevm = sd-log
         assert mailcap_result == f'logger "Mailcap is disabled." <{tmpfile_name}'
 
 
-class Test_SD_VM_Local:
+class Test_SD_VM_Common:
     def test_vm_config_keys(self, qube):
         """Every VM should check that it has only the configuration keys it
         expects.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,7 +2,9 @@ import pytest
 
 from tests.base import (
     QubeWrapper,
-    Test_SD_VM_Local,  # noqa: F401 [HACK: import so base tests run]
+)
+from tests.base import (
+    Test_SD_VM_Common as Test_SD_App_Common,  # noqa: F401 [HACK: import so base tests run]
 )
 
 

--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -6,7 +6,9 @@ import pytest
 
 from tests.base import (
     QubeWrapper,
-    Test_SD_VM_Local,  # noqa: F401 [HACK: import so base tests run]
+)
+from tests.base import (
+    Test_SD_VM_Common as Test_SD_Gpg_Common,  # noqa: F401 [HACK: import so base tests run]
 )
 
 

--- a/tests/test_log_vm.py
+++ b/tests/test_log_vm.py
@@ -7,7 +7,9 @@ import pytest
 from tests.base import (
     CURRENT_DEBIAN_VERSION,
     QubeWrapper,
-    Test_SD_VM_Local,  # noqa: F401 [HACK: import so base tests run]
+)
+from tests.base import (
+    Test_SD_VM_Common as Test_SD_Log_Common,  # noqa: F401 [HACK: import so base tests run]
 )
 
 

--- a/tests/test_proxy_vm.py
+++ b/tests/test_proxy_vm.py
@@ -2,7 +2,9 @@ import pytest
 
 from tests.base import (
     QubeWrapper,
-    Test_SD_VM_Local,  # noqa: F401 [HACK: import so base tests run]
+)
+from tests.base import (
+    Test_SD_VM_Common as Test_SD_Proxy_Common,  # noqa: F401 [HACK: import so base tests run]
 )
 
 

--- a/tests/test_sd_devices.py
+++ b/tests/test_sd_devices.py
@@ -4,7 +4,9 @@ import pytest
 
 from tests.base import (
     QubeWrapper,
-    Test_SD_VM_Local,  # noqa: F401 [HACK: import so base tests run]
+)
+from tests.base import (
+    Test_SD_VM_Common as Test_SD_Devices_Common,  # noqa: F401 [HACK: import so base tests run]
 )
 
 

--- a/tests/test_sd_whonix.py
+++ b/tests/test_sd_whonix.py
@@ -2,7 +2,9 @@ import pytest
 
 from tests.base import (
     QubeWrapper,
-    Test_SD_VM_Local,  # noqa: F401 [HACK: import so base tests run]
+)
+from tests.base import (
+    Test_SD_VM_Common as Test_SD_Whonix_Common,  # noqa: F401 [HACK: import so base tests run]
 )
 
 

--- a/tests/test_sys_usb.py
+++ b/tests/test_sys_usb.py
@@ -2,7 +2,9 @@ import pytest
 
 from tests.base import (
     QubeWrapper,
-    Test_SD_VM_Local,  # noqa: F401 [HACK: import so base tests run]
+)
+from tests.base import (
+    Test_SD_VM_Common as Test_SD_SysUSB_Common,  # noqa: F401 [HACK: import so base tests run]
 )
 
 

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -6,7 +6,9 @@ from qubesadmin import Qubes
 
 from tests.base import (
     QubeWrapper,
-    Test_SD_VM_Local,  # noqa: F401 [HACK: import so base tests run]
+)
+from tests.base import (
+    Test_SD_VM_Common as Test_SD_Viewer_Common,  # noqa: F401 [HACK: import so base tests run]
 )
 
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Work around the fact that when displaying results in OpenQA imported "base" tests (Test_SD_VM_Local) some [tests don't display the result](https://github.com/QubesOS/openqa-tests-qubesos/issues/31#issuecomment-2944757905
). This was due to all tests having the same name even though they were running in different test files.

This is what the results look like currently (without this PR):

![451926850-e8df5bcc-b463-499b-abf9-e8d548f0fe36](https://github.com/user-attachments/assets/6af8f87e-cad5-4285-a1ba-0611be730e86)

And this is after this PR:

![Screenshot 2025-06-18 at 10-56-59 Qubes OS openQA qubesos-4 2-securedrop-x86_64-Build2025061209-4 2-securedrop_test_dom0@64bit test results](https://github.com/user-attachments/assets/8f72793d-f5d5-4395-9824-26f8e81078e7)

An initial effort explored how to make the [`convert_junit.py`](https://github.com/QubesOS/openqa-tests-qubesos/blob/f0d5d35/extra-files/convert_junit.py) script (prior to OpenQA parsing) to be able smooth these out, but ultimately proved to be too much complexity without effectively solving the core issue. At the same time, it made the script potentially less tolerant to other JunitXML inputs, namely the ones the Qubes team may need in the future.

Therefore, the most straightforward solution is to rename the tests on our end.

## Testing

- [ ] OpenQA CI passes for dom0 does not have "blank" tests (like the first image) -- My expectation is that OpenQA will be triggered on this PR.