### PR TITLE
Fix OpenQA job on 404 returned from GitHub API

### DIFF
--- a/.github/workflows/openqa.yml
+++ b/.github/workflows/openqa.yml
@@ -56,7 +56,7 @@ jobs:
             read TEST_NAME < "${id}_name.txt"
 
             # Make OpenQA links visible by creating Github check for each
-            curl -L -X POST \
+            curl --fail -L -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $GH_TOKEN"\
             -H "X-GitHub-Api-Version: 2022-11-28" \
@@ -102,7 +102,7 @@ jobs:
                     exit 1
                     ;;
             esac
-            curl -L -X POST \
+            curl --fail -L -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $GH_TOKEN"\
             -H "X-GitHub-Api-Version: 2022-11-28" \
@@ -121,7 +121,7 @@ jobs:
               -X POST "jobs/${id}/cancel" ||:
 
             read TEST_NAME < "${id}_name.txt"
-            curl -L -X POST \
+            curl --fail -L -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $GH_TOKEN"\
             -H "X-GitHub-Api-Version: 2022-11-28" \


### PR DESCRIPTION
The OpenQA workflow is supposed to pass, except when there is a problem with the script itself. This didn't happen as it turns out that curl doesn't fail on 404. This adds the "--fail" parameter to catch these situations.

Fixes #1471 

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
:red_circle: **expected failure:** I pushed a commit `6f200ed` to force failure. [It did in fact fail](https://github.com/freedomofpress/securedrop-workstation/actions/runs/19034787977/job/54356561221?pr=1473), as we wanted.
:green_circle: **expected success:** Observe the result of the OpenQA status for this PR (**NOTE**: I have lowered the priority on OpenQA itself as not to clog Qubes' own tests)

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
