### PR TITLE
Nightlies: fix wrongly set `git_ref` actions input

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -113,4 +113,4 @@ jobs:
     needs: ["get-main-commit"]
     with:
       environment: "dev"
-      git_ref: ${{ needs.jobs.get-main-commit.outputs.main-commit}}
+      git_ref: ${{ needs.get-main-commit.outputs.main-commit}}


### PR DESCRIPTION
The supposed nightlies fixed introduced in https://github.com/freedomofpress/securedrop-workstation/pull/1504 contained a typo that is now fixed by this PR. This was an oversight that was not considered in the test instructions.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
A simulation of the nightly is in commit https://github.com/freedomofpress/securedrop-workstation/commit/201f74e1e88a774aa8dac836afd6734c773ba401
- [ ] Ensure that test correctly tests this change (see [diff](https://github.com/freedomofpress/securedrop-workstation/compare/201f74e1e88a774aa8dac836afd6734c773ba401...2025-12-unbreak-nightly#diff-80505581d0825c22f85d855bab0d91a21e6117e407ef8a910c6dc41ced95f1a5L116-R116))
- [ ] Look at CI jobs for [the test commit](https://github.com/freedomofpress/securedrop-workstation/commit/201f74e1e88a774aa8dac836afd6734c773ba401) and click the simulated nightly run:

   <img width="833" height="52" alt="Screenshot 2025-12-03 at 11-00-24 WIP unbreak nightlities · freedomofpress_securedrop-workstation@201f74e" src="https://github.com/user-attachments/assets/10b8b7c7-b748-40c9-9ee0-9062acad3aa8" />

   - [ ] expand "set up job" and look at "inputs". There you should confirm that it includes the commit. As an example [this](https://github.com/freedomofpress/securedrop-workstation/actions/runs/19891193295/job/57010199913#step:1:45) is what it should look like and [this](https://github.com/freedomofpress/securedrop-workstation/actions/runs/19884158046/job/56987937161#step:1:45) is what it should NOT look like. 

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
