### PR TITLE
Remove SecureDrop Client menu entry

### DIFF
--- a/files/press.freedom.SecureDropUpdaterClient.desktop
+++ b/files/press.freedom.SecureDropUpdaterClient.desktop
@@ -1,7 +1,0 @@
-[Desktop Entry]
-Version=1.0
-Type=Application
-Terminal=false
-Icon=securedrop
-Name=SecureDrop Client (legacy)
-Exec=sdw-updater

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -102,7 +102,6 @@ install -m 755 -d %{buildroot}%{_userunitdir}/
 install -m 755 -d %{buildroot}%{_unitdir}
 install -m 755 -d %{buildroot}%{_userpresetdir}/
 install -m 644 files/press.freedom.SecureDropUpdater.desktop %{buildroot}%{_datadir}/applications/
-install -m 644 files/press.freedom.SecureDropUpdaterClient.desktop %{buildroot}%{_datadir}/applications/
 install -m 644 files/securedrop-128x128.png %{buildroot}%{_datadir}/icons/hicolor/128x128/apps/securedrop.png
 install -m 644 files/securedrop-scalable.svg %{buildroot}%{_datadir}/icons/hicolor/scalable/apps/securedrop.svg
 install -m 755 files/sdw-updater.py %{buildroot}%{_bindir}/sdw-updater
@@ -152,7 +151,6 @@ install -m 644 securedrop_salt/apt-test_freedom_press.sources.j2 %{buildroot}/sr
 %attr(755, root, root) %{_bindir}/sdw-notify
 %attr(755, root, root) %{_bindir}/sdw-updater
 %attr(644, root, root) %{_datadir}/applications/press.freedom.SecureDropUpdater.desktop
-%attr(644, root, root) %{_datadir}/applications/press.freedom.SecureDropUpdaterClient.desktop
 %{python3_sitelib}/sdw_notify/*.py
 %{python3_sitelib}/sdw_updater/*.py
 %{python3_sitelib}/sdw_util/*.py


### PR DESCRIPTION
Remove the "SecureDrop Client (legacy)" Qubes menu entry as a minimal way to remove the Client from users without uninstalling the package, which requires more coordination with the Inbox release.

Refs https://github.com/freedomofpress/securedrop-client/issues/3411.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] Build this RPM and install into dom0
* [ ] See that "SecureDrop Client (legacy)" is no longer in the Qubes menu under "Other"
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
