### PR TITLE
Custom persist sd-app's unterminated SQLite writes

### DIFF
--- a/securedrop_salt/sd-app.sls
+++ b/securedrop_salt/sd-app.sls
@@ -57,6 +57,8 @@ sd-app-custom-persist:
     - set:
       - custom-persist.client_dir: dir:user:user:0700:/home/user/.securedrop_client
       - custom-persist.app_db: file:user:user:0600:/home/user/.config/SecureDrop/db.sqlite
+      - custom-persist.app_db_wal file:user:user:0600:/home/user/.config/SecureDrop/db.sqlite-wal
+      - custom-persist.app_db_shm file:user:user:0600:/home/user/.config/SecureDrop/db.sqlite-shm
       - custom-persist.app_downloaded_files: dir:user:user:0700:/home/user/.config/SecureDrop/files
 {% endif %}
 


### PR DESCRIPTION
SQLite stores [some extra files](https://www.sqlite.org/wal.html) that we also need to store via custom persist, otherwise there are issues where some of the last actions are not persisted under certain circumstances.

Fixes #1660

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
