### PR TITLE
fix: update string handling for updater

### DIFF
--- a/launcher/tests/conftest.py
+++ b/launcher/tests/conftest.py
@@ -6,6 +6,39 @@ import pytest
 
 
 @pytest.fixture
+def mocked_qubes_vm_update(tmp_path, monkeypatch):
+    """
+    Factory fixture: call with stderr/stdout/retcode to register a
+    fake qubes-vm-update process via a real script on PATH.
+    All test data is written to files — no user content in script source.
+
+    Assumption: `qubes-vm-update` is not called with /usr/bin/qubes-vm-update
+    """
+
+    def _mocked_qubes_vm_update(stderr="", stdout="", retcode=0):
+        (tmp_path / "stdout.txt").write_text(stdout + "\n")
+        (tmp_path / "stderr.txt").write_text(stderr + "\n")
+        assert isinstance(retcode, int), "'retcode' must be an int"
+
+        script = tmp_path / "qubes-vm-update"
+        script.write_text(
+            "#!/usr/bin/env python3\n"
+            "import sys\n"
+            "from pathlib import Path\n"
+            "base = Path(__file__).parent\n"
+            "sys.stdout.write((base / 'stdout.txt').read_text())\n"
+            "sys.stderr.write((base / 'stderr.txt').read_text())\n"
+            f"sys.exit({retcode})\n"
+        )
+        script.chmod(0o755)
+
+    # Prepend script to path, so it get called instead of the real one
+    monkeypatch.setenv("PATH", str(tmp_path), prepend=os.pathsep)
+
+    return _mocked_qubes_vm_update
+
+
+@pytest.fixture
 def tmpdir():
     """Run the test in a temporary directory"""
     cwd = os.getcwd()

--- a/launcher/tests/test_updater.py
+++ b/launcher/tests/test_updater.py
@@ -108,40 +108,38 @@ def test_apply_templates_success(
 
 
 @pytest.mark.parametrize(
-    ("templates", "stderr", "expected"),
+    ("templates", "qubes_upd_stderr", "qubes_upd_retcode", "expected"),
     [
         (
             ["template"],
             "template updating 0\ntemplate done success",
+            0,
             UpdateStatus.UPDATES_OK,
         ),
         (
             ["template"],
             "template updating 0\nunknown_keyword",
+            1,
             UpdateStatus.UPDATES_FAILED,
         ),
         (
             ["tpl1", "tpl2"],
             "tpl1 updating 0\ntpl2 updating 0\tpl1 done success\ntpl2 done error",
+            1,
             UpdateStatus.UPDATES_FAILED,
         ),
     ],
 )
-def test_apply_templates(templates, stderr, expected):
+def test_apply_templates(
+    templates, qubes_upd_stderr, qubes_upd_retcode, expected, mocked_qubes_vm_update
+):
+    mocked_qubes_vm_update(stderr=qubes_upd_stderr, retcode=qubes_upd_retcode)
     with (
-        mock.patch(
-            "sdw_updater.Updater._start_qubes_updater_proc",
-            return_value=subprocess.Popen(  # noqa: S602
-                f"echo '{stderr}' >> /dev/stderr",
-                shell=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            ),
-        ),
+        mock.patch("time.sleep"),  # skip time.sleep in polling to speed up test
         mock.patch("sdw_updater.Updater._get_current_templates", return_value=templates),
     ):
         result = Updater.apply_updates_templates()
-        assert result == expected
+    assert result == expected
 
 
 @pytest.mark.parametrize("status", UpdateStatus)

--- a/sdw_updater/Updater.py
+++ b/sdw_updater/Updater.py
@@ -189,8 +189,7 @@ def _qubes_updater_parse_stdout(stream):
             # Reached EOF
             break
 
-        line = Util.cleanup_for_log(line.decode("ascii")).rstrip()
-        line = line.rstrip()
+        line = Util.cleanup_for_log(line).rstrip()
         detail_log.info(f"[Qubes updater] {line}")
 
 
@@ -207,7 +206,7 @@ def _qubes_updater_parse_progress(stream, result, templates, progress_callback=N
             # Reached EOF
             break
 
-        line = Util.cleanup_for_log(line.decode("ascii")).rstrip()
+        line = Util.cleanup_for_log(line).rstrip()
         try:
             vm, status, info = line.split()
         except ValueError:


### PR DESCRIPTION
Fixes #1618 by updating the string-handling in the Updater. 

## Test plan
1. `make clone && make dev`
2. run `sdw_updater` from the CLI in dom0 and ensure you can run it to completion

## Checklist

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation

## Related work

Supersedes and therefore closes #1623. Does _not_ include solutions for #1620, to keep review simple, but I'll get to those shortly. 