### PR TITLE
Fix image name not including Fedora version suffix

### DIFF
--- a/scripts/container.sh
+++ b/scripts/container.sh
@@ -48,7 +48,7 @@ function oci_image() {
 function oci_run() {
     find . \( -name '*.pyc' -o -name __pycache__ \) -delete
 
-    NAME="${1}${SUFFIX}"
+    NAME="${1}${FEDORA_VERSION}${SUFFIX}"
 
     $OCI_BIN run \
            --rm \


### PR DESCRIPTION
oci_run was not also updated to have the image name use the version suffix, it only passed locally because we had the old image still built that worked.

This should fix OpenQA builds.

Fixes #1488.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] Run `podman rmi localhost/securedrop-workstation-dom0-config:latest` (or docker equivalent) locally and ensure that the old name of the image no longer exists
* [ ] Run `make build-rpm` and it works.
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
