### PR TITLE
Set xfce-exe-checksum on desktop launcher

### DIFF
--- a/files/update-xfce-settings
+++ b/files/update-xfce-settings
@@ -57,6 +57,14 @@ elif [[ $TASK == "adjust-icon-size" ]]; then
   echo "update-xfce-settings: Adjusting icon size for user $USER to $ICONSIZE px"
   xfconf-query -c xfce4-desktop -np '/desktop-icons/icon-size' -t 'int' -s $ICONSIZE
 
+elif [[ $TASK == "dismiss-desktop-icon-prompt" ]]; then
+  # Dismiss "security warning" when opening any desktop icons
+  # as it is not a true security mitigation in Qubes. See #1582
+  for f in "/home/${USER:?}/Desktop/"*.desktop; do
+    chmod +x "$f";
+    gio set -t string "$f" metadata::xfce-exe-checksum "$(sha256sum "$f" | awk '{print $1}')";
+  done
+
 elif [[ $TASK == "reset-power-management" ]]; then
   echo "update-xfce-settings: Resetting power management options for user $USER"
 
@@ -86,8 +94,9 @@ else
   echo
   echo "Task must be one of:"
   echo
-  echo " disable-unsafe-power-management   Disable suspend and hibernation buttons"
   echo " adjust-icon-size                  Increase the default desktop icon size"
-  echo " reset-power-management            Reset power management settings to default"
+  echo " disable-unsafe-power-management   Disable suspend and hibernation buttons"
+  echo " dismiss-desktop-icon-prompt       Mark the desktop icon for SDW as trusted"
   echo " reset-icon-size                   Reset icon size to default"
+  echo " reset-power-management            Reset power management settings to default"
 fi

--- a/securedrop_salt/sd-dom0-files.sls
+++ b/securedrop_salt/sd-dom0-files.sls
@@ -48,6 +48,17 @@ dom0-securedrop-launcher-desktop-shortcut:
     - group: {{ gui_user }}
     - mode: 755
 
+{% if grains['osrelease'] != '4.2' %}
+# Dismiss "security warning" when opening any desktop icons
+# as it is not a true security mitigation in Qubes. See #1582
+dom0-dismiss-desktop-icon-prompt:
+  cmd.run:
+    - name: /usr/bin/securedrop/update-xfce-settings dismiss-desktop-icon-prompt
+    - runas: {{ gui_user }}
+    - require:
+      - file: dom0-securedrop-launcher-desktop-shortcut
+{% endif %}
+
 dom0-environment-directory:
   file.directory:
     - name: /var/lib/securedrop-workstation/

--- a/tests/test_dom0_salt_config.py
+++ b/tests/test_dom0_salt_config.py
@@ -1,6 +1,17 @@
+import hashlib
+import os
 import subprocess
+from pathlib import Path
 
 import pytest
+
+from tests.conftest import skip_on_qubes_4_2
+
+DESKTOP_FILE_NAME = "press.freedom.SecureDropUpdater.desktop"
+
+
+def checksum(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
 def test_is_topfile_enabled():
@@ -13,3 +24,25 @@ def test_is_topfile_enabled():
 
     except subprocess.CalledProcessError:
         pytest.fail("Error checking topfiles")
+
+
+@skip_on_qubes_4_2
+@pytest.mark.provisioning
+def test_trust_desktop_launcher() -> None:
+    desktop_file = Path.home() / "Desktop" / DESKTOP_FILE_NAME
+
+    # Duplicate the dbus session bootstrap logic from `../files/update-xfce-settings`,
+    # so the test works under invocations that don't inherit a session bus,
+    # such as OpenQA's `su user -c`.
+    env = {**os.environ, "DBUS_SESSION_BUS_ADDRESS": f"unix:path=/run/user/{os.getuid()}/bus"}
+
+    # salt should have already provisioned the correct checksum
+    res = subprocess.run(
+        ["gio", "info", "--attributes", "metadata::xfce-exe-checksum", desktop_file],
+        text=True,
+        check=False,
+        capture_output=True,
+        env=env,
+    )
+    assert res.returncode == 0, "desktop launcher does not match"
+    assert checksum(desktop_file) in res.stdout


### PR DESCRIPTION
XFCE has a new "security" feature that requires us to set a checksum of the .desktop file in the gio database before it can be used.

A slightly overkill script sets the value and also offers a --check mode so that way salt can skip setting it when not needed.

Fixes #1577.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] Run `make dev` with this PR, verify you can click on the launcher and it doesn't have a prompt about it being untrusted.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
