### PR TITLE
Fix sdw-notify Qt5 compat; always launch Inbox

### DIFF
--- a/files/sdw-notify.py
+++ b/files/sdw-notify.py
@@ -67,7 +67,7 @@ def show_update_warning():
     # has opted to check for updates.
     if result == NotifyApp.NotifyStatus.CHECK_UPDATES:
         log.info("Launching Preflight Updater")
-        updater = UpdaterApp.UpdaterApp()
+        updater = UpdaterApp.UpdaterApp(launch_app=True)
         updater.show()
         sys.exit(app.exec())
     elif result == NotifyApp.NotifyStatus.DEFER_UPDATES:

--- a/sdw_notify/NotifyApp.py
+++ b/sdw_notify/NotifyApp.py
@@ -43,7 +43,7 @@ class NotifyDialog(QMessageBox):
 
     def _ui(self):
         self.setWindowTitle(strings.headline_notify_updates)
-        self.setIcon(QMessageBox.StandardButton.Warning)
+        self.setIcon(QMessageBox.Icon.Warning)
         self.setStandardButtons(QMessageBox.StandardButton.No | QMessageBox.StandardButton.Ok)
         self.setDefaultButton(QMessageBox.StandardButton.Ok)
         self.setEscapeButton(QMessageBox.StandardButton.No)


### PR DESCRIPTION
The `sdw-notify` background timer that reminds users if updates haven't run recently should always default to launching the Inbox. This is the only remaining place where UpdaterApp was invoked without an explicit `launch_app`.

Additionally, `sdw-notify` was crashing on 4.2 because `QMessageBox.StandardButton.Warning` doesn't exist in Qt5.

Fixes #1621.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] Build RPM and install in Qubes 4.2
* [x] in dom0, `rm ~/.securedrop_updater/sdw-last-updated`
* [x] in dom0, run `sdw-notify`, observe a dialog opens
* [x] when you click "Check for updates", the text should say "...use the SecureDrop **Inbox**" and not Client.
* [ ] (bonus) repeat for Qubes 4.3

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
