### PR TITLE
Fix test_proxy_config

### DIFF
--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -124,7 +124,7 @@ class SD_VM_Tests(unittest.TestCase):
         assert vm.features["vm-config.SD_MIME_HANDLING"] == "default"
         self._check_service_running(vm, "securedrop-mime-handling")
         self._check_service_running(vm, "securedrop-proxy-onion-config")
-        self._check_service_running(vm, "securedrop-arti")
+        self._check_service_running(vm, "tor")
 
     def test_sd_proxy_dvm(self):
         vm = self.app.domains["sd-proxy-dvm"]


### PR DESCRIPTION
## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

Test failure during 1.4.0 release flew under the radar due to issues with CI. The service "securedrop-arti" is no longer expected, but instead `tor.service`.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] any necessary RPM packaging updates (e.g., added/removed files, see `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [x] any required documentation
