### PR TITLE
Have mypy ignore rpm-build/

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ files = [
 ]
 exclude = [
     "launcher/", # Moving to sd-updater
+    "rpm-build/",
     "tests/",
 ]
 


### PR DESCRIPTION
After a `make rpm-build` there might be duplicate Python files there that conflict with the main copies, causing duplicate module failures.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] `make rpm-build && make mypy` doesn't fail with duplicate module issues
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
