### PR TITLE
Let the user configure SDW from backups

### DIFF
--- a/files/sdw-admin.py
+++ b/files/sdw-admin.py
@@ -8,6 +8,7 @@ does it handle the config.
 import argparse
 import json
 import os
+import pathlib
 import subprocess
 import sys
 
@@ -28,10 +29,10 @@ BASE_TEMPLATE = "debian-12-minimal"
 
 SUBMISSION_KEY = "sd-journalist.sec"
 TAILS_PATH = "/run/media/user/TailsData/"
-TAILS_GNUPG_PATH = TAILS_PATH + "gnupg/"
-TAILS_PKG_JOURNALIST_INTERFACE_CONFIG = TAILS_PATH + "securedrop-admin/app-journalist.auth_private"
-TAILS_GIT_JOURNALIST_INTERFACE_CONFIG = (
-    TAILS_PATH + "Persistent/securedrop/install_files/ansible-base/app-journalist.auth_private"
+TAILS_GNUPG_SUBPATH = "gnupg/"
+TAILS_PKG_JOURNALIST_INTERFACE_CONFIG_SUBPATH = "securedrop-admin/app-journalist.auth_private"
+TAILS_GIT_JOURNALIST_INTERFACE_CONFIG_SUBPATH = (
+    "Persistent/securedrop/install_files/ansible-base/app-journalist.auth_private"
 )
 
 sys.path.insert(1, os.path.join(SCRIPTS_PATH, "scripts/"))
@@ -76,6 +77,20 @@ def parse_args() -> argparse.Namespace:
         required=False,
         action="store_true",
         help="Configure SecureDrop Workstation",
+    )
+    parser.add_argument(
+        "--svs-tails-path",
+        default=TAILS_PATH,
+        metavar="PATH",
+        required=False,
+        help="Read SVS configuration from PATH in vault VM",
+    )
+    parser.add_argument(
+        "--journo-tails-path",
+        default=TAILS_PATH,
+        metavar="PATH",
+        required=False,
+        help="Read journalist workstation configuration from PATH in vault VM",
     )
     return parser.parse_args()
 
@@ -362,18 +377,19 @@ def _prompt_choose_submission_key(fingerprints: list[str]) -> str | None:
         return None
 
 
-def import_submission_key() -> str:
+def import_submission_key(tails_path: pathlib.Path) -> str:
     """
     Imports SecureDrop submission key from USB drive to dom0. Assumes that the USB drive
     is successfully attached to vault VM and decrypted.
     Returns the submission key fingerprint.
     """
+    tails_gnupg_path = tails_path / TAILS_GNUPG_SUBPATH
     gpg_output = subprocess.check_output(
         [
             "qvm-run",
             "--pass-io",
             "vault",
-            f"gpg --homedir {TAILS_GNUPG_PATH} -K --fingerprint --with-colon",
+            f"gpg --homedir {tails_gnupg_path} -K --fingerprint --with-colon",
         ],
         text=True,
     )
@@ -394,7 +410,7 @@ def import_submission_key() -> str:
             "qvm-run",
             "--pass-io",
             "vault",
-            f"gpg --homedir {TAILS_GNUPG_PATH} --export-secret-keys --armor {fingerprint}",
+            f"gpg --homedir {tails_gnupg_path} --export-secret-keys --armor {fingerprint}",
         ],
         text=True,
     )
@@ -408,12 +424,15 @@ def import_submission_key() -> str:
     return fingerprint
 
 
-def import_journalist_interface_config() -> tuple[str, str]:
+def import_journalist_interface_config(tails_path: pathlib.Path) -> tuple[str, str]:
     """
     Imports Journalist Interface address and authentication info from USB drive to dom0.
     Assumes that USB drive is attached to vault VM and decrypted.
     Returns (hostname, key) of the journalist interface hidserv
     """
+    pkg_path = tails_path / TAILS_PKG_JOURNALIST_INTERFACE_CONFIG_SUBPATH
+    git_path = tails_path / TAILS_GIT_JOURNALIST_INTERFACE_CONFIG_SUBPATH
+
     journalist_interface_config = ""
     try:
         # First, check for the 2.13.0+ location
@@ -422,7 +441,7 @@ def import_journalist_interface_config() -> tuple[str, str]:
                 "qvm-run",
                 "--pass-io",
                 "vault",
-                f"cat {TAILS_PKG_JOURNALIST_INTERFACE_CONFIG}",
+                f"cat {pkg_path}",
             ],
             text=True,
         )
@@ -434,7 +453,7 @@ def import_journalist_interface_config() -> tuple[str, str]:
                     "qvm-run",
                     "--pass-io",
                     "vault",
-                    f"cat {TAILS_GIT_JOURNALIST_INTERFACE_CONFIG}",
+                    f"cat {git_path}",
                 ],
                 text=True,
             )
@@ -450,7 +469,7 @@ def import_journalist_interface_config() -> tuple[str, str]:
     return addr, auth_token
 
 
-def import_config() -> None:
+def import_config(svs_tails_path: pathlib.Path, journo_tails_path: pathlib.Path) -> None:
     submission_key_fingerprint = _try_read_submission_key()
     if not submission_key_fingerprint:
         subprocess.Popen(
@@ -472,7 +491,7 @@ def import_config() -> None:
             print("Exiting.")
             return
         print("Importing submission key...")
-        submission_key_fingerprint = import_submission_key()
+        submission_key_fingerprint = import_submission_key(svs_tails_path)
         print(
             "Submission key import complete!\n"
             "Please detach and disconnect the USB containing the submission key\n\n"
@@ -501,7 +520,7 @@ def import_config() -> None:
             print("Exiting.")
             return
         try:
-            ji_addr, ji_auth_token = import_journalist_interface_config()
+            ji_addr, ji_auth_token = import_journalist_interface_config(journo_tails_path)
         except SDWAdminException as e:
             print(f"Error importing configuration: {e}")
             sys.exit(1)
@@ -605,7 +624,9 @@ def main() -> None:
             validate_config(SCRIPTS_PATH)
             print("Valid configuration found, configuration complete")
         except SDWAdminException:
-            import_config()
+            svs_tails_path = pathlib.Path(args.svs_tails_path)
+            journo_tails_path = pathlib.Path(args.journo_tails_path)
+            import_config(svs_tails_path, journo_tails_path)
     else:
         sys.exit(0)
 


### PR DESCRIPTION
If an administrator decides to configure SecureDrop Workstation via their backups, they should be able to choose the path that they are located in the vault VM. In this case, they may have a single USB stick that has folders for each backup of the SVS or Journalist Workstation.

Add two more CLI options (`--svs-tails-path` / `--journo-tails-path`) that can be used to locate these backups within the vault VM. The default value remains `/run/media/user/TailsData/` for the general case.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
