### PR TITLE
Use quay.io for fedora images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     container:
-      image: registry.fedoraproject.org/fedora:37
+      image: quay.io/fedora/fedora:37
     steps:
       - run: dnf install -y git make
       - uses: actions/checkout@v4
@@ -33,7 +33,7 @@ jobs:
   build-rpm:
     runs-on: ubuntu-latest
     container:
-      image: registry.fedoraproject.org/fedora:37
+      image: quay.io/fedora/fedora:37
     steps:
       - run: dnf install -y git make
       - uses: actions/checkout@v4
@@ -53,7 +53,7 @@ jobs:
   launcher-tests:
     runs-on: ubuntu-latest
     container:
-      image: registry.fedoraproject.org/fedora:37
+      image: quay.io/fedora/fedora:37
     steps:
       - run: dnf install -y make
       - uses: actions/checkout@v4

--- a/bootstrap/Dockerfile
+++ b/bootstrap/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:37
+FROM quay.io/fedora/fedora:37
 LABEL org="Freedom of the Press"
 LABEL image_name="securedrop-workstation-qubes-4.2"
 


### PR DESCRIPTION
Fixes #1385

replaces `registry.fedoraproject.org` refs with `quay.io/fedora` ones instead (it's been a redirect for a while and the former is currently getting ddosed anyway).

## Test plan
- [ ] CI passing
