### PR TITLE
Replace Fedora registry quay.io in nightly

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -19,7 +19,7 @@ jobs:
   build-rpm:
     runs-on: ubuntu-latest
     container:
-      image: registry.fedoraproject.org/fedora:37
+      image: quay.io/fedora/fedora:37
     steps:
       - run: dnf install -y make git
       - uses: actions/checkout@v4


### PR DESCRIPTION
Missed in 705effc. Fixes #1385.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
