### PR TITLE
fix clock skew on make-dev rpm build

### DIFF
--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -12,6 +12,11 @@ git clean -fdX rpm-build/ dist/
 # touch everything to a date in the future, so that way
 # rpm will clamp the mtimes down to the SOURCE_DATE_EPOCH
 find . -type f -exec touch -m -d "+1 day" {} \;
+
+# set a trap to reset the file mtimes to present time, otherwise
+# the `make clone` operation will spew tar errors about timestamps from the future.
+trap 'find . -type f -exec touch -m {} \;' EXIT
+
 /usr/bin/python3 setup.py sdist
 
 # Place tarball where rpmbuild will find it


### PR DESCRIPTION
Re-touches RPM source files to reset the mtimes to present time, avoiding warnings via tar about clock skew when copying to dom0 via `make clone`.

Encountered this issue while working on #1484, fixed it, and later looked up an issue and discovered it: therefore, closes #1399.

## Test plan
0. Check out this branch in `sd-dev`
1. Run `make clone` from dom0, observe clock skew
2. Run `make clone` from dom0 again, observe no clock skew!

## Checklist

This change accounts for:
- [x] any necessary RPM packaging updates (e.g., added/removed files, see `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [x] any required documentation
