### PR TITLE
Test nightlies.yml whenever workflow is edited

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -5,11 +5,14 @@ on:
   push:
     branches:
       - main
+  pull_request:  # To test changes in this workflow
+    paths:
+      - '.github/workflows/nightlies.yml'
 
 # Only allow one job to run at a time because we're pushing to git repos;
 # the string value doesn't matter, just that it's a fixed string.
 concurrency:
-  group: "just-one-please"
+  group: "just-one-please-${{ github.ref }}"
 
 defaults:
   run:
@@ -47,6 +50,7 @@ jobs:
           if-no-files-found: error
 
   commit-and-push:
+    if: ${{ github.ref == 'refs/heads/main' }} # Skip when testing workflow
     runs-on: ubuntu-latest
     container: debian:bookworm
     needs:


### PR DESCRIPTION
Some issues have been caused in the past due to workflow changes that affected the nightlies. This triggers a limited nightly run whenever nightlies.yml is edited.

Fixes #1545

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
- [ ] check that nightlies is triggered (**note:** failing job is acceptable here if due to https://github.com/freedomofpress/securedrop-workstation/pull/1544)
- [ ] push empty commit and check that nightlies does NOT run
- [ ] (after merging) check that the next nightly is correctly triggered

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for: (NOT NECESSARY)
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
