### PR TITLE
[1.7.1 backport] sdw-admin apply: fix breakage in fedora updates

### DIFF
--- a/securedrop_salt/sd-sys-vms.sls
+++ b/securedrop_salt/sd-sys-vms.sls
@@ -107,14 +107,11 @@ create-{{ required_dispvm }}:
 {% endif %}
 {% if salt['cmd.shell']('qvm-prefs ' + sys_vm + ' template') != sd_supported_fedora_template %}
 sd-{{ sys_vm }}-fedora-version-halt:
-  qvm.kill:
+  qvm.shutdown:
     - name: {{ sys_vm }}
-    - require:
-      - qvm: dom0-install-fedora-template
-
-sd-{{ sys_vm }}-fedora-version-halt-wait:
-  cmd.run:
-    - name: sleep 5
+      flags:
+        - wait
+        - force
     - require:
       - qvm: dom0-install-fedora-template
 
@@ -124,7 +121,7 @@ sd-{{ sys_vm }}-fedora-version-update:
     - prefs:
       - template: {{ sd_supported_fedora_template }}
     - require:
-      - cmd: sd-{{ sys_vm }}-fedora-version-halt-wait
+      - qvm: sd-{{ sys_vm }}-fedora-version-halt
 {% if sd_supported_fedora_template.endswith("-dvm") %}
       - qvm: create-{{ sd_supported_fedora_template }}
 {% endif %}


### PR DESCRIPTION
## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
- [ ] base branch is `release/1.7.1`
- [ ] backports exactly https://github.com/freedomofpress/securedrop-workstation/pull/1691

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
