### PR TITLE
Have try-client-pr autostart sd-proxy

### DIFF
--- a/scripts/try-client-pr.py
+++ b/scripts/try-client-pr.py
@@ -162,6 +162,8 @@ def main():
         ["qvm-ls", "--tags", "sd-workstation", "--raw-list", "--running"]
     ).splitlines()
     subprocess.check_call(["qvm-shutdown", "--wait"] + all_vms)
+    # Manually start sd-proxy so Tor can start up early
+    subprocess.check_call(["qvm-start", "sd-proxy"])
     print(f"\n\nYour workstation is provisioned with PR #{args.pr_id}.")
     target = "app" if args.app else "client"
     print(f"\n\nYou can start the {target} with `make run-{target}`.")


### PR DESCRIPTION
Since it shuts down all the VMs, apply the same-ish hack as 428222f559 so that the proxy and Tor are running by the time we try to log in.

Fixes #1550.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

* Use the script and see that it still shuts down all the VMs but then starts sd-proxy afterwards.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
