### PR TITLE
Update nightlies repo structure

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -89,6 +89,7 @@ jobs:
           git config --global user.name "sdcibot-nightlies[bot]"
           cd securedrop-yum-test
           mkdir -p $QUBES_REPO_DIR
+          [ ! -e $QUBES_REPO_DIR ] && ln -s $(basename $FEDORA_REPO_DIR) $QUBES_REPO_DIR  # Keep old structure
           cp -v ../rpm-build-${{ matrix.qubes_release.fedora_ver }}/*.rpm $QUBES_REPO_DIR
           git add .
           git diff-index --quiet HEAD || git commit -m "Automated SecureDrop workstation build"


### PR DESCRIPTION
Repo structure changed due to #1508. This updates the nightly workflow to push to the correct directories.

To be merged in coordination with:
- https://github.com/freedomofpress/securedrop-yum-test/pull/83

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
- visual review (confirm new directories match https://github.com/freedomofpress/securedrop-yum-test/pull/83)

It's kind of hard to test this one because it requires coordination with another merge. I'm guessing visual review should be enough and if something breaks we just revert it. 