### PR TITLE
1.6.1 changelog backport

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,15 @@ This release primarily completes Qubes 4.3 support and takes advantage of the ne
   * Bump actions/download-artifact from 7 to 8 (#1587)
   * Bump actions/create-github-app-token from 2 to 3 (#1614)
 
+## 1.6.1-rc1
+
+This release enables upgrading to Qubes 4.3; please review the migration guide for detailed instructions.
+
+* Switch to Fedora 43 (#1638)
+* Add Qubes 4.3 upgrade prep script (#1653)
+* Internal:
+  * Rename CI jobs and run against 4.3 (#1373)
+
 ## 1.6.0
 
 This release switches to using the [new SecureDrop Inbox](https://securedrop.org/news/securedrop-inbox-is-coming/)

--- a/changelog.md
+++ b/changelog.md
@@ -25,14 +25,14 @@ This release primarily completes Qubes 4.3 support and takes advantage of the ne
   * Bump actions/download-artifact from 7 to 8 (#1587)
   * Bump actions/create-github-app-token from 2 to 3 (#1614)
 
-## 1.6.1-rc1
+## 1.6.1
 
 This release enables upgrading to Qubes 4.3; please review the migration guide for detailed instructions.
 
 * Switch to Fedora 43 (#1638)
-* Add Qubes 4.3 upgrade prep script (#1653)
 * Internal:
   * Rename CI jobs and run against 4.3 (#1373)
+  * Add upgrade prep script draft (#1653)
 
 ## 1.6.0
 

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -225,7 +225,7 @@ fi
 * Mon May 18 2026 SecureDrop Team <securedrop@freedom.press> - 1.8.0rc1
 - See changelog.md
 
-* Thu May 14 2026 SecureDrop Team <securedrop@freedom.press> - 1.6.1rc1
+* Thu May 21 2026 SecureDrop Team <securedrop@freedom.press> - 1.6.1
 - See changelog.md
 
 * Wed May 13 2026 SecureDrop Team <securedrop@freedom.press> - 1.7.0

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -225,6 +225,9 @@ fi
 * Mon May 18 2026 SecureDrop Team <securedrop@freedom.press> - 1.8.0rc1
 - See changelog.md
 
+* Thu May 14 2026 SecureDrop Team <securedrop@freedom.press> - 1.6.1rc1
+- See changelog.md
+
 * Wed May 13 2026 SecureDrop Team <securedrop@freedom.press> - 1.7.0
 - See changelog.md
 

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -222,7 +222,7 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
-* Mon May 18 2026 SecureDrop Team <securedrop@freedom.press> - 1.8.0rc1
+* Wed May 27 2026 SecureDrop Team <securedrop@freedom.press> - 1.8.0rc1
 - See changelog.md
 
 * Thu May 21 2026 SecureDrop Team <securedrop@freedom.press> - 1.6.1


### PR DESCRIPTION
A big of a weid one because 1.6.1 was released after 1.7.0, but I kept the monotonic versioning instead of following the timeline. Hopefully this does not cause issues.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
- [ ] includes full backlog


## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
