### PR TITLE
sdw-upgrade: handle qube for removal in global prop

### DIFF
--- a/files/sdw-upgrade.py
+++ b/files/sdw-upgrade.py
@@ -333,7 +333,7 @@ class RemoveWhonix17(RemoveQubesStep):
         )
 
     def on_fail(self) -> None:
-        print("\tWe detected some non-default whonix qubes which made automated risky.")
+        print("\tWe detected some non-default whonix qubes which made automated removal risky.")
         print("")
         print(
             f"\t{BOLD}Action:{RESET} Consider removing Whonix 17, if there is no use-case for it."

--- a/files/sdw-upgrade.py
+++ b/files/sdw-upgrade.py
@@ -101,9 +101,13 @@ class UpgradePrepStep:
         action = self.can_run()
         if action == ActionRecommendation.AUTOMATIC:
             print(f"{LOG_SUB_ACTION}Applying...")
-            self.apply()
-            self.has_ran = True
-            print(f"{LOG_SUB_ACTION}Successfully applied!")
+            try:
+                self.apply()
+                self.has_ran = True
+                print(f"{LOG_SUB_ACTION}Successfully applied!")
+            except subprocess.CalledProcessError:
+                print(f"{LOG_SUB_ACTION}WARNING: Step may be incomplete")
+                self.has_ran = False
         elif action == ActionRecommendation.NOT_NEEDED:
             print(f"{LOG_SUB_ACTION}Step skipped (not needed)...")
             self.has_ran = True
@@ -382,6 +386,7 @@ def prepare_upgrade() -> None:
             print(f"{RED}[MANUAL]{RESET} " f"{BOLD}{ITALIC}{incomplete_step.description}{RESET}")
             incomplete_step.on_fail()
             print("")
+        sys.exit(1)
 
 
 def main() -> None:
@@ -391,11 +396,7 @@ def main() -> None:
     if args.debug:
         logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
-    try:
-        prepare_upgrade()
-    except subprocess.CalledProcessError as e:
-        print(f"Error: {e}")
-        sys.exit(1)
+    prepare_upgrade()
 
 
 if __name__ == "__main__":

--- a/files/sdw-upgrade.py
+++ b/files/sdw-upgrade.py
@@ -174,15 +174,23 @@ class RemoveQubesStep(UpgradePrepStep):
 
             if qube not in impacted_qubes_expected:
                 # early failure: mismatch
-                log.debug(f"Unexpected dependent: {qube.name}")
+                log.warning(f"Unexpected dependent: {qube.name}")
                 return ActionRecommendation.MANUAL
 
             if qube not in visited:
                 visited.append(qube)
                 for holder_qube, prop in qubesadmin.utils.vm_dependencies(app, qube):
-                    if holder_qube is None:
-                        # Global properties don't matter for finding dependencies
-                        continue
+                    if holder_qube is None:  # it's a global property
+                        if qube not in self.qubes_for_removal:
+                            # Fine to keep global properties on dependent qubes
+                            # so long as these are not for removal
+                            continue
+
+                        log.warning(
+                            f"Global property {prop} is set to {qube.name}, "
+                            "which is pending removal"
+                        )
+                        return ActionRecommendation.MANUAL
 
                     queue.append(holder_qube)
 


### PR DESCRIPTION
The script failed to detect when a qube was pending removal.

Fixes https://github.com/freedomofpress/securedrop-workstation/issues/1686

## Test plan

**Preparation:**
  - [x] Be on a Qubes 4.2.4
  - [x] install this branch's RPM + `sdw-admin --apply` (should install fedora-43 template)
  - [x] Ensure you have whonix qubes (if not, please run `sudo qubesctl state.apply qvm.anon-whonix`)
  - [x] Understand that this will remove Whonix and other qubes in the system (please ensure adequate precautions)

**Reproduction instructions:**
  ```bash 
  # Set whonix dvm as default dispvm so it's inherited implicitly
  qubes-prefs default_dispvm whonix-workstation-17-dvm
  
  # Create a qube. Note: we can't put template as whonix-workstation-17
  # because it would have other dependencies in whonix qubes that may
  # trip the early detection, thus not reproducing the issue. 
  qvm-create --label red --template fedora-43-xfce custom-qube
  
  python3 files/sdw-upgrade.py --debug
  ```

**Testing:**

- [x] Run "reproduction instructions"
   - [x] Script presents some action messages, in particular:
     <img width="772" height="96" alt="Screenshot 2026-05-20 at 14-41-56 sdw-upgrade (prep script) extra qube with `default_dispvm` set to whonix dvm not detected · Issue #1686 · freedomofpress_securedrop-workstation" src="https://github.com/user-attachments/assets/3c2030a7-a7d5-469e-8f60-c49dc211acc2" />
   - [x] confirm the other steps either succeeded (and have no action needed) or if they failed, confirm the debug logs.

- [x] Restore qubes removed in previous step
   - Whonix qubes with `sudo qubesctl state.apply qvm.anon-whonix` — should be quick since it failed before the templates got removed 
   - restore other qubes as needed
- [ ] Run "reproduction instructions". You should see the following:
    ```
    Step 3: Remove Whonix 17 entirely
    --> Applying...
        Applying the following changes:
          - anon-whonix (removal)
          - sys-whonix  (removal)
          - whonix-workstation-17-dvm   (removal)
          - whonix-gateway-17   (removal)
          - whonix-workstation-17   (removal)
    VM whonix-workstation-17-dvm cannot be removed. It is in use as:
     - default_dispvm for whoix-custom
    qvm-remove: error: Domain is in use: 'whonix-workstation-17-dvm';see 'journalctl -u qubesd -e' in dom0 for details
    Error: Command '['qvm-remove', '--force', 'anon-whonix', 'whonix-workstation-17-dvm', 'sys-whonix']' returned non-zero exit status 1.
    ```
- [ ] Restore whonix qubes with `sudo qubesctl state.apply qvm.anon-whonix` — should be quick since it failed before the templates got removed 
- [ ] Now cherry-pick just bf0b7e204cb8a7a6e31277ee7710d846f570f6ab on top of main 
- [ ] It should show the same error, but the script doesn't immediately exit. Instead, it shows a failure message for all the failed steps.
- [ ] (optional) Try to break this in other circumstances