### PR TITLE
Unbreak OpenQA tests with new parameters

### DIFF
--- a/.github/workflows/openqa.yml
+++ b/.github/workflows/openqa.yml
@@ -53,6 +53,7 @@ jobs:
             DISTRI=qubesos ARCH=x86_64 \
             GIT_REF="$GIT_REF" \
             SECUREDROP_ENV="$SECUREDROP_ENV" \
+            XRES=1920 YRES=1080 \
             FLAVOR=securedrop \
             CASEDIR="${SECUREDROP_OPENQA_REPO_URL}#${SECUREDROP_OPENQA_REPO_BRANCH}" \
             MAX_JOB_TIME=10800 | tee openqa.json


### PR DESCRIPTION
Minor parameter changes for OpenQA that make it possible to run GUI tests:
- Remove `NEEDLES_DIR` (this one turned out to also critical to [unbreak CI](https://github.com/freedomofpress/securedrop-workstation/pull/1373#issuecomment-3666624573))
- Increase screen resolution in GUI tests (otherwise the classic client would be cropped)

See commit message for context.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
- [x] Make sure tests pass, as expected
- [ ] Look at the screen dimension in OpenQA and compare it with the nightly test (the former should be 16:9, indicative of 1080p whereas the later is 4:6)

**NOTE:** Actually validating the NEEDLES_DIR fix is a bit more involved (not sure if worth the trouble). But it would be basically:
1. Switch OpenQA repo branch to https://github.com/freedomofpress/openqa-tests-qubesos/pull/9 (or another branch with GUI tests)
2. Wait for the `test_gui` to start, then click **developer mode** and set the debugging to open on screen assertion timeout
3. Wait for the test to fail somewhere (assuming the chosen branch are incomplete GUI tests)
4. Create a new needle for the missing step
5. Continue test
6. Make sure test successfully proceeds to the next step: this tells us that the needle we just created was actually used
