### PR TITLE
Start building Qubes 4.3 (Fedora 41) nightlies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,14 @@ jobs:
           make lint
   build-rpm:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        fedora_version:
+          - 37  # Qubes 4.2
+          - 41  # Qubes 4.3
     container:
-      image: quay.io/fedora/fedora:37
+      image: quay.io/fedora/fedora:${{ matrix.fedora_version }}
     steps:
       - run: dnf install -y git make
       - uses: actions/checkout@v5

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -18,8 +18,14 @@ defaults:
 jobs:
   build-rpm:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        fedora_version:
+          - 37  # Qubes 4.2
+          - 41  # Qubes 4.3
     container:
-      image: quay.io/fedora/fedora:37
+      image: quay.io/fedora/fedora:${{ matrix.fedora_version }}
     steps:
       - run: dnf install -y make git
       - uses: actions/checkout@v5
@@ -36,7 +42,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         id: upload
         with:
-          name: rpm-build
+          name: rpm-build-${{ matrix.fedora_version }}
           path: rpm-build/RPMS/noarch/*.rpm
           if-no-files-found: error
 
@@ -77,7 +83,9 @@ jobs:
           git config --global user.name "sdcibot-nightlies[bot]"
           cd securedrop-yum-test
           mkdir -p workstation/dom0/f37-nightlies
-          cp -v ../rpm-build/*.rpm workstation/dom0/f37-nightlies/
+          cp -v ../rpm-build-37/*.rpm workstation/dom0/f37-nightlies/
+          mkdir -p workstation/dom0/f41-nightlies
+          cp -v ../rpm-build-41/*.rpm workstation/dom0/f41-nightlies/
           git add .
           git diff-index --quiet HEAD || git commit -m "Automated SecureDrop workstation build"
           git push https://x-access-token:${GH_TOKEN}@github.com/${TARGET_REPO}.git main

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 DEFAULT_GOAL: help
 PYTHON3 := $(if $(shell bash -c "command -v python3.11"), python3.11, python3)
-# If we're on anything but Fedora 37, execute some commands in a container
+# If we're on anything but Fedora 37/41, execute some commands in a container
 # Note: if your development environment is Fedora 37 based, you may want to
 # manually prepend ./scripts/container.sh to commands you want to execute
-CONTAINER := $(if $(shell grep "Thirty Seven" /etc/fedora-release),,./scripts/container.sh)
+CONTAINER := $(if $(shell grep -E "(Thirty Seven|Forty One)" /etc/fedora-release),,./scripts/container.sh)
 
 HOST=$(shell hostname)
 

--- a/bootstrap/Dockerfile
+++ b/bootstrap/Dockerfile
@@ -1,6 +1,5 @@
-FROM quay.io/fedora/fedora:37
-LABEL org="Freedom of the Press"
-LABEL image_name="securedrop-workstation-qubes-4.2"
+ARG FEDORA_VERSION=37
+FROM quay.io/fedora/fedora:${FEDORA_VERSION}
 
 ARG USER_NAME
 ENV USER_NAME ${USER_NAME:-root}

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -2,6 +2,7 @@ TOPLEVEL=$(git rev-parse --show-toplevel)
 export TOPLEVEL
 PROJECT="securedrop-workstation-dom0-config"
 export PROJECT
+export FEDORA_VERSION="${FEDORA_VERSION:-37}"
 
 OCI_RUN_ARGUMENTS="${OCI_RUN_ARGUMENTS:-}"
 export OCI_RUN_ARGUMENTS

--- a/scripts/container.sh
+++ b/scripts/container.sh
@@ -7,14 +7,13 @@ set -eu
 
 source "$(dirname "$0")/common.sh"
 
+OCI_BUILD_ARGUMENTS="${OCI_BUILD_ARGUMENTS:-} --build-arg=FEDORA_VERSION=${FEDORA_VERSION}"
+
 # Whenever we're not on the platform we expect, explicitly tell the container
 # runtime what platform we need
-# This is also relevant for CI, as the --platform argument is only available
-# from Docker API 1.32 onward, while at the time of writing CircleCI still on
-# API 1.23
 if [[ "$(uname -sm)" != "Linux x86_64" ]]; then
     OCI_RUN_ARGUMENTS="${OCI_RUN_ARGUMENTS} --platform linux/amd64"
-    OCI_BUILD_ARGUMENTS="${OCI_RUN_ARGUMENTS} --platform linux/amd64"
+    OCI_BUILD_ARGUMENTS="${OCI_BUILD_ARGUMENTS} --platform linux/amd64"
 fi
 
 # Pass -it if we're a tty
@@ -34,10 +33,10 @@ fi
 
 
 function oci_image() {
-    NAME="${1}${SUFFIX}"
+    NAME="${1}${FEDORA_VERSION}${SUFFIX}"
 
     $OCI_BIN build \
-           ${OCI_BUILD_ARGUMENTS:-} \
+           ${OCI_BUILD_ARGUMENTS} \
            --build-arg=USER_ID="$(id -u)" \
            --build-arg=USER_NAME="${USER:-root}" \
            --build-arg=DEPS="${DEPS}" \


### PR DESCRIPTION
Provides the base infrastructure needed to build the RPM on Fedora 41 and push it to yum-test, with no attention paid to whether that RPM works or not.

Fixes #1476.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] Review https://github.com/freedomofpress/securedrop-workstation/actions/runs/19312766805/job/55237007016, see that it created both f37 and f41 packages and would've pushed it to yum-test (had I not commented that part out)

Note that once this is ready to merge, we'll need infra to update the "Required" CI levels to use the new job names.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
