### PR TITLE
spike: sd-admin VM via RPM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,18 @@ build-rpm: ## Build RPM package
 	@echo
 	@echo "Build log available at $(OUT)"
 
+.PHONY: build-admin-rpm
+build-admin-rpm: OUT:=build-log/securedrop-admin-$(shell date +%Y%m%d).log
+build-admin-rpm: ## Build admin RPM package (opt-in)
+	@mkdir -p build-log
+	@echo "Building SecureDrop Admin RPM..."
+	@export TERM=dumb
+	@USE_BUILD_CONTAINER=true script \
+		--command "$(CONTAINER) ./scripts/build-admin-rpm.sh" \
+		--return $(OUT)
+	@echo
+	@echo "Build log available at $(OUT)"
+
 # FIXME: the time variations have been temporarily removed from reprotest
 # Suspecting upstream issues in rpm land is causing issues with 1 file\'s modification time not being clamped correctly only in a reprotest environment
 .PHONY: reprotest
@@ -103,6 +115,21 @@ test-deps: build-deps ## Install package dependencies for running tests
 
 	@echo "Installing python package dependencies (e.g. PyQt)"
 	dnf install -y `rpmspec --parse $(SPEC_FILE) | sed -n "s/^Requires:.*python3/python3/p"`
+
+.PHONY: install-admin-rpm
+install-admin-rpm: assert-dom0 ## Install locally-built admin RPM (opt-in)
+	@echo "Installing securedrop-admin-dom0-config RPM..."
+	@scripts/install-admin-rpm
+
+.PHONY: sd-admin
+sd-admin: assert-dom0 ## Provision sd-admin VM and install securedrop-admin
+	sudo rm -rf /var/cache/salt
+	sudo qubesctl saltutil.sync_all refresh=true
+	@echo "Creating sd-admin template and AppVM..."
+	sudo qubesctl --show-output -- state.sls admin_salt.sd-admin
+	@echo "Installing packages inside sd-admin-trixie-template..."
+	sudo qubesctl --show-output --skip-dom0 --targets sd-admin-trixie-template -- state.sls admin_salt.sd-admin-packages
+	qvm-shutdown --wait -- sd-admin-trixie-template
 
 clone: assert-dom0 ## Builds rpm && pulls the latest repo from work VM to dom0
 	@./scripts/clone-to-dom0

--- a/admin_salt/README
+++ b/admin_salt/README
@@ -1,0 +1,1 @@
+Placeholder

--- a/admin_salt/README
+++ b/admin_salt/README
@@ -1,1 +1,0 @@
-Placeholder

--- a/admin_salt/sd-admin-config.sls
+++ b/admin_salt/sd-admin-config.sls
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+##
+# Minimal config for sd-admin, decoupled from securedrop_salt/sd-default-config.sls
+# during prototyping. The main SDW config imports config.json (which contains
+# SDW-specific fields like submission_key_fpr and vmsizes) and hardcodes
+# distribution=bookworm. We hardcode trixie here instead.
+#
+# TODO: Post-spike, consider extracting shared apt config into a common location
+# to avoid duplication with securedrop_salt/sd-default-config.sls.
+##
+
+{% set admin_vars = {
+    "apt_sources_filename": "apt_freedom_press.sources",
+    "component": "main",
+    "distribution": "trixie"
+} %}

--- a/admin_salt/sd-admin-packages.sls
+++ b/admin_salt/sd-admin-packages.sls
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+##
+# Configures the FPF apt repository and installs securedrop-admin
+# inside the sd-admin-trixie-template VM.
+#
+# Mirrors the approach in securedrop_salt/fpf-apt-repo.sls and
+# securedrop_salt/sd-base-template-packages.sls, but uses duplicated
+# .j2 templates and a self-contained config to keep the admin package
+# independent of the workstation package.
+##
+
+{% from 'admin_salt/sd-admin-config.sls' import admin_vars with context %}
+
+update-apt-cache:
+  cmd.run:
+    - name: apt-get update --allow-releaseinfo-change
+
+autoremove-old-packages:
+  cmd.run:
+    - name: apt-get autoremove -y
+    - require:
+      - cmd: update-apt-cache
+
+configure-fpf-apt-repo:
+  file.managed:
+    - name: "/etc/apt/sources.list.d/{{ admin_vars.apt_sources_filename }}"
+    - source: "salt://admin_salt/{{ admin_vars.apt_sources_filename }}.j2"
+    - template: jinja
+    - context:
+        codename: {{ grains['oscodename'] }}
+        component: {{ admin_vars.component }}
+    - require:
+      - cmd: autoremove-old-packages
+
+# TODO: there's no keyring for trixie yet
+# install-securedrop-keyring:
+#   pkg.installed:
+#     - pkgs:
+#       - securedrop-keyring
+#     - require:
+#       - file: configure-fpf-apt-repo
+
+install-securedrop-admin:
+  pkg.installed:
+    - pkgs:
+      - securedrop-admin
+    - refresh: True

--- a/admin_salt/sd-admin-template.sls
+++ b/admin_salt/sd-admin-template.sls
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+
+# Installs a Debian 13 (Trixie)-based "sd-admin" VM.
+dom0-install-debian-13-template:
+  qvm.template_installed:
+    - name: debian-13
+
+# N.B. hardcoding "trixie" rather than reading from sdvars to decouple
+# the sd-admin config from the rest of the SDW config during prototyping.
+sd-admin-trixie-template:
+  qvm.vm:
+    - name: sd-admin-trixie-template
+    - clone:
+      - source: debian-13
+      - label: red
+    - prefs:
+      - virt-mode: pvh
+      # - kernel: 'pvgrub2-pvh'
+      - default_dispvm: ""
+    - tags:
+      - add:
+        - sd-workstation
+        - sd-workstation-trixie
+        - sd-admin
+    - require:
+      - qvm: dom0-install-debian-13-template

--- a/admin_salt/sd-admin.sls
+++ b/admin_salt/sd-admin.sls
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+##
+# Creates the 'sd-admin' AppVM to provide tooling for admin operations
+# against SecureDrop Servers (as opposed to against SecureDrop Workstation).
+#
+# Currently it uses sys-firewall for networking; we'll need to test
+# direct connections to the hardware firewall, as well as configure Torified access.
+##
+
+include:
+  - admin_salt.sd-admin-template
+
+sd-admin:
+  qvm.vm:
+    - name: sd-admin
+    - present:
+      - label: red
+      - template: sd-admin-trixie-template
+    - prefs:
+      - template: sd-admin-trixie-template
+      - netvm: sys-firewall
+      - autostart: false
+      - default_dispvm: ""
+    - tags:
+      - add:
+        - sd-workstation
+        - sd-admin
+    - require:
+      - qvm: sd-admin-trixie-template

--- a/admin_salt/sd-admin.top
+++ b/admin_salt/sd-admin.top
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+base:
+  dom0:
+    - admin_salt.sd-admin-template
+    - admin_salt.sd-admin
+
+  sd-admin-trixie-template:
+    - admin_salt.sd-admin-packages

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -49,11 +49,18 @@ SecureDrop Workstation project. The package should be installed
 in dom0, or AdminVM, context, in order to manage updates to the VM
 configuration over time.
 
+%package -n securedrop-admin-dom0-config
+Summary: SecureDrop Admin
+%description -n securedrop-admin-dom0-config
+This package contains VM configuration files for the Qubes-based
+SecureDrop Admin project. The package should be installed
+in dom0, or AdminVM, context, in order to manage updates to the VM
+configuration over time.
 
 %build
 # Nothing to build; rpmbuild is invoked with --build-in-place
 
-
+# single install directive for files for all packages
 %install
 install -m 755 -d %{buildroot}%{python3_sitelib}/sdw_notify
 install -m 755 -d %{buildroot}%{python3_sitelib}/sdw_updater
@@ -67,6 +74,12 @@ cp -a securedrop_salt %{buildroot}/srv/salt/
 
 install -m 755 -d %{buildroot}%{_datadir}/%{name}/scripts
 install -m 755 -d %{buildroot}%{_bindir}
+
+# test admin directory install
+cp -a admin_salt %{buildroot}/srv/salt/admin_salt
+
+install -m 755 -d %{buildroot}/%{_datadir}/%{name}/scripts
+install -m 755 -d %{buildroot}/%{_bindir}
 install -m 755 -d %{buildroot}/opt/securedrop
 install -m 755 -d %{buildroot}/usr/bin/securedrop
 install -m 755 files/update-xfce-settings %{buildroot}/usr/bin/securedrop/
@@ -144,6 +157,10 @@ install -m 644 files/securedrop-user-xfce-icon-size.service %{buildroot}%{_useru
 %attr(755, root, root) /usr/bin/securedrop/update-xfce-settings
 
 %doc README.md
+%license LICENSE
+
+%files -n securedrop-admin-dom0-config
+/srv/salt/admin_salt/*
 %license LICENSE
 
 %post

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -3,6 +3,10 @@ Version:	1.6.0rc1
 Release:	1%{?dist}
 Summary:	SecureDrop Workstation
 
+# Build the admin subpackage only when explicitly requested:
+#   rpmbuild --with admin ...
+%bcond_with admin
+
 # For reproducible builds:
 #
 #   * Ensure that SOURCE_DATE_EPOCH env is honored and inherited from the
@@ -49,18 +53,21 @@ SecureDrop Workstation project. The package should be installed
 in dom0, or AdminVM, context, in order to manage updates to the VM
 configuration over time.
 
+%if %{with admin}
 %package -n securedrop-admin-dom0-config
 Summary: SecureDrop Admin
+Requires: qubes-mgmt-salt-dom0-virtual-machines
 %description -n securedrop-admin-dom0-config
 This package contains VM configuration files for the Qubes-based
 SecureDrop Admin project. The package should be installed
 in dom0, or AdminVM, context, in order to manage updates to the VM
 configuration over time.
+%endif
 
 %build
 # Nothing to build; rpmbuild is invoked with --build-in-place
 
-# single install directive for files for all packages
+
 %install
 install -m 755 -d %{buildroot}%{python3_sitelib}/sdw_notify
 install -m 755 -d %{buildroot}%{python3_sitelib}/sdw_updater
@@ -74,12 +81,6 @@ cp -a securedrop_salt %{buildroot}/srv/salt/
 
 install -m 755 -d %{buildroot}%{_datadir}/%{name}/scripts
 install -m 755 -d %{buildroot}%{_bindir}
-
-# test admin directory install
-cp -a admin_salt %{buildroot}/srv/salt/admin_salt
-
-install -m 755 -d %{buildroot}/%{_datadir}/%{name}/scripts
-install -m 755 -d %{buildroot}/%{_bindir}
 install -m 755 -d %{buildroot}/opt/securedrop
 install -m 755 -d %{buildroot}/usr/bin/securedrop
 install -m 755 files/update-xfce-settings %{buildroot}/usr/bin/securedrop/
@@ -121,6 +122,16 @@ install -m 644 files/10-securedrop-logind_override.conf %{buildroot}/etc/systemd
 install -m 644 files/securedrop-user-xfce-settings.service %{buildroot}%{_userunitdir}/
 install -m 644 files/securedrop-user-xfce-icon-size.service %{buildroot}%{_userunitdir}/
 
+%if %{with admin}
+cp -a admin_salt %{buildroot}/srv/salt/admin_salt
+
+# Install shared apt source templates into admin_salt so the admin package
+# can reference them via salt://admin_salt/ without depending on the
+# workstation package at runtime.
+install -m 644 securedrop_salt/apt_freedom_press.sources.j2 %{buildroot}/srv/salt/admin_salt/
+install -m 644 securedrop_salt/apt-test_freedom_press.sources.j2 %{buildroot}/srv/salt/admin_salt/
+%endif
+
 %files
 %attr(755, root, root) %{_datadir}/%{name}/scripts/clean-salt
 %attr(755, root, root) %{_datadir}/%{name}/scripts/destroy-vm
@@ -159,9 +170,11 @@ install -m 644 files/securedrop-user-xfce-icon-size.service %{buildroot}%{_useru
 %doc README.md
 %license LICENSE
 
+%if %{with admin}
 %files -n securedrop-admin-dom0-config
 /srv/salt/admin_salt/*
 %license LICENSE
+%endif
 
 %post
 # Update Salt Configuration

--- a/scripts/build-admin-rpm.sh
+++ b/scripts/build-admin-rpm.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/bash
-# Helper script for fully reproducible RPMs
+# Build the securedrop-admin-dom0-config RPM.
+# Uses the same spec file as the workstation RPM, with the admin
+# bcond enabled via --with admin.
 set -e
 set -u
 set -o pipefail
 
 source "$(dirname "$0")/common.sh"
+
+ADMIN_PROJECT="securedrop-admin-dom0-config"
 
 git clean -fdX rpm-build/
 # touch everything to a date in the future, so that way
@@ -18,10 +22,11 @@ trap 'find . -type f -exec touch -m {} \;' EXIT
 rpmbuild \
     --build-in-place \
     --define "_topdir $PWD/rpm-build" \
+    --with admin \
     -bb "rpm-build/SPECS/${PROJECT}.spec"
 
 # Check reproducibility
 python3 scripts/verify_rpm_mtime.py
 
 printf '\nBuild complete! RPMs and their checksums are:\n\n'
-find rpm-build/ -type f -iname "${PROJECT}-$(cat "${TOPLEVEL}/VERSION")*.rpm" -print0 | sort -zV | xargs -0 sha256sum
+find rpm-build/ -type f -iname "${ADMIN_PROJECT}-$(cat "${TOPLEVEL}/VERSION")*.rpm" -print0 | sort -zV | xargs -0 sha256sum

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -24,4 +24,4 @@ rpmbuild \
 python3 scripts/verify_rpm_mtime.py
 
 printf '\nBuild complete! RPMs and their checksums are:\n\n'
-find rpm-build/ -type f -iname "${PROJECT}-$(cat "${TOPLEVEL}/VERSION")*.rpm" -print0 | sort -zV | xargs -0 sha256sum
+find rpm-build/ -type f -iname "securedrop-*-$(cat "${TOPLEVEL}/VERSION")*.rpm" -print0 | sort -zV | xargs -0 sha256sum

--- a/scripts/install-admin-rpm
+++ b/scripts/install-admin-rpm
@@ -1,41 +1,32 @@
 #!/usr/bin/bash
-# Developer-oriented utility script for deploying Saltstack config
-# files for the SecureDrop Workstation dev env. Installs the latest
-# locally built RPM in order to deploy the Salt config.
+# Install the locally-built securedrop-admin-dom0-config RPM.
+# This is opt-in and separate from the main prep-dev workflow.
 set -euo pipefail
 
-
-# The dest directory in dom0 is not customizable.
 dom0_dev_dir="$HOME/securedrop-workstation"
-
-# Substring to ensure that the primary dom0 config RPM is selected;
-# used to differentiate between the the default RPM and the WIP sd-admin RPM.
-rpm_name="securedrop-workstation-dom0-config"
+rpm_name="securedrop-admin-dom0-config"
 
 function find_latest_rpm() {
-    # Look up which version of dom0 we're using.
     fedora_version="$(rpm --eval '%{fedora}')"
     find "${dom0_dev_dir}/rpm-build/RPMS/" -type f -iname "${rpm_name}*fc${fedora_version}.noarch.rpm" -print0 | xargs -r -0 ls -t | head -n 1
 }
 
 function find_any_rpm() {
-    # Fallback for CI, which renames rpms. Try installing
-    # any rpm present in the RPMS directory.
     find "${dom0_dev_dir}/rpm-build/RPMS/" -type f -iname "${rpm_name}*.rpm" -print0 | xargs -r -0 ls -t | head -n 1
 }
 
 latest_rpm="$(find_latest_rpm)"
 if [[ -z "$latest_rpm" ]]; then
-    echo "No exact match, try any rpm in build directory"
+    echo "No exact match for current Fedora version, trying any admin rpm in build directory"
+    latest_rpm="$(find_any_rpm)"
 fi
 
-latest_rpm="$(find_any_rpm)"
 if [[ -z "$latest_rpm" ]]; then
-    echo "Could not find RPM!"
+    echo "Could not find admin RPM! Run 'make build-admin-rpm' first."
     exit 1
 fi
 
-echo "Deploying Salt config..."
+echo "Installing admin RPM..."
 sudo dnf clean all
 if rpm -q "$rpm_name" > /dev/null 2>&1; then
     echo "Reinstalling $latest_rpm ..."


### PR DESCRIPTION
This PR adopts the "admin-config" RPM spec file by @zenmonkeykstop in #1554. It also pulls in the simplified RPM build logic from #1565; therefore, #1565 should be reviewed and merged first.

Based on @zenmonkeykstop's work, I added an `sd-admin` VM based on Debian 13 Trixie. There's no grsec kernel or keyring package yet, but the `securedrop-admin` tooling is installed:

<details>
<summary>
securedrop-admin help text
</summary>

```
[conor@dom0 securedrop-workstation]$ qvm-run -p sd-admin "securedrop-admin --help"
usage: securedrop-admin [-h] [-v] [-d] [--force]
                        {sdconfig,install,localconfig,tailsconfig,qubesconfig,generate_v3_keys,backup,restore,check_for_updates,logs,reset_admin_access,verify} ...

SecureDrop Admin Toolkit.

For use by administrators to install, maintain, and manage their SD
instances.

positional arguments:
  {sdconfig,install,localconfig,tailsconfig,qubesconfig,generate_v3_keys,backup,restore,check_for_updates,logs,reset_admin_access,verify}
    sdconfig            Configure SD site settings
    install             Install/Update SecureDrop
    localconfig (tailsconfig, qubesconfig)
                        Configure either Tails or Qubes environment post SD install
    generate_v3_keys    
                        This method will either read v3 Tor onion service keys if found or generate
                        a new public/private keypair.
    backup              Perform backup of the SecureDrop Application Server.
                        Creates a tarball of submissions and server config, and fetches
                        back to the Admin Workstation. Future `restore` actions can be performed
                        with the backup tarball.
    restore             Perform restore of the SecureDrop Application Server.
                        Requires a tarball of submissions and server config, created via
                        the `backup` action.
    check_for_updates   Check for SecureDrop updates
    logs                Get logs for forensics and debugging purposes
    reset_admin_access  Resets SSH access to the SecureDrop servers, locking it to
                        this Admin Workstation.
    verify              Run configuration tests against SecureDrop servers

options:
  -h, --help            show this help message and exit
  -v                    Increase verbosity on output (default: False)
  -d                    Developer mode. Not to be used in production. (default: False)
  --force               force command execution without update check (default: False)
[conor@dom0 securedrop-workstation]$ 
```
</details>

The RPM setup reuses Salt state files between the two RPMs, but installs them to unique dest paths, ensuring both RPMs can be installed independently of one another, without triggering dnf conflicts. We can lean into this and port more of the pre-existing Salt config if we desire. 

Towards #1507. 

## Test plan
1. Ensure that `make clone && make dev` passes without error
2. Run `make sd-admin` to configure the `sd-admin` VM; check that `securedrop-admin` CLI is installed within it.
3. Build the RPMs locally and run `rpm -qlp <path>` on them; inspect their file contents and ensure no conflicts or overlaps between them, because any duplication of dest paths will cause problems.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `MANIFEST.in` and `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
