### PR TITLE
[1.7.1 backport] Stop installing securedrop-client and hide it

### DIFF
--- a/files/press.freedom.SecureDropUpdaterClient.desktop
+++ b/files/press.freedom.SecureDropUpdaterClient.desktop
@@ -1,7 +1,0 @@
-[Desktop Entry]
-Version=1.0
-Type=Application
-Terminal=false
-Icon=securedrop
-Name=SecureDrop Client (legacy)
-Exec=sdw-updater

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -101,7 +101,6 @@ install -m 755 -d %{buildroot}%{_userunitdir}/
 install -m 755 -d %{buildroot}%{_unitdir}
 install -m 755 -d %{buildroot}%{_userpresetdir}/
 install -m 644 files/press.freedom.SecureDropUpdater.desktop %{buildroot}%{_datadir}/applications/
-install -m 644 files/press.freedom.SecureDropUpdaterClient.desktop %{buildroot}%{_datadir}/applications/
 install -m 644 files/securedrop-128x128.png %{buildroot}%{_datadir}/icons/hicolor/128x128/apps/securedrop.png
 install -m 644 files/securedrop-scalable.svg %{buildroot}%{_datadir}/icons/hicolor/scalable/apps/securedrop.svg
 install -m 755 files/sdw-updater.py %{buildroot}%{_bindir}/sdw-updater
@@ -149,7 +148,6 @@ install -m 644 securedrop_salt/apt-test_freedom_press.sources.j2 %{buildroot}/sr
 %attr(755, root, root) %{_bindir}/sdw-notify
 %attr(755, root, root) %{_bindir}/sdw-updater
 %attr(644, root, root) %{_datadir}/applications/press.freedom.SecureDropUpdater.desktop
-%attr(644, root, root) %{_datadir}/applications/press.freedom.SecureDropUpdaterClient.desktop
 %{python3_sitelib}/sdw_notify/*.py
 %{python3_sitelib}/sdw_updater/*.py
 %{python3_sitelib}/sdw_util/*.py

--- a/securedrop_salt/sd-app-files.sls
+++ b/securedrop_salt/sd-app-files.sls
@@ -16,10 +16,9 @@ include:
 
 # FPF repo is setup in "securedrop-workstation-$sdvars.distribution" template,
 # and then cloned as "sd-small-$sdvars.distribution-template"
-install-securedrop-client-package:
+install-securedrop-app-package:
   pkg.installed:
     - pkgs:
-      - securedrop-client
       - securedrop-app
     - require:
       - sls: securedrop_salt.fpf-apt-repo

--- a/tests/test_vm_sd_app.py
+++ b/tests/test_vm_sd_app.py
@@ -24,9 +24,7 @@ def qube():
             "SD_SUBMISSION_KEY_FPR",
             "SD_MIME_HANDLING",
         },
-        enforced_apparmor_profiles={
-            "/usr/bin/securedrop-client",
-        },
+        enforced_apparmor_profiles=set(),
         mime_types_handling=True,
     )
 
@@ -48,14 +46,10 @@ def test_mailcap_hardened(qube):
 
 
 @pytest.mark.configuration
-def test_sd_client_package_installed(qube):
-    assert qube.package_is_installed("securedrop-client")
-
-
-@pytest.mark.configuration
-def test_sd_client_dependencies_installed(qube):
-    assert qube.package_is_installed("python3-pyqt5")
-    assert qube.package_is_installed("python3-pyqt5.qtsvg")
+def test_sd_app_package_installed(qube: QubeWrapper) -> None:
+    assert qube.package_is_installed("securedrop-app")
+    # And the client has been removed
+    assert not qube.package_is_installed("securedrop-client")
 
 
 @pytest.mark.provisioning


### PR DESCRIPTION
## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
- [ ] backports https://github.com/freedomofpress/securedrop-workstation/pull/1683

(note I haven't had a chance to test this one on 4.3 yet)

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
