### PR TITLE
Salt: avoid running sd-dom0-files.sls twice

### DIFF
--- a/securedrop_salt/sd-base-template.sls
+++ b/securedrop_salt/sd-base-template.sls
@@ -4,8 +4,10 @@
 # Imports "sdvars" for environment config
 {% from 'securedrop_salt/sd-default-config.sls' import sdvars with context %}
 
-include:
-  - securedrop_salt.sd-dom0-files
+# Ensure debian-12-minimal is present for use as base template
+dom0-install-debian-minimal-template:
+  qvm.template_installed:
+    - name: debian-12-minimal
 
 # Clones a base templateVM from debian-12-minimal
 sd-base-template:

--- a/securedrop_salt/sd-dom0-files.sls
+++ b/securedrop_salt/sd-dom0-files.sls
@@ -6,11 +6,6 @@
 # over time. These scripts should be ported to an RPM package.
 ##
 
-# Ensure debian-12-minimal is present for use as base template
-dom0-install-debian-minimal-template:
-  qvm.template_installed:
-    - name: debian-12-minimal
-
 {% set gui_user = salt['cmd.shell']('groupmems -l -g qubes') %}
 {% import_json "securedrop_salt/config.json" as d %}
 


### PR DESCRIPTION
Since we're running the salt formulas in bits, SaltStack cannot guarantee that formulas run only once. In this case installing the template was in sd-dom0-files whereas in practice it should be out of that file, since it's only really ever used when creating the sd-base template.

Fixes #1585

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

- [ ] Start from a clean state
  - [ ] run `sdw-admin --uninstall`
  - [ ] run `qvm-template remove debian-12-minimal`
- [ ] Run `sdw-admin --apply` and look in the output for repeated salt states from `sd-dom0-files.sls` (each should only be run once)
- [ ] `sd-base-bookworm-template` is provisioned correctly.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
