### PR TITLE
dev: deeper make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,10 +109,13 @@ clone: assert-dom0 ## Builds rpm && pulls the latest repo from work VM to dom0
 clone-norpm: assert-dom0 ## As above, but skip creating RPM
 	@BUILD_RPM=false ./scripts/clone-to-dom0
 
+.PHONY: clean
 clean: assert-dom0 ## Destroys all SD VMs
 # Use the local script path, since system PATH location will be absent
 # if clean has already been run.
 	./files/sdw-admin.py --uninstall --force
+	rpm -qa | grep '^securedrop-workstation' | xargs -r sudo dnf remove -y
+	find /etc/yum.repos.d -type f -iname 'securedrop-workstation*.repo' -exec sudo rm -v {} +
 
 .PHONY: test-prereqs
 test-prereqs: ## Checks that test prerequisites are satisfied


### PR DESCRIPTION
Ensures that the "make clean" target purges all SDW-related setup from dom0. It still runs the "sdw-admin --uninstall" logic, but thereafter also uninstalls any SDW-related RPM packages, and removes and SDW yum repo files from dom0, too.

There's an argument to add this functionality to the "sdw-admin --uninstall" logic, but for now, let's enusre the functionality is available to devs, so that "make clean" actually cleans the system, preparing it for another "make dev" run.

Refs #1530.

## Test plan
Visual review is sufficient: are these changes reasonable and sound, for a dev env? The openqa tests don't yet use "make clean" so I don't expect any side-effects over there, either.

## Checklist

This change accounts for:
- [x] any necessary RPM packaging updates (e.g., added/removed files, see `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [x] any required documentation
