### PR TITLE
1.2.1 backports

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # changelog
 
+## 1.2.1
+
+* Disable SELinux to work around failed update of Fedora templates (#1370)
+
 ## 1.2.0
 
 This release mainly enables support for driverless printing, which

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -154,8 +154,8 @@ qubesctl saltutil.sync_all refresh=true -l quiet --out quiet > /dev/null || true
 qubesctl top.enable securedrop_salt.sd-workstation > /dev/null ||:
 
 # Force full run of all Salt states - uncomment in release branch
-mkdir -p /tmp/sdw-migrations
-touch /tmp/sdw-migrations/fedora-selinux-fix
+# mkdir -p /tmp/sdw-migrations
+# touch /tmp/sdw-migrations/fedora-selinux-fix
 
 # Enable service that conditionally removes our systemd-logind customizations
 # on dev machines only.

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -154,8 +154,8 @@ qubesctl saltutil.sync_all refresh=true -l quiet --out quiet > /dev/null || true
 qubesctl top.enable securedrop_salt.sd-workstation > /dev/null ||:
 
 # Force full run of all Salt states - uncomment in release branch
-# mkdir -p /tmp/sdw-migrations
-# touch /tmp/sdw-migrations/whonix-17-update
+mkdir -p /tmp/sdw-migrations
+touch /tmp/sdw-migrations/fedora-selinux-fix
 
 # Enable service that conditionally removes our systemd-logind customizations
 # on dev machines only.

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -181,7 +181,10 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
-* Tue May 13 2025 SecureDrop Team <securedrop@freedom.press> - 1.3.0rc1
+* Mon Jul 14 2025 SecureDrop Team <securedrop@freedom.press> - 1.3.0rc1
+- See changelog.md
+
+* Mon Jul 14 2025 SecureDrop Team <securedrop@freedom.press> - 1.2.1
 - See changelog.md
 
 * Tue May 13 2025 SecureDrop Team <securedrop@freedom.press> - 1.2.0

--- a/securedrop_salt/sd-sys-vms.sls
+++ b/securedrop_salt/sd-sys-vms.sls
@@ -31,6 +31,16 @@ set-fedora-template-as-default-mgmt-dvm:
     - require:
       - cmd: dom0-install-fedora-template
 
+# Temporary workaround for https://github.com/QubesOS/qubes-issues/issues/9503
+fedora-bypass-selinux:
+  qvm.vm:
+    - name: {{ sd_fedora_base_template }}
+    - features:
+      - disable:
+        - selinux
+    - require:
+      - cmd: set-fedora-template-as-default-mgmt-dvm
+
 # If the VM has just been installed via package manager, update it immediately
 update-fedora-template-if-new:
   cmd.wait:
@@ -41,7 +51,7 @@ update-fedora-template-if-new:
       # Update the mgmt-dvm setting first, to avoid problems during first update
       - cmd: set-fedora-template-as-default-mgmt-dvm
     - watch:
-      - cmd: dom0-install-fedora-template
+      - qvm: fedora-bypass-selinux
 
 # qvm.default-dispvm is not strictly required here, but we want it to be
 # updated as soon as possible to ensure make clean completes successfully, as

--- a/tests/base.py
+++ b/tests/base.py
@@ -2,6 +2,7 @@ import json
 import subprocess
 import unittest
 
+import pytest
 from qubesadmin import Qubes
 
 # Reusable constant for DRY import across tests
@@ -220,6 +221,8 @@ class Test_SD_VM_Common:
 
     def test_lsm_enabled(self, qube):
         """Check that the expected LSM is enabled"""
+        if qube.name == "sys-usb":
+            pytest.skip("Temporarily skipped due qubes-issues#1369")
         if qube.linux_security_modules == "apparmor":
             assert qube.package_is_installed("apparmor")
             # returns error code if AppArmor not enabled


### PR DESCRIPTION
## Description of Changes

Applies 1.2.0 backports and temporarily suppresses a test so main doesn't break.

## Testing

- [x] test skipped `test_sys_usb.SD_SysUSB_Tests.test_lsm_enabled`
- [x] all 1.2.1 backports were applied
- [x] migrations flag disabled

## Deployment
No special consideration

## Checklist

### If you have made changes to the provisioning logic

- [ ] All tests (`make test`) pass in `dom0`

### If you have added or removed files

- [ ] I have updated `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`

### If documentation is required

- [ ] I have opened a PR in the [docs repo](https://github.com/freedomofpress/securedrop-workstation-docs) for these changes, or will do so later
- [ ] I would appreciate help with the documentation