### PR TITLE
Build  securedrop-admin-dom0-config package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include securedrop_salt/*
+include admin_salt/*
 include README.md
 include LICENSE
 include VERSION

--- a/admin_salt/README
+++ b/admin_salt/README
@@ -1,0 +1,1 @@
+Placeholder

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -52,6 +52,13 @@ SecureDrop Workstation project. The package should be installed
 in dom0, or AdminVM, context, in order to manage updates to the VM
 configuration over time.
 
+%package -n securedrop-admin-dom0-config
+Summary: SecureDrop Admin
+%description -n securedrop-admin-dom0-config
+This package contains VM configuration files for the Qubes-based
+SecureDrop Admin project. The package should be installed
+in dom0, or AdminVM, context, in order to manage updates to the VM
+configuration over time.
 
 %prep
 %setup -q -n %{name}-%{version}
@@ -60,7 +67,7 @@ configuration over time.
 %build
 # No building necessary here, but this soothes rpmlint
 
-
+# single install directive for files for all packages
 %install
 %{python3} -m pip install --no-compile --no-index --no-build-isolation --root %{buildroot} .
 # direct_url.json is is not reproducible and not strictly needed
@@ -69,6 +76,9 @@ sed -i "/\.dist-info\/direct_url\.json,/d" %{buildroot}/%{python3_sitelib}/*%{ve
 
 install -m 755 -d %{buildroot}/srv/salt/
 cp -a securedrop_salt %{buildroot}/srv/salt/
+
+# test admin directory install
+cp -a admin_salt %{buildroot}/srv/salt/admin_salt
 
 install -m 755 -d %{buildroot}/%{_datadir}/%{name}/scripts
 install -m 755 -d %{buildroot}/%{_bindir}
@@ -151,6 +161,10 @@ install -m 644 files/securedrop-user-xfce-icon-size.service %{buildroot}/%{_user
 %attr(755, root, root) /usr/bin/securedrop/update-xfce-settings
 
 %doc README.md
+%license LICENSE
+
+%files -n securedrop-admin-dom0-config
+/srv/salt/admin_salt/*
 %license LICENSE
 
 %post

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -30,4 +30,4 @@ rpmbuild \
 python3 scripts/verify_rpm_mtime.py
 
 printf '\nBuild complete! RPMs and their checksums are:\n\n'
-find rpm-build/ -type f -iname "${PROJECT}-$(cat "${TOPLEVEL}/VERSION")*.rpm" -print0 | sort -zV | xargs -0 sha256sum
+find rpm-build/ -type f -iname "securedrop-*-$(cat "${TOPLEVEL}/VERSION")*.rpm" -print0 | sort -zV | xargs -0 sha256sum


### PR DESCRIPTION
WIP - this builds a dummy package `securedrop-admin-dom0-config` via the project's existing `.spec` file.

After investigation, it looks like there are two potential approaches to organizing the specfile to support multiple packages, the first being to have a null parent package that doesn't generate an rpm but sets common fields like License:

```
Name: securedrop
Version: 1.0.0
Release: 1
Summary: SecureDrop Qubes packages
License: AGPLv3

%description
I am a parent package description...

# subpackage number 1 - rpm name will be securedrop-workstation-dom0-config
%package workstation-dom0-config
Summary: SecureDrop Workstation configurator

%description workstation-dom0-config
I am the workstation package description...

# subpackage number 2 - rpm name will be securedrop-workstation-dom0-config
%package admin-dom0-config
Summary: SecureDrop Admin configurator

%description admin-dom0-config
I am the admin package description...


%install
# All packages' files are moved to buildroot here

%files
# parent package files - no files means no RPM

%files workstation-dom0-config
# workstation files here

%files admin-dom0-config
# admin files here
```

The other approach (followed in this PR) is to build the existing `securedrop-workstation-dom0-config` RPM as the parent package and just add additional ones:

```
Name: securedrop- workstation-dom0-config
Version: 1.0.0
Release: 1
Summary: SecureDrop Workstation configurator
License: AGPLv3

%description 
I am the workstation package description...

# subpackage - rpm name will be securedrop-workstation-dom0-config
%package -n securedrop-admin-dom0-config
Summary: SecureDrop Admin configurator

%description -n securedrop-admin-dom0-config
I am the admin package description...

%install
# All packages' files are moved to shared buildroot here

%files
# workstation files go  here

%files -n securedrop-admin-dom0-config
# admin files here
```

In the second approach, admin RPM files should be added to the Python MANIFEST.in so they get included in the source tarball used to populate `rpm-build/BUILD`. After that, how they're structured is up to the `%install` and `%files <package>` section.

Which we pick is really a matter of taste. If we did decide to split out the updater to its own RPM as a potential requirement for both the workstation and admin config packages, it might be worth trying the first approach. But for just one additional RPM, the second approach works fine.