### PR TITLE
Revert "Hardcode 'main' as GIT_REF for nightly OpenQA job"

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -93,5 +93,3 @@ jobs:
   openqa-nightly:
     uses: ./.github/workflows/openqa.yml
     secrets: inherit
-    env:
-      GIT_REF: "main"


### PR DESCRIPTION
Reverts freedomofpress/securedrop-workstation#1472

This isn't valid GHA syntax and broke nightlies.