### PR TITLE
Hardcode 'main' as GIT_REF for nightly OpenQA job

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -93,3 +93,5 @@ jobs:
   openqa-nightly:
     uses: ./.github/workflows/openqa.yml
     secrets: inherit
+    env:
+      GIT_REF: "main"


### PR DESCRIPTION
**Update**: I've realized now that [this worked in](https://github.com/freedomofpress/securedrop-workstation/actions/runs/18984333523/job/54224432446#step:5:44) a not-so-distant nightly. **So after all this PR may not be needed.**

${GIT_REF} was not accessible as an inherited secret since it was calculated with ${{ github.event.head_commit.id }}. Apparently this is not accessible from scheduled events.

Ideally we'd place the exact commit hash, rather than 'main', so that on OpenQA we can reference it back. But as a temporary relief, this already enables the nightly job to work.

Fixes #1470

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
Should we add this as a PR's workflow to test or is there a better way to test this?
