### PR TITLE
Make openqa-pending label faster to find

### DIFF
--- a/.github/workflows/openqa-pull-request.yml
+++ b/.github/workflows/openqa-pull-request.yml
@@ -39,19 +39,19 @@ jobs:
                 process.exit(1);
             }
 
-            // Find all openqa-pending-* labels
+            // Find all '*-openqa-pending' labels
             const openqaLabels = labels.filter(label =>
-              label.name && label.name.match(/^openqa-pending-[0-9]+\.[0-9]+$/)
+              label.name && label.name.match(/^[0-9]+\.[0-9]+-openqa-pending$/)
             );
 
             if (openqaLabels.length === 0) {
-              console.log('No valid openqa-pending-* labels found');
+              console.log('No valid *-openqa-pending labels found');
               return;
             }
 
             // Extract Qubes versions
             const qubesVersions = openqaLabels.map(label =>
-              label.name.replace('openqa-pending-', '')
+              label.name.replace('-openqa-pending', '')
             );
 
             console.log(`Found openqa-pending labels for versions: ${qubesVersions.join(', ')}`);


### PR DESCRIPTION
When adding a label to a PR in order to trigger an OpenQA run, it's slightly hard to do so when with the version at the end (e.g.: openqa-pending-4.3). This is because the GitHub label list starts alphabetically with numbered labels being first. Therefore, starting with numbers should require no label searching.

Refs: #1515

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
