### PR TITLE
Fix broken nightlies:  Canceling since a higher priority waiting request for Nightlies-refs/heads/main-dev- exists

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -116,7 +116,7 @@ jobs:
     needs: ["get-main-commit"]
     strategy:
       matrix:
-        qubes_verson: ["4.2", "4.3"]
+        qubes_version: ["4.2", "4.3"]
     with:
       environment: "dev"
       git_ref: ${{ needs.get-main-commit.outputs.main-commit}}


### PR DESCRIPTION
Nightly run would be started without `qubes_ver`, thus colliding with the openqa.yml concurrency restrictions (they'd have the same name).

Fixes #1543.
Blocker: #1546 (if we really want to test this ­— but in practice it doesn't get worse than broken, so might as well merge it) 

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
- (once rebased on top of https://github.com/freedomofpress/securedrop-workstation/pull/1491) check that nightlies is triggered and has the correct `qubes_ver` passed along. 

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
