### PR TITLE
Sleep before pushing nightlies

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -88,6 +88,8 @@ jobs:
           cp -v ../rpm-build-41/*.rpm workstation/dom0/f41-nightlies/
           git add .
           git diff-index --quiet HEAD || git commit -m "Automated SecureDrop workstation build"
+          # Sleep before we push so the token will have propagated across GitHub infra 
+          sleep 5
           git push https://x-access-token:${GH_TOKEN}@github.com/${TARGET_REPO}.git main
 
   get-main-commit:


### PR DESCRIPTION
So that the token will have had time to propagate across the GitHub infra.

Refs https://github.com/freedomofpress/infrastructure/issues/6263.


## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
n/a
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] any necessary RPM packaging updates (e.g., added/removed files, see `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [x] any required documentation
