### PR TITLE
Add `make run-app`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,8 +139,8 @@ test-gpg: test-prereqs ## Runs tests for SD GPG functionality
 # Client autologin variables
 XDOTOOL_PATH=$(shell command -v xdotool)
 OATHTOOL_PATH=$(shell command -v oathtool)
-PHONY: run-client
-run-client: assert-dom0 ## Run client application (automatic login)
+.PHONY: run-deps
+run-deps:
 ifeq ($(XDOTOOL_PATH),)
 	@echo $(XDOTOOL_PATH)
 	@echo 'please install xdotool with "sudo qubes-dom0-update xdotool"'
@@ -150,12 +150,26 @@ ifeq ($(OATHTOOL_PATH),)
 	@echo 'please install oathtool with "sudo qubes-dom0-update oathtool"'
 	@false
 endif
+
+PHONY: run-client
+run-client: assert-dom0 run-deps ## Run client application (automatic login)
 	qvm-run --service sd-app qubes.StartApp+press.freedom.SecureDropClient
 	@sleep 3
 	@xdotool type "journalist"
 	@xdotool key Tab
 	@xdotool type "correct horse battery staple profanity oil chewy"
 	@xdotool key Tab
+	@xdotool key Tab
+	@xdotool type $(shell oathtool --totp --base32 JHCOGO7VCER3EJ4L)
+	@xdotool key Return
+
+PHONY: run-app
+run-app: assert-dom0 run-deps ## Run SecureDrop App (automatic login)
+	qvm-run --service sd-app qubes.StartApp+press.freedom.SecureDropApp
+	@sleep 5
+	@xdotool type "journalist"
+	@xdotool key Tab
+	@xdotool type "correct horse battery staple profanity oil chewy"
 	@xdotool key Tab
 	@xdotool type $(shell oathtool --totp --base32 JHCOGO7VCER3EJ4L)
 	@xdotool key Return

--- a/scripts/try-client-pr.py
+++ b/scripts/try-client-pr.py
@@ -163,7 +163,8 @@ def main():
     ).splitlines()
     subprocess.check_call(["qvm-shutdown", "--wait"] + all_vms)
     print(f"\n\nYour workstation is provisioned with PR #{args.pr_id}.")
-    print("\n\nYou can start the client with `make run-client`.")
+    target = "app" if args.app else "client"
+    print(f"\n\nYou can start the {target} with `make run-{target}`.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Same as `run-client`, but just for the app

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] After installing the app, try it with `make run-app`
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
