### PR TITLE
Add release template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -39,8 +39,16 @@ Refer to the [SecureDrop Workstation RM docs](https://developers.securedrop.org/
 
 ## Test Plan
 
-### Fresh install
+### Common tests
 
-### Upgrade testing
+### Scenario: Fresh install
+
+- `config.json` environment:
+- Other QA setup notes:
+
+### Scenario: Upgrade testing
+
+- `config.json` environment:
+- Other QA setup notes:
 
 ### Additional testing (if applicable)


### PR DESCRIPTION
Fixes #1321

Draws inspiration from https://github.com/freedomofpress/securedrop-client/blob/main/.github/ISSUE_TEMPLATE/release.md but I've generally opted for brief wording since https://developers.securedrop.org/en/latest/workstation_release_management.html should be our canonical, detailed documentation and going into too much detail here risks that things may fall out of sync.

This change accounts for:
- [x] any necessary RPM packaging updates (e.g., added/removed files, see `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [x] any required documentation
