### PR TITLE
Run `sdw-admin --apply` (migration) in 1.6.0 installation

### DIFF
--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -160,8 +160,8 @@ qubesctl saltutil.sync_all refresh=true -l quiet --out quiet > /dev/null || true
 qubesctl top.enable securedrop_salt.sd-workstation > /dev/null ||:
 
 # Force full run of all Salt states - uncomment in release branch
-# mkdir -p /tmp/sdw-migrations
-# touch /tmp/sdw-migrations/fedora-selinux-fix
+mkdir -p /tmp/sdw-migrations
+touch /tmp/sdw-migrations/install-securedrop-app
 
 # Enable service that conditionally removes our systemd-logind customizations
 # on dev machines only.


### PR DESCRIPTION
We need a migration for this release in order to have [`securedrop-app` installed via salt](https://github.com/freedomofpress/securedrop-workstation/blob/release/1.6.0/securedrop_salt/sd-app-files.sls#L23).

## Test plan
- [x] visual check (later in release QA we'll test the upgrade itself)

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
