### PR TITLE
sdw-upgrade: fix whonix-removal

### DIFF
--- a/files/sdw-upgrade.py
+++ b/files/sdw-upgrade.py
@@ -300,7 +300,7 @@ class RemoveWhonix17(RemoveQubesStep):
     WHONIX_17_TEMPLATES = names_to_qubes(["whonix-gateway-17", "whonix-workstation-17"])
     WHONIX_17_DERIVED = names_to_qubes(
         [
-            "anon-whonix",  # order matters (until we can use "qvm-template purge")
+            "anon-whonix",
             "whonix-workstation-17-dvm",
             "sys-whonix",
         ]
@@ -316,12 +316,13 @@ class RemoveWhonix17(RemoveQubesStep):
     def apply(self) -> None:
         self.print_purge_impact(removal_text="removal")
 
-        # "qvm-template purge" is best fit but we run into qubes-issues#10879
+        # NOTE: workaround bug in "qvm-template purge" (qubes-issues#10879)
+        # unsetting netvms because qvm-template can't break netvm dependencies
+        for qube in self.WHONIX_17_DERIVED:
+            qube.netvm = ""  # type: ignore[assignment]
+
         subprocess.run(
-            ["qvm-remove", "--force"] + qubes_to_names(self.WHONIX_17_DERIVED), check=True
-        )
-        subprocess.run(
-            ["qvm-remove", "--force"] + qubes_to_names(self.WHONIX_17_TEMPLATES), check=True
+            ["qvm-template", "purge"] + qubes_to_names(self.WHONIX_17_TEMPLATES), check=True
         )
 
     def on_fail(self) -> None:


### PR DESCRIPTION
Fixes #1692 by using `qvm-template purge` on the whonix templates, but prior to that breaking any netvm dependencies (which are the reason why `qvm-template purge` fails on Whonix (see qubes-issues#10879).

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
- [x] Have Whonix 17 fully installed
- [x] backup both whonix templates so you don't need to re-download them:
  - `qvm-clone whonix-workstation-17 whonix-ws-17-bak`
  - `qvm-clone whonix-gateway-17 whonix-gw-17-bak`
- [x] install SDW RPM
- [x] Run `sdw-upgrade` (:warning: be careful because it may also mess with other stuff, explained in the script when running)
- [x] Confirm whonix is fully removed in qube manager (search "whonix", for example)

Repeat (optional, but recommended in case there was already a partial removal):
- [x] restore 'backups'
    - `qvm-clone whonix-ws-17-bak whonix-workstation-17`
    - `qvm-clone whonix-gw-17-bak whonix-gateway-17` 
- [ ] (re)create whonix qubes: `sudo qubesctl state.apply qvm.anon-whonix`
- [ ] re-reun previous steps 

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
  :warning: we'll need docs changes