### PR TITLE
Require securedrop-workstation-keyring (prod) package

### DIFF
--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -40,6 +40,7 @@ BuildRequires:	systemd-rpm-macros
 # This package installs all standard VMs in Qubes
 Requires:		qubes-mgmt-salt-dom0-virtual-machines
 Requires:		python3-qt5
+Requires:       securedrop-workstation-keyring
 
 %description
 This package contains VM configuration files for the Qubes-based


### PR DESCRIPTION
WIP  (last to merge; dom0 tests will be written after #1210 and #1393 are merged)

Explicitly depend on the keyring package in the dom0 config rpm.

That means the (prod) keyring package must always be installed (even on developer setups); this is similar to our apt-keyring strategy.

## Test plan
- [ ] base branch is `feat/sdw-keyring-compat`
- [ ] visual review
- [ ] Build local rpm, then uninstall prod keyring package (if installed), which will remove the prod signing key from rpm db. Installation fails.
- [ ] Build local rpm and install (locally-built) prod keyring package. Installation of local rpm succeeds.  (When prod package is available on qubes-contrib, can test with it as well.)
- [ ] Upgrade testing: (will be part of release QA, once prod keyring package is hosted on qubes-contrib) Upgrading dom0 config rpm to one with these changes also pulls in the prod keyring package.  This can also be tested against our yum-qa repo if we publish a prod keyring package there. 

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
