### PR TITLE
Ability to tweak OpenQA configuration in first post

### DIFF
--- a/.github/workflows/openqa-pull-request.yml
+++ b/.github/workflows/openqa-pull-request.yml
@@ -70,6 +70,7 @@ jobs:
       environment: "dev"
       git_ref: ${{ github.event.pull_request.head.sha }}
       qubes_ver: ${{ matrix.qubes_version }}
+      extra_params: "KEY1=value1 KEY2=value2"
 
       # NOTE: cancellation is done through concurrency: by starting another job
       # with the same conditions as the one we want to cancel, it necessarily

--- a/.github/workflows/openqa.yml
+++ b/.github/workflows/openqa.yml
@@ -16,6 +16,9 @@ on:
       cancel:
         required: false
         type: boolean
+      extra_params:  # KEY1=value1 KEY2=value2
+        required: false
+        type: string
 
 # NOTE Concurrency serves two purposes:
 #   1. When starting a new OpenQA job
@@ -52,6 +55,7 @@ jobs:
       # The URL to clone the remote OpenQA repo from (useful for forks):
       SECUREDROP_OPENQA_REPO_URL: "https://github.com/freedomofpress/openqa-tests-qubesos"
       QUBES_VER: ${{ inputs.qubes_ver }}
+      EXTRA_PARAMS: ${{ inputs.extra_params }}
     container:
       image: debian:trixie
     steps:
@@ -78,7 +82,8 @@ jobs:
             XRES=1920 YRES=1080 \
             FLAVOR=securedrop \
             CASEDIR="${SECUREDROP_OPENQA_REPO_URL}#${SECUREDROP_OPENQA_REPO_BRANCH}" \
-            MAX_JOB_TIME=10800 | tee openqa.json
+            MAX_JOB_TIME=10800 \
+            $EXTRA_PARAMS | tee openqa.json
 
           for id in $(jq -r '.ids[]' openqa.json); do
 


### PR DESCRIPTION
Useful to have workflows specify pass along extra OpenQA configuration values.

Fixes #1558 

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

-  [ ] _`EXTRA_PARAMS` gets propagated to OpenQA itself_
   Example: as of a6f5b12, the [OpenQA Github workflow](https://github.com/freedomofpress/securedrop-workstation/actions/runs/21592418194/job/62215700876) successfully passed `KEY1=value1 KEY2=value2` along [to OpenQA](https://openqa.qubes-os.org/tests/166092#settings) (see the settings)

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
