### PR TITLE
Revert "test: temporarily disable dom0 yum checks"

### DIFF
--- a/tests/test_dom0_rpm_repo.py
+++ b/tests/test_dom0_rpm_repo.py
@@ -45,9 +45,7 @@ class SD_Dom0_Rpm_Repo_Tests(unittest.TestCase):
             {"FEDORA_VERSION": FEDORA_VERSION}
         )
 
-    # Temporarily disabling this test pending backend fixes:
-    # https://github.com/freedomofpress/securedrop-workstation/issue/1530
-    def _test_rpm_repo_config(self):
+    def test_rpm_repo_config(self):
         repo = self.config["repo_file_name"]
         baseurl = self.config["yum_repo_url"]
         repo_file = f"/etc/yum.repos.d/{repo}"


### PR DESCRIPTION
Reverts freedomofpress/securedrop-workstation#1537. TODO needs to be rebased on of https://github.com/freedomofpress/securedrop-workstation/pull/1533.

Just creating this as a draft to make sure we don't forget (CC @conorsch)