### PR TITLE
tests: repo baseurl changed to include `$releasever`

### DIFF
--- a/tests/test_dom0_rpm_repo.py
+++ b/tests/test_dom0_rpm_repo.py
@@ -39,9 +39,7 @@ class SD_Dom0_Rpm_Repo_Tests(unittest.TestCase):
 
         self.config = REPO_CONFIG[self.env]
 
-    # Temporarily disabling this test pending backend fixes:
-    # https://github.com/freedomofpress/securedrop-workstation/issue/1530
-    def _test_rpm_repo_config(self):
+    def test_rpm_repo_config(self):
         repo = self.config["repo_file_name"]
         baseurl = self.config["yum_repo_url"]
         repo_file = f"/etc/yum.repos.d/{repo}"


### PR DESCRIPTION
Tests were failing (see #1530) due to a change in the respository url structure [implemented in the keyring package](https://github.com/freedomofpress/securedrop-workstation-keyring/pull/38). The release is no longer hard coded, but instead uses $releasever.

This also adds another test to ensure that "$releasever" is interpreted by DNF as the Qubes version. This is mostly just a sanity check.

Fixes #1530

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
- [ ] visual review
- [ ] tests pass

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
