### PR TITLE
Use installed validation script for `make dev/staging`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ dev staging: assert-dom0 ## Installs, configures and builds a dev or staging env
 configure-env-%:
 	@echo "Configuring $* environment"
 	./scripts/configure-environment.py --env $*
-	./files/validate_config.py
+	sdw-admin --validate
 
 .PHONY: assert-keyring-%
 assert-keyring-%: ## Correct keyring pkg installed


### PR DESCRIPTION
The validate_config.py script can no longer be run directly because of recent changes made while improving typing. Instead we should just run the installed validation script, which is what we actually want to test when setting up a new environment.

Fixes #1680.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
