### PR TITLE
fix first-run make-dev via dom0 keyring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,9 @@ assert-keyring-%: ## Correct keyring pkg installed
 	fi
 
 install-rpm: assert-dom0 ## Install locally-built rpm (dev) or download published rpm
+	# All environments depend on the prod keyring package
+	@echo "Installing prod keyring package"
+	@rpm -q securedrop-workstation-keyring || sudo qubes-dom0-update -y --clean securedrop-workstation-keyring
 ifeq ($(RPM_INSTALL_STRATEGY),dev)
 	@echo "Install dependencies and locally-built rpm"
 	@sudo qubes-dom0-update --clean -y grub2-xen-pvh


### PR DESCRIPTION
The `make dev` flow had an implicit dependency on the prod `securedrop-workstation-keyring` package being already installed in dom0. The dev and staging targets will also configure other repos, but in all cases, we want the prod signing key and repo to be present, otherwise the installation of `securedrop-workstation-dom0-config` will fail.

Closes #1484.

## Test plan
An adequate test would require a "clean" workstation, without any pre-existing SDW software installed on it. Since presumably those are hard to come by on the time, review the diff visually, and make sure it does what it says on the tin: installs the `securedrop-workstation-keyring` RPM package in dom0, prior to kicking off the full provisioning run.

## Checklist

This change accounts for:
- [x] any necessary RPM packaging updates (e.g., added/removed files, see `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [x] any required documentation
