### PR TITLE
CI: Run OpenQA tests from main upstream branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
             GIT_REF="$GIT_REF" \
             FLAVOR=securedrop \
             NEEDLES_DIR="%%CASEDIR%%/needles" \
-            CASEDIR="https://github.com/deeplow/openqa-tests-qubesos.git#securedrop-basic-functionality"\
+            CASEDIR="https://github.com/QubesOS/openqa-tests-qubesos.git#main"\
             MAX_JOB_TIME=10800 | tee openqa.json
       - name: Wait for openQA
         run: |

--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -194,6 +194,7 @@ class SD_VM_Platform_Tests(unittest.TestCase):
             vm = self.app.domains[vm_name]
             # First verify it looks like what we provisioned
             self._validate_apt_sources(vm)
+
             stdout, stderr = vm.run("apt-get indextargets")
             contents = stdout.decode().strip()
             assert (


### PR DESCRIPTION
## Description of Changes

With the merging of the base workstation tests [1], we can now point to main.

[1]: https://github.com/QubesOS/openqa-tests-qubesos/pull/35

## Testing

OpenQA tests are passing.