### PR TITLE
Suppress GPG prompt

### DIFF
--- a/securedrop_salt/sd-gpg-files.sls
+++ b/securedrop_salt/sd-gpg-files.sls
@@ -16,7 +16,8 @@ sd-gpg-increase-keyring-access-timeout:
     - marker_start: "### BEGIN securedrop-workstation ###"
     - marker_end: "### END securedrop-workstation ###"
     - content: |
-        export QUBES_GPG_AUTOACCEPT=2147483647 # hides GPG prompt (max epoch)
+        # hides GPG prompt (max epoch)
+        export QUBES_GPG_AUTOACCEPT=2147483647
 
 sd-gpg-create-keyring-directory:
   file.directory:

--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -63,7 +63,7 @@ def vm_fingerprint(qube):
 
 
 def test_sd_gpg_timeout(qube):
-    line = "export QUBES_GPG_AUTOACCEPT=28800"
+    line = "export QUBES_GPG_AUTOACCEPT=2147483647"
     qube.assertFileHasLine("/home/user/.profile", line)
 
 


### PR DESCRIPTION
Open a fix, per discussion with @legoktm. This suppresses the following prompt that showed up on first start and then every now and then:

![gpg_key](https://github.com/freedomofpress/securedrop-workstation/assets/47065258/bd73de55-060c-4d75-91ee-b7056b6f821a)

Prompt was an unnecessary extra UX hoop as there was no reason for denying the prompt (after all, the user always wants sd-app to be able to have its submissions decrypted). The qrexec policy is a more effective counter-measure, which is already in place: if it exists, the GPG decryption is allowed. If it's not there, then it's not allowed.



Suppression is done by setting the max linux epoch value (2**31-1). This works because When the qubes.Gpg RPC service is called, it compares the expiry date with the current time.

Fixes #960

(test on: openqa)

[1]: https://github.com/QubesOS/qubes-app-linux-split-gpg/blob/bf8d6b38b58ad63bada2fce3c78a56aec2a421f6/qubes.Gpg.service#L32

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
- upgrade path
  - [x] make dev (over existing dev install)
  - [x] check that sd-gpg does not show any prompt
- "clean install"
  - [x] `qvm-remove sd-gpg`
  - [x] repeat "upgrade path" plan

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
