### PR TITLE
Display OpenQA Tests Results / Links as GitHub PR Checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
       OPENQA_KEY: ${{ secrets.OPENQA_KEY }}
       OPENQA_SECRET: ${{ secrets.OPENQA_SECRET }}
       GIT_REF: ${{ github.event.head_commit.id }}
+      GH_TOKEN: ${{ github.token }}
     container:
       image: debian:trixie
     steps:
@@ -115,7 +116,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install --yes openqa-client jq
+          apt-get install --yes openqa-client jq curl
       - name: Start openQA jobs
         run: |
           echo "Queuing openQA jobs for commit ${GIT_REF}"
@@ -132,13 +133,71 @@ jobs:
             NEEDLES_DIR="%%CASEDIR%%/needles" \
             CASEDIR="https://github.com/QubesOS/openqa-tests-qubesos.git#main"\
             MAX_JOB_TIME=10800 | tee openqa.json
+
+          for id in $(jq -r '.ids[]' openqa.json); do
+
+            # Obtain mapping (test_id, test_name)
+            openqa-cli api \
+              --host "$OPENQA_HOST" \
+              --apikey "$OPENQA_KEY" \
+              --apisecret "$OPENQA_SECRET" \
+              -X GET "jobs/${id}" | jq -r ".job.settings.TEST" >  "${id}_name.txt"
+            read TEST_NAME < "${id}_name.txt"
+
+            # Make OpenQA links visible by creating Github check for each
+            curl -L -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN"\
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/commits/$GIT_REF/statuses \
+            -d "{\"state\": \"pending\", \"target_url\": \"${OPENQA_HOST}tests/${id}\", \"context\": \"OpenQA / $TEST_NAME\"}"
+
+          done
       - name: Wait for openQA
         run: |
           openqa-cli monitor \
             --host "$OPENQA_HOST" \
             --apikey "$OPENQA_KEY" \
             --apisecret "$OPENQA_SECRET" \
-            $(jq -r '.ids[]' openqa.json)
+            $(jq -r '.ids[]' openqa.json) || :
+      - name: Get result
+        run: |
+          for id in $(jq -r '.ids[]' openqa.json); do
+            read TEST_NAME < "${id}_name.txt"
+
+            # Obtain mapping (test_id, test_name)
+            openqa_result=`openqa-cli api \
+              --host "$OPENQA_HOST" \
+              --apikey "$OPENQA_KEY" \
+              --apisecret "$OPENQA_SECRET" \
+              -X GET "jobs/${id}" | jq -r ".job.result"`
+
+            # Apply result mapping: OpenQA -> GitHub
+            case $openqa_result in
+                "passed")
+                    github_state="success"
+                    ;;
+                "failed")
+                    github_state="failure"
+                    ;;
+                "skipped"|"incomplete"|"user_cancelled")
+                    github_state="error"
+                    ;;
+                "none")
+                    continue
+                    ;;
+                *)
+                    echo "Unknown test status: $openqa_result"
+                    exit 1
+                    ;;
+            esac
+            curl -L -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN"\
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/commits/$GIT_REF/statuses \
+            -d "{\"state\": \"$github_state\", \"target_url\": \"${OPENQA_HOST}tests/${id}\", \"context\": \"OpenQA / $TEST_NAME\"}"
+          done
       - name: Cancel openQA test (if needed)
         if: cancelled()
         run: |
@@ -149,12 +208,12 @@ jobs:
               --apikey "$OPENQA_KEY" \
               --apisecret "$OPENQA_SECRET" \
               -X POST "jobs/${id}/cancel" ||:
-          done
-      - name: View logs
-        if: always()
-        run: |
-          echo "View the logs for this run at:"
 
-          for id in $(jq -r '.ids[]' openqa.json); do
-            echo "${OPENQA_HOST}tests/${id}"
+            read TEST_NAME < "${id}_name.txt"
+            curl -L -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN"\
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/commits/$GIT_REF/statuses \
+            -d "{\"state\": \"error\", \"target_url\": \"${OPENQA_HOST}tests/${id}\", \"context\": \"OpenQA / $TEST_NAME\"}" ||:
           done


### PR DESCRIPTION
## Description of Changes

Fixes #1359. Makes it easy to see OpenQA test status with a convenient link to OpenQA's UI.
Implemented via commit statuses. I tried via github checks, but overriding the URL was not working.

## Testing

> **Note:** Since this pertains to CI tests, it's a bit hard to test without making modifications. Feel free to do them, but to make review easier, I am providing a table bellow with commits I made simulating specific conditions. Github then has a way to see the result in the individual commits.

- [ ] For each result type, confirm the result matches the expectation (check table bellow)
- [ ] No scenarios were missed in table bellow
- [ ] GitHub OpenQA statuses link to respective test on OpenQA

|  Situation (commit) | Result  |
|-----|-----|
| Pending | <img width="762" height="167" alt="Screenshot 2025-07-11 at 09-39-51 Display OpenQA Tests Results _ Links as GitHub PR Checks by deeplow · Pull Request #1363 · freedomofpress_securedrop-workstation" src="https://github.com/user-attachments/assets/3274aef9-b732-4dbf-858f-ca808d5cf311" /> |
| Success  (https://github.com/freedomofpress/securedrop-workstation/pull/1363/commits/fd5a61a2d60f96aeb594d1802e2544a37688e484) | <img width="762" height="172" alt="all-good" src="https://github.com/user-attachments/assets/171ffc63-27f5-425b-8399-c29e519937a3" /> | 
| Partial Success  (https://github.com/freedomofpress/securedrop-workstation/pull/1363/commits/14170600762eac1ae35f99791c11cb1a5f08c071)| <img width="1128" height="339" alt="Screenshot 2025-08-04 at 18-01-44 Display OpenQA Tests Results _ Links as GitHub PR Checks by deeplow · Pull Request #1363 · freedomofpress_securedrop-workstation" src="https://github.com/user-attachments/assets/46d087f5-1a52-42b4-bf1e-da2b7390f105" /> |
| Cancelled on OpenQA ([d0d1e64](https://github.com/freedomofpress/securedrop-workstation/pull/1363/commits/d0d1e648705fee854dd69b7ecb01d4a6be021978)) | <img width="1059" height="311" alt="Screenshot 2025-08-05 at 12-47-12 Display OpenQA Tests Results _ Links as GitHub PR Checks by deeplow · Pull Request #1363 · freedomofpress_securedrop-workstation" src="https://github.com/user-attachments/assets/4b992e6c-ad37-41a3-8829-71673b1ccd77" /> |
| Cancelled on GitHub ([12f9940c](https://github.com/freedomofpress/securedrop-workstation/pull/1363/commits/12f9940c0bbab517f212bceb80523eff6104572d)) |<img width="1083" height="241" alt="Screenshot 2025-08-05 at 13-02-11 Display OpenQA Tests Results _ Links as GitHub PR Checks by deeplow · Pull Request #1363 · freedomofpress_securedrop-workstation" src="https://github.com/user-attachments/assets/a11589d2-fb01-4053-8bac-8fc0fe7afd9b" /> |
