### PR TITLE
Have try-client-pr always install securedrop-app

### DIFF
--- a/scripts/try-client-pr.py
+++ b/scripts/try-client-pr.py
@@ -42,16 +42,13 @@ def check_out_pr(pr_id):
     print(f"Successfully checked out PR #{pr_id}")
 
 
-def build_debs(build_app: bool):
+def build_debs():
     """Run make build-debs in build VM to build the Debian packages."""
     # TODO: we should download these from CI instead of building them ourselves
     # TODO: an option to also update securedrop-builder?
     print(f"Building Debian packages in {BUILD_VM} VM...")
     run_in_vm(["rm", "-rf", "securedrop-client/build"], BUILD_VM)
-    build_args = ["FAST=1"]
-    if build_app:
-        build_args.append("WHAT=app")
-    build_args.extend(["make", "-C", "securedrop-client", "build-debs"])
+    build_args = ["FAST=1", "make", "-C", "securedrop-client", "build-debs"]
     run_in_vm(build_args, BUILD_VM)
     print("Successfully built Debian packages")
 
@@ -97,7 +94,7 @@ def move_deb_to_template(dom0_path, template_vm):
     return f"/home/user/QubesIncoming/dom0/{dom0_path.name}"
 
 
-def install_debs_in_template(all_deb_paths, template_vm, build_app: bool):
+def install_debs_in_template(all_deb_paths, template_vm):
     """Install .deb files in template VM."""
 
     # Need to escape "${Package}\n" from being interpreted by bash
@@ -106,7 +103,7 @@ def install_debs_in_template(all_deb_paths, template_vm, build_app: bool):
         template_vm,
         capture_output=True,
     ).splitlines()
-    if build_app and "securedrop-client" in wanted_packages:
+    if "securedrop-client" in wanted_packages:
         # If this is the VM where the client is installed, also install the app
         wanted_packages.append("securedrop-app")
     print(f"Going to install into {template_vm}: {', '.join(wanted_packages)}")
@@ -135,16 +132,13 @@ def install_debs_in_template(all_deb_paths, template_vm, build_app: bool):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("pr_id", type=int, help="ID of the Pull Request to test")
-    parser.add_argument(
-        "--app", default=False, action="store_true", help="Build and install SecureDrop App too"
-    )
     args = parser.parse_args()
 
     print(f"Using build VM: {BUILD_VM}")
 
     # Run the workflow
     check_out_pr(args.pr_id)
-    build_debs(build_app=args.app)
+    build_debs()
 
     # Find deb files and get their names
     deb_files = find_debs_in_build_vm()
@@ -154,8 +148,8 @@ def main():
         print(f"Package: {package_name} - {deb_file}")
 
     # Install the deb files in template VMs
-    install_debs_in_template(deb_files, SMALL_TEMPLATE, build_app=args.app)
-    install_debs_in_template(deb_files, LARGE_TEMPLATE, build_app=args.app)
+    install_debs_in_template(deb_files, SMALL_TEMPLATE)
+    install_debs_in_template(deb_files, LARGE_TEMPLATE)
 
     # Shutdown
     all_vms = subprocess.check_output(
@@ -165,8 +159,7 @@ def main():
     # Manually start sd-proxy so Tor can start up early
     subprocess.check_call(["qvm-start", "sd-proxy"])
     print(f"\n\nYour workstation is provisioned with PR #{args.pr_id}.")
-    target = "app" if args.app else "client"
-    print(f"\n\nYou can start the {target} with `make run-{target}`.")
+    print("\n\nYou can start the app with `make run-app`.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
To match <https://github.com/freedomofpress/securedrop-client/pull/3060>, which always builds the securedrop-app package.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
