### PR TITLE
Fix reference to remove-deprecated-qubes.sls

### DIFF
--- a/files/sdw-admin.py
+++ b/files/sdw-admin.py
@@ -265,7 +265,7 @@ def perform_uninstall():
             ["sudo", "qubesctl", "state.sls", "securedrop_salt.sd-clean-default-dispvm"]
         )
         print("Destroying all VMs")
-        provision("Removing unused SDW qubes", "securedrop_salt.sd-remove-deprecated-qubes")
+        provision("Removing unused SDW qubes", "securedrop_salt.sd-remove-unused-qubes")
         subprocess.check_call([os.path.join(SCRIPTS_PATH, "scripts/destroy-vm"), "--all-tagged"])
         print("Reverting dom0 configuration")
         subprocess.check_call(["sudo", "qubesctl", "state.sls", "securedrop_salt.sd-clean-all"])


### PR DESCRIPTION
Now renamed to remove-unused-qubes.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] `sdw-admin --uninstall` works.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
