### PR TITLE
Prevent SDW Update amid inplace upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
   launcher-tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix: *qubes_release
     container:
       image: quay.io/fedora/fedora:${{ matrix.qubes_release.fedora_ver }}

--- a/Makefile
+++ b/Makefile
@@ -145,17 +145,18 @@ clean: assert-dom0 ## Destroys all SD VMs
 	rpm -qa | grep '^securedrop-workstation' | xargs -r sudo dnf remove -y
 	find /etc/yum.repos.d -type f -iname 'securedrop-workstation*.repo' -exec sudo rm -v {} +
 
+DOM0_TEST_PREREQS = python3-pytest python3-pytest-cov python3-pytest-xdist python3-systemd
 .PHONY: test-prereqs
 test-prereqs: ## Checks that test prerequisites are satisfied
 	@echo "Checking prerequisites before running test suite..."
 	@test -e config.json || (echo "Ensure config.json is in this directory" && exit 1)
 	@test -e sd-journalist.sec || (echo "Ensure sd-journalist.sec is in this directory" && exit 1)
-	@rpm -q python3-pytest python3-pytest-cov python3-pytest-xdist || (echo 'please install test dependencies with "make install-dom0-test-prereqs"' && exit 1)
+	@rpm -q $(DOM0_TEST_PREREQS) || (echo 'please install test dependencies with "make install-dom0-test-prereqs"' && exit 1)
 
 .PHONY: install-dom0-test-prereqs
 install-dom0-test-prereqs: assert-dom0 ## Installs pytest dependencies in dom0
-	@rpm -q python3-pytest python3-pytest-cov python3-pytest-xdist python3-systemd || \
-		sudo qubes-dom0-update -y python3-pytest python3-pytest-cov python3-pytest-xdist python3-systemd
+	rpm -q $(DOM0_TEST_PREREQS) || \
+		sudo qubes-dom0-update -y $(DOM0_TEST_PREREQS)
 
 test: test-prereqs ## Runs all application tests (no integration tests yet)
 	# N.B. make sure to use "-vv" for max-length diffs on test failures

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ clean: assert-dom0 ## Destroys all SD VMs
 	rpm -qa | grep '^securedrop-workstation' | xargs -r sudo dnf remove -y
 	find /etc/yum.repos.d -type f -iname 'securedrop-workstation*.repo' -exec sudo rm -v {} +
 
-DOM0_TEST_PREREQS = python3-pytest python3-pytest-cov python3-pytest-xdist python3-systemd
+DOM0_TEST_PREREQS = python3-pytest python3-pytest-cov python3-pytest-xdist python3-pytest-mock python3-systemd
 .PHONY: test-prereqs
 test-prereqs: ## Checks that test prerequisites are satisfied
 	@echo "Checking prerequisites before running test suite..."

--- a/files/sdw-updater.py
+++ b/files/sdw-updater.py
@@ -9,7 +9,7 @@ except ImportError:
 
 
 from sdw_updater import Updater
-from sdw_updater.Updater import should_launch_updater
+from sdw_updater.Updater import is_qubes_mid_upgrade, should_launch_updater
 from sdw_updater.UpdaterApp import UpdaterApp, launch_securedrop_client
 from sdw_util import Util
 
@@ -39,11 +39,17 @@ def main(argv):
     Util.configure_logging(Updater.LOG_FILE)
     Util.configure_logging(Updater.DETAIL_LOG_FILE, Updater.DETAIL_LOGGER_PREFIX, backup_count=10)
     sdlog = Util.get_logger()
+
     lock_handle = Util.obtain_lock(Updater.LOCK_FILE)
     if lock_handle is None:
         # Preflight updater already running or problems accessing lockfile.
         # Logged.
         sys.exit(1)
+
+    if is_qubes_mid_upgrade():
+        sdlog.info("Detected inplace upgrade in process. Exiting!")
+        sys.exit(0)
+
     sdlog.info("Starting SecureDrop Launcher")
 
     args = parse_argv(argv)

--- a/launcher/tests/conftest.py
+++ b/launcher/tests/conftest.py
@@ -4,6 +4,8 @@ import tempfile
 
 import pytest
 
+import sdw_updater.Updater
+
 
 @pytest.fixture
 def tmpdir():
@@ -19,3 +21,44 @@ skip_in_dom0 = pytest.mark.skipif(
     socket.gethostname() == "dom0",
     reason="Test cannot be run in dom0",
 )
+
+
+@pytest.fixture
+def mocked_qubes_app(mocker):
+    from qubesadmin.tests.mock_app import MockQube, QubesTestWrapper
+
+    class MockQubesWorkstation(QubesTestWrapper):
+        def __init__(self):
+            super().__init__()
+
+            # FIXME avoid using module under test. Obtain directly from main tests
+            current_vms = sdw_updater.Updater._get_current_vms()
+
+            # 1. create the templates
+            for template_name in set(current_vms.values()):
+                self._qubes[template_name] = MockQube(
+                    name=template_name,
+                    qapp=self,
+                    klass="TemplateVM",
+                    netvm="",
+                )
+
+            # 2. create the app qubes
+            for qube_name, template_name in current_vms.items():
+                MockQube(
+                    qube_name,
+                    self,
+                    template=template_name,
+                )
+
+            # 3. TODO Lastly create the disposables
+
+            self.update_vm_calls()
+
+    mock_qubes_app = MockQubesWorkstation()
+
+    # Patch "Qubes()" to allow tests to run on this fake mock
+    mocker.patch("qubesadmin.Qubes").return_value = mock_qubes_app
+
+    # yield the mock to allow for further modifications in tests
+    return mock_qubes_app

--- a/launcher/tests/test_updater.py
+++ b/launcher/tests/test_updater.py
@@ -403,6 +403,33 @@ def test_read_dom0_update_flag_from_disk_fails(
         mocked_info.assert_has_calls(info_calls)
 
 
+@pytest.mark.parametrize(
+    ("qubes_ver", "agent_ver", "is_mid_upgrade"),
+    [
+        ("4.2", "4.2", False),  # Regular 4.2 system
+        ("4.3", "4.2", True),  # System in middle of 4.2 -> 4.3 upgrade
+        ("4.3", "4.3", False),  # Regular 4.3 system
+        ("4.4", "4.3", True),  # System in middle of 4.3 -> 4.4 upgrade
+    ],
+)
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true", reason="Skipping on CI (should only run in Qubes)"
+)
+def test_is_qubes_mid_upgrade(qubes_ver, agent_ver, is_mid_upgrade, mocker, mocked_qubes_app):
+    # Overrding "dnf.rpm.detect_releasever" to simulate being on particular Qubes version
+    mocker.patch("dnf.rpm").detect_releasever.return_value = qubes_ver
+
+    # Make templates return the version set by the test (MockQubes is just a mock)
+    for qube in mocked_qubes_app.domains:
+        if qube.klass == "TemplateVM":
+            mocked_qubes_app.expected_calls[
+                (qube.name, "admin.vm.feature.Get", "qubes-agent-version", None)
+            ] = b"0\x00" + agent_ver.encode()
+
+    # Actual test
+    assert Updater.is_qubes_mid_upgrade() == is_mid_upgrade
+
+
 @mock.patch(
     "sdw_updater.Updater.read_dom0_update_flag_from_disk",
     return_value={

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -43,6 +43,7 @@ Requires:		qubes-mgmt-salt-dom0-virtual-machines
 Requires:       securedrop-workstation-keyring
 Requires:       grub2-xen-pvh
 Requires:       qubes-gpg-split-dom0
+Requires:       python3-dnf
 # Qubes 4.3 dependencies:
 %{?fc41:Requires: python3-pyqt6}
 # Qubes 4.2 dependencies:

--- a/sdw_updater/Updater.py
+++ b/sdw_updater/Updater.py
@@ -14,6 +14,9 @@ import time
 from datetime import datetime, timedelta
 from enum import Enum
 
+import dnf
+from qubesadmin import Qubes
+
 from sdw_util import Util
 
 DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
@@ -453,6 +456,26 @@ def apply_dom0_state():
         clean_output = Util.cleanup_for_log(e.output.decode("utf-8").strip())
         detail_log.error(f"Output from failed command: {cmd_for_log}\n{clean_output}")
         return UpdateStatus.UPDATES_FAILED
+
+
+def is_qubes_mid_upgrade():
+    """
+    Detects if the system is in the middle of a dist. upgrade (e.g. 4.2 -> 4.3)
+
+    This detects if STAGE 4 of qubes-dist-upgrade has not yet started.
+    """
+
+    # If already past stages 1, 2 and 3 this should be the next Qubes version
+    qubes_ver = dnf.rpm.detect_releasever("/")
+
+    # But before stage 4, templates are still targetting the old qubes agent
+    all_qubes = Qubes().domains
+    templates = [all_qubes[q_name] for q_name in _get_current_templates()]
+    qube_agent_versions = [t.features.get("qubes-agent-version") for t in templates]
+
+    # Any mismatch between dom0's version and the templates' agent version
+    # is indicative of not yet having gone through STAGE 4 of the upgrade
+    return any([qubes_ver != agent_ver for agent_ver in qube_agent_versions])
 
 
 def should_launch_updater(interval):

--- a/sdw_updater/Updater.py
+++ b/sdw_updater/Updater.py
@@ -14,9 +14,6 @@ import time
 from datetime import datetime, timedelta
 from enum import Enum
 
-import dnf
-import qubesadmin
-
 from sdw_util import Util
 
 DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
@@ -464,6 +461,9 @@ def is_qubes_mid_upgrade():
 
     This detects if STAGE 4 of qubes-dist-upgrade has not yet started.
     """
+    # Lazy imports: these are dom0-only system packages, not available in CI venv
+    import dnf
+    import qubesadmin
 
     # If already past stages 1, 2 and 3 this should be the next Qubes version
     qubes_ver = dnf.rpm.detect_releasever("/")

--- a/sdw_updater/Updater.py
+++ b/sdw_updater/Updater.py
@@ -15,7 +15,7 @@ from datetime import datetime, timedelta
 from enum import Enum
 
 import dnf
-from qubesadmin import Qubes
+import qubesadmin
 
 from sdw_util import Util
 
@@ -469,7 +469,7 @@ def is_qubes_mid_upgrade():
     qubes_ver = dnf.rpm.detect_releasever("/")
 
     # But before stage 4, templates are still targetting the old qubes agent
-    all_qubes = Qubes().domains
+    all_qubes = qubesadmin.Qubes().domains
     templates = [all_qubes[q_name] for q_name in _get_current_templates()]
     qube_agent_versions = [t.features.get("qubes-agent-version") for t in templates]
 


### PR DESCRIPTION
Fixes #1547

Only missing figuring out how to get the dnf dependency in working in CI.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

- **lengthy test**: Ideally this is tested on a real in-place upgrade, but it's not that trivial to do, since we'd need the package up on the repos. Here's a plan suggestions:
   - [ ] Build for package for qubes 4.2 and 4.3 (here `make build-rpm FEDORA_VERSION=41`)
   - [ ] Copy RPMs to test machine's dom0 (you'll need both later)
   - [ ] Install 4.2 version of RPM in dom0 and run `sdw-updater` in dom0 (just to ensure the updater still works)
   - [ ] Do an in-place upgrade (stages 1,2,3 **but do NOT restart**): 
      - [ ] `sudo qubes-dom0-update qubes-dist-upgrade`
      - [ ] `sudo qubes-dist-upgrade --releasever=4.3 --all-pre-reboot --assumeyes`  (**do NOT reboot**)
   - [ ] Install 4.3 version of RPM in dom0 and restart
   - [ ] Updater did not launch upon rebooting
   - [ ] complete inplace upgrade
   - [ ] test if `sdw-updater` launches correctly
- **short test**: look at the test and replicate it (`qvm-features <template> qubes-agent-version 4.1` or one version lower than what your current system has — don't forget to revert it). 

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
