### PR TITLE
Set fail-fast: false on OpenQA jobs

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -119,6 +119,7 @@ jobs:
     secrets: inherit
     needs: ["get-main-commit"]
     strategy:
+      fail-fast: false
       matrix:
         qubes_version: ["4.2", "4.3"]
     with:

--- a/.github/workflows/openqa-pull-request.yml
+++ b/.github/workflows/openqa-pull-request.yml
@@ -62,6 +62,7 @@ jobs:
     needs: [check]
     if: ${{ needs.check.outputs.qubes-versions != '' }}
     strategy:
+      fail-fast: false
       matrix:
         qubes_version: ${{ fromJSON(needs.check.outputs.qubes-versions) }}
     uses: ./.github/workflows/openqa.yml

--- a/.github/workflows/openqa-pull-request.yml
+++ b/.github/workflows/openqa-pull-request.yml
@@ -5,9 +5,16 @@ run-name: "[OpenQA] ${{ github.event.action == 'synchronize' && 'synchronize' ||
 on:
   pull_request:
     types:
-      - labeled    # Trigger immediately when label added
-      - unlabeled  # Detect label removal in order to cancel previous runs
-      - synchronize
+      - labeled     # Trigger immediately when label added
+      - unlabeled   # Detect label removal in order to cancel previous runs
+      - synchronize # Re-run against new HEAD when commits are pushed to the PR
+
+# Collapse rapid toggles of the same label into a single run of the job.
+# Different labels (4.2 vs 4.3) and synchronize events stay in separate groups,
+# so they run independently.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.label.name || github.event.action }}
+  cancel-in-progress: true
 
 jobs:
   check:


### PR DESCRIPTION
If e.g. 4.2 fails, we don't want to automatically kill the 4.3 job.

Fixes #1581.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
Could test by intentionally breaking 4.2 and seeing that the 4.3 job continues?
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
