### PR TITLE
Run launcher tests dom0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ test-prereqs: ## Checks that test prerequisites are satisfied
 	which pytest coverage || (echo 'please install test dependencies with "sudo qubes-dom0-update python3-pytest python3-pytest-cov"' && exit 1)
 
 test: test-prereqs ## Runs all application tests (no integration tests yet)
-	pytest -v tests
+	pytest -v tests -v launcher/tests
 
 test-base: test-prereqs ## Runs tests for VMs layout
 	pytest -v tests/test_vms_exist.py

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,6 @@ CONTAINER := $(if $(shell grep "Thirty Seven" /etc/fedora-release),,./scripts/co
 
 HOST=$(shell hostname)
 
-ifneq ($(HOST),dom0)
-	POETRY_ARGS=poetry run
-endif
 
 assert-dom0: ## Confirms command is being run under dom0
 ifneq ($(HOST),dom0)
@@ -152,12 +149,12 @@ check: lint test ## Runs linters and tests
 lint: check-ruff mypy rpmlint shellcheck zizmor ## Runs all linters
 
 
+ifneq ($(HOST),dom0)  # Not necessary in dom0
+RUN_WRAPPERS=xvfb-run poetry run
+endif
 .PHONY: test-launcher
 test-launcher: ## Runs launcher tests
-ifeq ($(HOST),dom0)
-	@which pytest coverage xvfb-run || (echo 'please install test dependencies with "sudo qubes-dom0-update xorg-x11-server-Xvfb"' && exit 1)
-endif
-	xvfb-run $(POETRY_ARGS) python3 -m pytest --cov-report term-missing --cov=sdw_notify --cov=sdw_updater/ --cov=sdw_util -v launcher/tests/
+	$(RUN_WRAPPERS) python3 -m pytest --cov-report term-missing --cov=sdw_notify --cov=sdw_updater/ --cov=sdw_util -v launcher/tests/
 
 .PHONY: check-ruff
 check-ruff: ## Check Python source code formatting with ruff

--- a/launcher/tests/conftest.py
+++ b/launcher/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import socket
 import tempfile
 
 import pytest
@@ -12,3 +13,9 @@ def tmpdir():
         os.chdir(tmpdir)
         yield tmpdir
         os.chdir(cwd)
+
+
+skip_in_dom0 = pytest.mark.skipif(
+    socket.gethostname() == "dom0",
+    reason="Test cannot be run in dom0",
+)

--- a/launcher/tests/test_signing_key.py
+++ b/launcher/tests/test_signing_key.py
@@ -1,21 +1,17 @@
 import socket
-
-import pytest
-
-if socket.gethostname() == "dom0":
-    pytest.skip(
-        reason="not running due to unavailable dom0 python modules", allow_module_level=True
-    )
-
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
-import pysequoia
-from debian import deb822
+if socket.gethostname() != "dom0":
+    import pysequoia
+    from debian import deb822
+
+from conftest import skip_in_dom0
 
 ROOT = Path(__name__).parent.parent
 
 
+@skip_in_dom0
 def test_apt_sources():
     """Verify the key in the sources file is our prod signing key"""
     path = ROOT / "securedrop_salt/apt_freedom_press.sources.j2"
@@ -24,6 +20,7 @@ def test_apt_sources():
     assert_key(sources["Signed-By"].encode())
 
 
+@skip_in_dom0
 def test_dom0_key():
     path = ROOT / "securedrop_salt/securedrop-release-signing-pubkey-2021.asc"
     assert_key(path.read_bytes())

--- a/launcher/tests/test_signing_key.py
+++ b/launcher/tests/test_signing_key.py
@@ -1,3 +1,12 @@
+import socket
+
+import pytest
+
+if socket.gethostname() == "dom0":
+    pytest.skip(
+        reason="not running due to unavailable dom0 python modules", allow_module_level=True
+    )
+
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 

--- a/launcher/tests/test_signing_key.py
+++ b/launcher/tests/test_signing_key.py
@@ -8,6 +8,10 @@ if socket.gethostname() != "dom0":
 
 from conftest import skip_in_dom0
 
+# A couple of tests are skipped in dom0 since:
+#  - they rely on poetry-installed dependencies (not trival to get in dom0)
+#  - This test may go away later once the .sources files in the keyring package
+
 ROOT = Path(__name__).parent.parent
 
 

--- a/launcher/tests/test_sources.py
+++ b/launcher/tests/test_sources.py
@@ -5,6 +5,15 @@ Strictly speaking this doesn't have to do with the launcher, but
 it needs dependencies installed and to be run under pytest
 """
 
+import socket
+
+import pytest
+
+if socket.gethostname() == "dom0":
+    pytest.skip(
+        reason="not running due to unavailable dom0 python modules", allow_module_level=True
+    )
+
 from pathlib import Path
 
 import pysequoia

--- a/launcher/tests/test_sources.py
+++ b/launcher/tests/test_sources.py
@@ -14,6 +14,11 @@ if socket.gethostname() != "dom0":
 
 from conftest import skip_in_dom0
 
+# A couple of tests are skipped in dom0 since:
+#  - they rely on poetry-installed dependencies (not trival to get in dom0)
+#  - This test may go away later once the .sources files in the keyring package
+
+
 SECUREDROP_SALT = Path(__file__).parent.parent.parent / "securedrop_salt"
 
 

--- a/launcher/tests/test_sources.py
+++ b/launcher/tests/test_sources.py
@@ -6,22 +6,18 @@ it needs dependencies installed and to be run under pytest
 """
 
 import socket
-
-import pytest
-
-if socket.gethostname() == "dom0":
-    pytest.skip(
-        reason="not running due to unavailable dom0 python modules", allow_module_level=True
-    )
-
 from pathlib import Path
 
-import pysequoia
-from debian import deb822
+if socket.gethostname() != "dom0":
+    import pysequoia
+    from debian import deb822
+
+from conftest import skip_in_dom0
 
 SECUREDROP_SALT = Path(__file__).parent.parent.parent / "securedrop_salt"
 
 
+@skip_in_dom0
 def test_prod_sources():
     """Verify the key in the aptsources file is our prod signing key"""
     path = SECUREDROP_SALT / "apt_freedom_press.sources.j2"
@@ -37,6 +33,7 @@ def test_prod_sources():
     assert key.expiration.year == 2027
 
 
+@skip_in_dom0
 def test_test_sources():
     """Verify the key in the apt-test sources file is our dev signing key"""
     path = SECUREDROP_SALT / "apt-test_freedom_press.sources.j2"

--- a/launcher/tests/test_updater.py
+++ b/launcher/tests/test_updater.py
@@ -387,12 +387,11 @@ def test_read_dom0_update_flag_from_disk(mocked_error, mocked_subprocess, status
     assert not mocked_error.called
 
 
-@pytest.mark.parametrize("status", UpdateStatus)
 @mock.patch("subprocess.check_call")
 @mock.patch("sdw_updater.Updater.sdlog.error")
 @mock.patch("sdw_updater.Updater.sdlog.info")
 def test_read_dom0_update_flag_from_disk_fails(
-    mocked_info, mocked_error, mocked_subprocess, status, tmp_path
+    mocked_info, mocked_error, mocked_subprocess, tmp_path
 ):
     with mock.patch(
         "sdw_updater.Updater.get_dom0_path",

--- a/launcher/tests/test_updater.py
+++ b/launcher/tests/test_updater.py
@@ -2,6 +2,7 @@ import json
 import os
 import subprocess
 from datetime import datetime, timedelta
+from pathlib import Path
 from unittest import mock
 from unittest.mock import call
 
@@ -393,18 +394,18 @@ def test_read_dom0_update_flag_from_disk(mocked_error, mocked_subprocess, status
 def test_read_dom0_update_flag_from_disk_fails(
     mocked_info, mocked_error, mocked_subprocess, status, tmp_path
 ):
-    with mock.patch("os.path.expanduser", return_value=tmp_path):
-        flag_file_dom0 = Updater.get_dom0_path(Updater.FLAG_FILE_STATUS_DOM0)
-    updater_path = tmp_path / ".securedrop_updater"
-    updater_path.mkdir()
-    with open(flag_file_dom0, "w") as f:
-        f.write("something")
-
-    info_calls = [call("Cannot read dom0 status flag, assuming first run")]
-
-    assert Updater.read_dom0_update_flag_from_disk() is None
-    assert not mocked_error.called
-    mocked_info.assert_has_calls(info_calls)
+    with mock.patch(
+        "sdw_updater.Updater.get_dom0_path",
+        return_value=tmp_path / Path(Updater.FLAG_FILE_STATUS_DOM0),
+    ):
+        flag_file_dom0 = Path(Updater.get_dom0_path(Updater.FLAG_FILE_STATUS_DOM0))
+        flag_file_dom0.parent.mkdir()
+        with open(flag_file_dom0, "w") as f:
+            f.write("something")
+        info_calls = [call("Cannot read dom0 status flag, assuming first run")]
+        assert Updater.read_dom0_update_flag_from_disk() is None
+        assert not mocked_error.called
+        mocked_info.assert_has_calls(info_calls)
 
 
 @mock.patch(

--- a/launcher/tests/test_updaterapp.py
+++ b/launcher/tests/test_updaterapp.py
@@ -1,5 +1,3 @@
-import os
-import subprocess
 import unittest
 from unittest import mock
 
@@ -12,12 +10,9 @@ from sdw_updater.Updater import UpdateStatus, overall_update_status
 
 @pytest.fixture(scope="module", autouse=True)
 def app():
-    with subprocess.Popen(["/usr/bin/Xvfb", ":99"]) as xvfb:
-        os.environ["DISPLAY"] = ":99"
-        app = QApplication([])
-        yield app
-        app.quit()
-        xvfb.kill()
+    app = QApplication([])
+    yield app
+    app.quit()
 
 
 @mock.patch("sdw_updater.Updater.apply_updates_dom0", return_value=UpdateStatus.UPDATES_FAILED)


### PR DESCRIPTION
## Description of Changes

Fixes #1334 and also fixes a test that was actually not functionally correct.

## Testing

- make sure OpenQA is running also the launcher tests
- visual check
- make test runs launcher tests as well
- `make test-launcher` works in dom0 as well as `sd-dev`

## Deployment

(dev-facing. No deployment considerations)

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation