### PR TITLE
sdw-admin apply: fix breakage in fedora updates

### DIFF
--- a/securedrop_salt/sd-sys-vms.sls
+++ b/securedrop_salt/sd-sys-vms.sls
@@ -107,14 +107,11 @@ create-{{ required_dispvm }}:
 {% endif %}
 {% if salt['cmd.shell']('qvm-prefs ' + sys_vm + ' template') != sd_supported_fedora_template %}
 sd-{{ sys_vm }}-fedora-version-halt:
-  qvm.kill:
+  qvm.shutdown:
     - name: {{ sys_vm }}
-    - require:
-      - qvm: dom0-install-fedora-template
-
-sd-{{ sys_vm }}-fedora-version-halt-wait:
-  cmd.run:
-    - name: sleep 5
+      flags:
+        - wait
+        - force
     - require:
       - qvm: dom0-install-fedora-template
 
@@ -124,7 +121,7 @@ sd-{{ sys_vm }}-fedora-version-update:
     - prefs:
       - template: {{ sd_supported_fedora_template }}
     - require:
-      - cmd: sd-{{ sys_vm }}-fedora-version-halt-wait
+      - qvm: sd-{{ sys_vm }}-fedora-version-halt
 {% if sd_supported_fedora_template.endswith("-dvm") %}
       - qvm: create-{{ sd_supported_fedora_template }}
 {% endif %}


### PR DESCRIPTION
Updates or clean installs that included a Fedora version bump would fail mid-way on some systems, specifically when running 'sd-sys-vms.sls'. One of the error messages was the following:

>    Start failed: internal error: Unknown PCI header type '127' for device ... see /var/log/libvirt/libxl/libxl-driver.log for details

A restart was needed to work around the issue. Marek identified the problem as likely being a combinations of PCI devices not being properly reset due to a use of qvm-kill instead of qvm-shutdown. This commit replaces the problematic commands.

Fixes #1668

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

NOTE: On hardware where this issue happens (e.g. NovaCustom NV41)

- install SDW 1.6.0 and upgrade to SDW 1.6.1
- it it doesn't fail to start sys-net, all is good.

<details><summary>(I have a little script to test this multiple times, but it needs some tweaks)</summary>

NOTE: the script needs some slight tweaks so it doesn't break when setting up the original environment (i.e. Fedora 43 -> Fedora 42)

```
set -euxo pipefail
qvm-run -p sd-dev "cat securedrop-workstation/securedrop_salt/sd-sys-vms.sls" | sudo tee /srv/salt/securedrop_salt/sd-sys-vms.sls

#make clone-norpm

clear_salt_cache() {
  sudo qubesctl saltutil.clear_cache -l quiet --out quiet > /dev/null || true
  sudo qubesctl saltutil.sync_all refresh=true -l quiet --out quiet > /dev/null || true
  sudo qubesctl top.enable securedrop_salt.sd-workstation > /dev/null ||:
}

for i in {1..5}; do
  echo ""
  echo ">>>>> ITERATION $i <<<<<<"
  echo "reset to normal"
  sudo sed -i 's/43/42/g' /srv/salt/securedrop_salt/sd-sys-vms.sls
  clear_salt_cache
  sudo qubesctl --show-output state.apply securedrop_salt.sd-sys-vms

  echo "Install 1.6.0 (seems to somewhat have impact)"
  echo "Fedora 42 -> 42"
  sudo dnf reinstall -y securedrop-workstation-dom0-config
  sudo qubesctl --show-output state.apply securedrop_salt.sd-sys-vms

  echo "Fedora 42 -> 43"
  qvm-run -p sd-dev "cat securedrop-workstation/securedrop_salt/sd-sys-vms.sls" | sudo tee /srv/salt/securedrop_salt/sd-sys-vms.sls
  clear_salt_cache
  sudo qubesctl --show-output state.apply securedrop_salt.sd-sys-vms
done

</details>




## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
