### PR TITLE
Fix custom-persist for fresh installs

### DIFF
--- a/securedrop_salt/sd-app.sls
+++ b/securedrop_salt/sd-app.sls
@@ -55,9 +55,9 @@ sd-app-custom-persist:
     - enable:
       - service.custom-persist
     - set:
-      - custom-persist.client_dir: /home/user/.securedrop_client/
-      - custom-persist.app_db: /home/user/.config/SecureDrop/db.sqlite
-      - custom-persist.app_downloaded_files: /home/user/.config/SecureDrop/files/
+      - custom-persist.client_dir: dir:user:user:0700:/home/user/.securedrop_client
+      - custom-persist.app_db: file:user:user:0600:/home/user/.config/SecureDrop/db.sqlite
+      - custom-persist.app_downloaded_files: dir:user:user:0700:/home/user/.config/SecureDrop/files
 {% endif %}
 
 sd-app-config:

--- a/securedrop_salt/sd-gpg.sls
+++ b/securedrop_salt/sd-gpg.sls
@@ -58,5 +58,5 @@ sd-gpg-custom-persist:
     - enable:
       - service.custom-persist
     - set:
-      - custom-persist.gnupg_dir: /home/user/.gnupg
+      - custom-persist.gnupg_dir: dir:user:user:0700:/home/user/.gnupg
 {% endif %}

--- a/securedrop_salt/sd-log.sls
+++ b/securedrop_salt/sd-log.sls
@@ -82,7 +82,7 @@ sd-log-custom-persist:
     - enable:
       - service.custom-persist
     - set:
-      - custom-persist.logs: /home/user/QubesIncomingLogs/
+      - custom-persist.logs: dir:user:user:0755:/home/user/QubesIncomingLogs
 {% endif %}
 
 # The private volume size should be set in config.json


### PR DESCRIPTION
By using the extended syntax, Qubes will auto-create the path if needed so it'll be correctly persisted on fresh installs.

Fixes #1650.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] `sdw-admin --uninstall`
* [ ] fresh install this PR, launch the Inbox and sync
* [ ] restart sd-app VM and see that the Inbox's DB state is preserved and not lost
* [ ] now look at sd-log and see logs are there
* [ ] restart sd-log and see the logs are still there!
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
