### PR TITLE
[1.6.0] Backport "Always provision the Inbox; use "SecureDrop Inbox" in user-facing strings"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ run-client: assert-dom0 run-deps ## Run client application (automatic login)
 	@xdotool key Return
 
 PHONY: run-app
-run-app: assert-dom0 run-deps ## Run SecureDrop App (automatic login)
+run-app: assert-dom0 run-deps ## Run SecureDrop Inbox (automatic login)
 	qvm-run --service sd-app qubes.StartApp+press.freedom.SecureDropApp
 	@sleep 5
 	@xdotool type "journalist"

--- a/files/press.freedom.SecureDropUpdater.desktop
+++ b/files/press.freedom.SecureDropUpdater.desktop
@@ -3,5 +3,5 @@ Version=1.0
 Type=Application
 Terminal=false
 Icon=securedrop
-Name=SecureDrop
+Name=SecureDrop Inbox
 Exec=sdw-updater --launch-app

--- a/sdw_updater/UpdaterApp.py
+++ b/sdw_updater/UpdaterApp.py
@@ -18,11 +18,11 @@ logger = Util.get_logger(module=__name__)
 
 def launch_securedrop_client(app: bool = False):
     """
-    Helper function to launch the SecureDrop Client or App
+    Helper function to launch the SecureDrop Client or Inbox ("app")
     """
     if app:
         desktop_file = "press.freedom.SecureDropApp"
-        app_name = "SecureDrop app"
+        app_name = "SecureDrop Inbox"
     else:
         desktop_file = "press.freedom.SecureDropClient"
         app_name = "SecureDrop client"

--- a/sdw_updater/strings.py
+++ b/sdw_updater/strings.py
@@ -10,7 +10,7 @@ description_introduction = (
 description_introduction_app = (
     "<p>To keep your Workstation safe, daily software updates are required.</p> "
     "<p>This typically takes between 10 and 30 minutes. You cannot use the SecureDrop "
-    "App or any of its VMs while the updater is running.</p>"
+    "Inbox or any of its VMs while the updater is running.</p>"
     "<p><span style='color:#E62354;'><b>Interrupting software updates may break "
     "the Workstation.</b></span> Please cancel and return later if you are pressed "
     "for time.</p>"
@@ -30,7 +30,7 @@ description_status_updates_complete = (
     "Click <em>Continue</em> to launch the SecureDrop Client. No reboot is necessary."
 )
 description_status_updates_complete_app = (
-    "Click <em>Continue</em> to launch the SecureDrop App. No reboot is necessary."
+    "Click <em>Continue</em> to launch the SecureDrop Inbox. No reboot is necessary."
 )
 
 headline_status_updates_failed = "Security updates failed"
@@ -40,7 +40,7 @@ description_status_updates_failed = (
 )
 description_status_updates_failed_app = (
     "There was an error downloading or installing updates for your workstation. "
-    "The SecureDrop App cannot be started at this time. Please contact your administrator."
+    "The SecureDrop Inbox cannot be started at this time. Please contact your administrator."
 )
 # Post-update actions (launching client, reboot)
 headline_status_reboot_required = "All updates complete!"

--- a/securedrop_salt/press.freedom.SecureDropUpdater.desktop.j2
+++ b/securedrop_salt/press.freedom.SecureDropUpdater.desktop.j2
@@ -3,5 +3,5 @@ Version=1.0
 Type=Application
 Terminal=false
 Icon=securedrop
-Name=SecureDrop
+Name=SecureDrop Inbox
 Exec={{ desktop_exec }}

--- a/securedrop_salt/sd-app-files.sls
+++ b/securedrop_salt/sd-app-files.sls
@@ -20,8 +20,6 @@ install-securedrop-client-package:
   pkg.installed:
     - pkgs:
       - securedrop-client
-      {% if d.get('app', false) %}
       - securedrop-app
-      {% endif %}
     - require:
       - sls: securedrop_salt.fpf-apt-repo

--- a/securedrop_salt/sd-dom0-files.sls
+++ b/securedrop_salt/sd-dom0-files.sls
@@ -30,7 +30,7 @@ dom0-login-autostart-desktop-file:
     - context:
         desktop_name: SDWLogin
         desktop_comment: Updates SecureDrop Workstation DispVMs at login
-        desktop_exec: /usr/bin/sdw-login{% if d.get('app', false) %} --launch-app{% endif %}
+        desktop_exec: /usr/bin/sdw-login --launch-app
     - user: {{ gui_user }}
     - group: {{ gui_user }}
     - mode: 664
@@ -43,7 +43,7 @@ dom0-securedrop-launcher-desktop-shortcut:
     - source: "salt://securedrop_salt/press.freedom.SecureDropUpdater.desktop.j2"
     - template: jinja
     - context:
-        desktop_exec: sdw-updater{% if d.get('app', false) %} --launch-app{% endif %}
+        desktop_exec: sdw-updater --launch-app
     - user: {{ gui_user }}
     - group: {{ gui_user }}
     - mode: 755


### PR DESCRIPTION
## Description of Changes

Backport of #1606.

## Testing

* [x] CI is passing
* [x] base is `release/1.6.0`
* [x] Only contains changes from #1606.
