### PR TITLE
Semgrep: detect salt pitfalls (watch, cmd.wait)

### DIFF
--- a/.semgrep/saltstack-rules.yml
+++ b/.semgrep/saltstack-rules.yml
@@ -12,3 +12,29 @@ rules:
     paths:
       include:
         - "*.sls"
+
+  - id: saltstack-cmd-wait-discouraged # "Regression test" for issue #1641
+    patterns:
+      - pattern: |
+          cmd.wait:
+            ...
+    message: SaltStack's cmd.wait is particularly tricky and the docs discourage it
+    languages:
+      - generic
+    severity: ERROR
+    paths:
+      include:
+        - "*.sls"
+  - id: saltstack-watch-requires-mod-watch # "Regression test" for issue #1641
+    patterns:
+      - pattern: |
+          ...:
+            ...
+            - watch: ...
+    message: Please make sure the watched state implements 'mod_watch'
+    languages:
+      - generic
+    severity: ERROR
+    paths:
+      include:
+        - "*.sls"


### PR DESCRIPTION
Detect tricky salt commands that even the documentation [warns about](https://docs.saltproject.io/en/latest/ref/states/requisites.html#watch). Helps detect regressions similar to #1641.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

- [ ] `make semgrep` exits `0`
- [ ] Apply the following patch
    ```patch
    diff --git a/securedrop_salt/sd-sys-vms.sls b/securedrop_salt/sd-sys-vms.sls
    index a1298f8..d058f05 100644
    --- a/securedrop_salt/sd-sys-vms.sls
    +++ b/securedrop_salt/sd-sys-vms.sls
    @@ -40,7 +40,7 @@ set-fedora-template-as-default-mgmt-dvm:
     #     running updater has a stale list
     #     (see https://github.com/freedomofpress/securedrop-workstation/issues/758)
     update-fedora-template-if-new:
    -  cmd.run:
    +  cmd.wait:
         - name: qubes-vm-update --quiet --force-update --targets {{ sd_fedora_base_template }}
         - runas: {{ gui_user }}
         - require:
    @@ -59,6 +59,8 @@ set-fedora-default-template-version:
         - require:
           - qvm: dom0-install-fedora-template
           - sls: qvm.default-dispvm
    +    - watch:
    +      - cmd: update-fedora-template-if-new
     
     # On 4.1, several sys qubes are disposable by default - since we also want to
     # upgrade the templates for those, we need to ensure that the respective dvms
    ```
- [ ] `make semgrep` exits `1` and accuses the errors.
 
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
