### PR TITLE
Perform salt 'migration' to fix device auto-attach

### DIFF
--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -154,8 +154,8 @@ qubesctl saltutil.sync_all refresh=true -l quiet --out quiet > /dev/null || true
 qubesctl top.enable securedrop_salt.sd-workstation > /dev/null ||:
 
 # Force full run of all Salt states - uncomment in release branch
-# mkdir -p /tmp/sdw-migrations
-# touch /tmp/sdw-migrations/fedora-selinux-fix
+mkdir -p /tmp/sdw-migrations
+touch /tmp/sdw-migrations/fedora-42-bump
 
 # Enable service that conditionally removes our systemd-logind customizations
 # on dev machines only.


### PR DESCRIPTION
Attaching USB drives and printers got broken in the 1.3.0 release. This was because a migration was missed (`sdw-admin --apply`). This change introduces this missing migration, thus fixing the issue upon update installation.

Fixes #1420