### PR TITLE
Update templates to debian 13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ sd-admin: assert-dom0 ## Provision sd-admin VM and install securedrop-admin
 	sudo qubesctl saltutil.sync_all refresh=true
 	@echo "Creating sd-admin template and AppVM..."
 	sudo qubesctl --show-output -- state.sls admin_salt.sd-admin
-	@echo "Installing packages inside sd-admin-trixie-template..."
+	@echo "Installing packages inside sd-admin-debian-13..."
 	sudo qubesctl --show-output --skip-dom0 --targets sd-admin-trixie-template -- state.sls admin_salt.sd-admin-packages
 	qvm-shutdown --wait -- sd-admin-trixie-template
 

--- a/files/sdw-admin.py
+++ b/files/sdw-admin.py
@@ -99,7 +99,7 @@ def provision_and_configure() -> None:
     """
     provision("Provisioning Fedora-based system VMs", "securedrop_salt.sd-sys-vms")
     provision("Provisioning base template", "securedrop_salt.sd-base-template")
-    configure("Configuring base template", ["sd-base-trixie-template"])
+    configure("Configuring base template", ["sd-base-debian-13"])
     provision_all()
     configure(
         "Configure all SecureDrop Workstation VMs with service-specific configs",
@@ -202,13 +202,13 @@ def sync_appmenus() -> None:
     n.b. none of the small VMs are shown in the menu on prod, but nice to have it synced
     """
 
-    run_cmd(["qvm-start", "--skip-if-running", "sd-small-trixie-template"])
-    run_cmd(["qvm-sync-appmenus", "sd-small-trixie-template"])
-    run_cmd(["qvm-shutdown", "sd-small-trixie-template"])
+    run_cmd(["qvm-start", "--skip-if-running", "sd-small-debian-13"])
+    run_cmd(["qvm-sync-appmenus", "sd-small-debian-13"])
+    run_cmd(["qvm-shutdown", "sd-small-debian-13"])
 
-    run_cmd(["qvm-start", "--skip-if-running", "sd-large-trixie-template"])
-    run_cmd(["qvm-sync-appmenus", "sd-large-trixie-template"])
-    run_cmd(["qvm-shutdown", "sd-large-trixie-template"])
+    run_cmd(["qvm-start", "--skip-if-running", "sd-large-debian-13"])
+    run_cmd(["qvm-sync-appmenus", "sd-large-debian-13"])
+    run_cmd(["qvm-shutdown", "sd-large-debian-13"])
 
     # These are the ones we show in prod VMs, so sync explicitly
     run_cmd(["qvm-sync-appmenus", "--regenerate-only", "sd-devices"])

--- a/files/sdw-admin.py
+++ b/files/sdw-admin.py
@@ -24,7 +24,7 @@ DEFAULT_SD_LOG_GB = 5
 
 SCRIPTS_PATH = "/usr/share/securedrop-workstation-dom0-config/"
 SALT_PATH = "/srv/salt/securedrop_salt/"
-BASE_TEMPLATE = "debian-12-minimal"
+BASE_TEMPLATE = "debian-13-minimal"
 
 SUBMISSION_KEY = "sd-journalist.sec"
 TAILS_PATH = "/run/media/user/TailsData/"
@@ -37,7 +37,7 @@ TAILS_GIT_JOURNALIST_INTERFACE_CONFIG = (
 sys.path.insert(1, os.path.join(SCRIPTS_PATH, "scripts/"))
 from validate_config import SDWConfigValidator  # noqa: E402
 
-DEBIAN_VERSION = "bookworm"
+DEBIAN_VERSION = "trixie"
 
 
 def parse_args() -> argparse.Namespace:
@@ -99,7 +99,7 @@ def provision_and_configure() -> None:
     """
     provision("Provisioning Fedora-based system VMs", "securedrop_salt.sd-sys-vms")
     provision("Provisioning base template", "securedrop_salt.sd-base-template")
-    configure("Configuring base template", ["sd-base-bookworm-template"])
+    configure("Configuring base template", ["sd-base-trixie-template"])
     provision_all()
     configure(
         "Configure all SecureDrop Workstation VMs with service-specific configs",
@@ -202,13 +202,13 @@ def sync_appmenus() -> None:
     n.b. none of the small VMs are shown in the menu on prod, but nice to have it synced
     """
 
-    run_cmd(["qvm-start", "--skip-if-running", "sd-small-bookworm-template"])
-    run_cmd(["qvm-sync-appmenus", "sd-small-bookworm-template"])
-    run_cmd(["qvm-shutdown", "sd-small-bookworm-template"])
+    run_cmd(["qvm-start", "--skip-if-running", "sd-small-trixie-template"])
+    run_cmd(["qvm-sync-appmenus", "sd-small-trixie-template"])
+    run_cmd(["qvm-shutdown", "sd-small-trixie-template"])
 
-    run_cmd(["qvm-start", "--skip-if-running", "sd-large-bookworm-template"])
-    run_cmd(["qvm-sync-appmenus", "sd-large-bookworm-template"])
-    run_cmd(["qvm-shutdown", "sd-large-bookworm-template"])
+    run_cmd(["qvm-start", "--skip-if-running", "sd-large-trixie-template"])
+    run_cmd(["qvm-sync-appmenus", "sd-large-trixie-template"])
+    run_cmd(["qvm-shutdown", "sd-large-trixie-template"])
 
     # These are the ones we show in prod VMs, so sync explicitly
     run_cmd(["qvm-sync-appmenus", "--regenerate-only", "sd-devices"])

--- a/launcher/tests/test_updater.py
+++ b/launcher/tests/test_updater.py
@@ -21,7 +21,7 @@ debian_based_vms = [
 ]
 
 WHONIX_VERSION = 17
-DEBIAN_VERSION = "bookworm"
+DEBIAN_VERSION = "trixie"
 
 TEST_RESULTS_OK = {
     "dom0": UpdateStatus.UPDATES_OK,

--- a/launcher/tests/test_updater.py
+++ b/launcher/tests/test_updater.py
@@ -21,7 +21,6 @@ debian_based_vms = [
 ]
 
 WHONIX_VERSION = 17
-DEBIAN_VERSION = "trixie"
 
 TEST_RESULTS_OK = {
     "dom0": UpdateStatus.UPDATES_OK,

--- a/launcher/tests/test_util.py
+++ b/launcher/tests/test_util.py
@@ -19,7 +19,7 @@ CONFLICTING_PROCESS_REGEX = r"Conflicting process .* is currently running."
 # Fixtures (sample files) for certain tests
 FIXTURES_PATH = Path(__file__).parent / "fixtures"
 
-DEBIAN_VERSION = "bookworm"
+DEBIAN_VERSION = "trixie"
 WHONIX_VERSION = 17
 
 

--- a/launcher/tests/test_util.py
+++ b/launcher/tests/test_util.py
@@ -19,7 +19,7 @@ CONFLICTING_PROCESS_REGEX = r"Conflicting process .* is currently running."
 # Fixtures (sample files) for certain tests
 FIXTURES_PATH = Path(__file__).parent / "fixtures"
 
-DEBIAN_VERSION = "trixie"
+DEBIAN_VERSION = 13
 WHONIX_VERSION = 17
 
 
@@ -252,7 +252,7 @@ def test_is_sdapp_halted_yes(os_release_fixture, version_contains):
     """
     output = bytes(
         "NAME     STATE     CLASS     LABEL     TEMPLATE\nsd-app"
-        f"    Halted    AppVM   yellow     sd-small-{DEBIAN_VERSION}-template\n",
+        f"    Halted    AppVM   yellow     sd-small-debian-{DEBIAN_VERSION}\n",
         "utf-8",
     )
 
@@ -277,7 +277,7 @@ def test_is_sdapp_halted_no(os_release_fixture, version_contains):
     """
     output = bytes(
         "NAME     STATE     CLASS     LABEL     TEMPLATE\nsd-app"
-        f"    Paused    AppVM   yellow     sd-small-{DEBIAN_VERSION}-template\n",
+        f"    Paused    AppVM   yellow     sd-small-debian-{DEBIAN_VERSION}\n",
         "utf-8",
     )
 

--- a/scripts/switch-apt-source.py
+++ b/scripts/switch-apt-source.py
@@ -22,8 +22,8 @@ SOURCES_DIR = Path(__file__).parent.parent / "securedrop_salt"
 OPTIONS = ["dev", "staging", "prod"]
 CODENAME = "trixie"
 TEMPLATES = [
-    "sd-small-trixie-template",
-    "sd-large-trixie-template",
+    "sd-small-debian-13",
+    "sd-large-debian-13",
 ]
 TEST_COMPONENTS = {
     "dev": "main nightlies",

--- a/scripts/switch-apt-source.py
+++ b/scripts/switch-apt-source.py
@@ -20,10 +20,10 @@ CONFIG_JSON = Path("/usr/share/securedrop-workstation-dom0-config/config.json")
 SOURCES_DIR = Path(__file__).parent.parent / "securedrop_salt"
 
 OPTIONS = ["dev", "staging", "prod"]
-CODENAME = "bookworm"
+CODENAME = "trixie"
 TEMPLATES = [
-    "sd-small-bookworm-template",
-    "sd-large-bookworm-template",
+    "sd-small-trixie-template",
+    "sd-large-trixie-template",
 ]
 TEST_COMPONENTS = {
     "dev": "main nightlies",

--- a/scripts/try-client-pr.py
+++ b/scripts/try-client-pr.py
@@ -8,8 +8,8 @@ import tempfile
 from pathlib import Path
 
 BUILD_VM = os.environ.get("SECUREDROP_DEV_VM", "sd-dev")
-SMALL_TEMPLATE = "sd-small-bookworm-template"
-LARGE_TEMPLATE = "sd-large-bookworm-template"
+SMALL_TEMPLATE = "sd-small-trixie-template"
+LARGE_TEMPLATE = "sd-large-trixie-template"
 
 
 def run_in_vm(command: list[str], vmname: str, capture_output: bool = False) -> str | None:

--- a/scripts/try-client-pr.py
+++ b/scripts/try-client-pr.py
@@ -8,8 +8,8 @@ import tempfile
 from pathlib import Path
 
 BUILD_VM = os.environ.get("SECUREDROP_DEV_VM", "sd-dev")
-SMALL_TEMPLATE = "sd-small-trixie-template"
-LARGE_TEMPLATE = "sd-large-trixie-template"
+SMALL_TEMPLATE = "sd-small-debian-13"
+LARGE_TEMPLATE = "sd-large-debian-13"
 
 
 def run_in_vm(command: list[str], vmname: str, capture_output: bool = False) -> str | None:

--- a/sdw_updater/Updater.py
+++ b/sdw_updater/Updater.py
@@ -40,7 +40,7 @@ detail_log = Util.get_logger(prefix=DETAIL_LOGGER_PREFIX, module=__name__)
 
 
 def _get_current_vms() -> dict[str, str]:
-    debian_version = "bookworm"
+    debian_version = "trixie"
 
     # The are the TemplateVMs that require full patch level at boot in order to start the inbox,
     # as well as their associated TemplateVMs.

--- a/sdw_updater/Updater.py
+++ b/sdw_updater/Updater.py
@@ -40,20 +40,20 @@ detail_log = Util.get_logger(prefix=DETAIL_LOGGER_PREFIX, module=__name__)
 
 
 def _get_current_vms() -> dict[str, str]:
-    debian_version = "trixie"
+    debian_version = "13"
 
     # The are the TemplateVMs that require full patch level at boot in order to start the inbox,
     # as well as their associated TemplateVMs.
     # In the future, we could use qvm-prefs to extract this information.
     return {
         "fedora": "fedora-43-xfce",
-        "sd-viewer": f"sd-large-{debian_version}-template",
-        "sd-app": f"sd-small-{debian_version}-template",
-        "sd-log": f"sd-small-{debian_version}-template",
-        "sd-devices": f"sd-large-{debian_version}-template",
-        "sd-printers": f"sd-large-{debian_version}-template",
-        "sd-proxy": f"sd-small-{debian_version}-template",
-        "sd-gpg": f"sd-small-{debian_version}-template",
+        "sd-viewer": f"sd-large-debian-{debian_version}",
+        "sd-app": f"sd-small-debian-{debian_version}",
+        "sd-log": f"sd-small-debian-{debian_version}",
+        "sd-devices": f"sd-large-debian-{debian_version}",
+        "sd-printers": f"sd-large-debian-{debian_version}",
+        "sd-proxy": f"sd-small-debian-{debian_version}",
+        "sd-gpg": f"sd-small-debian-{debian_version}",
     }
 
 

--- a/securedrop_salt/sd-app-files.sls
+++ b/securedrop_salt/sd-app-files.sls
@@ -5,15 +5,15 @@
 # sd-app-files
 # ========
 #
-# Moves files into place on sd-small-$sdvars.distribution-template
+# Moves files into place on sd-small-debian-$sdvars.debian_version
 #
 ##
 include:
   - securedrop_salt.fpf-apt-repo
   - securedrop_salt.sd-logging-setup
 
-# FPF repo is setup in "securedrop-workstation-$sdvars.distribution" template,
-# and then cloned as "sd-small-$sdvars.distribution-template"
+# FPF repo is setup in base template, and then cloned as
+# "sd-small-debian-$sdvars.debian_version"
 install-securedrop-app-package:
   pkg.installed:
     - pkgs:

--- a/securedrop_salt/sd-app.sls
+++ b/securedrop_salt/sd-app.sls
@@ -25,9 +25,9 @@ sd-app:
       # Label color is set during initial configuration but
       # not enforced on every Salt run, in case of user customization.
       - label: yellow
-      - template: sd-small-{{ sdvars.distribution }}-template
+      - template: sd-small-debian-{{ sdvars.debian_version }}
     - prefs:
-      - template: sd-small-{{ sdvars.distribution }}-template
+      - template: sd-small-debian-{{ sdvars.debian_version }}
       - netvm: ""
       - default_dispvm: "sd-viewer"
       {% if grains['osrelease'] != '4.2' %}
@@ -45,7 +45,7 @@ sd-app:
         - service.paxctld
         - service.securedrop-mime-handling
     - require:
-      - qvm: sd-small-{{ sdvars.distribution }}-template
+      - qvm: sd-small-debian-{{ sdvars.debian_version }}
       - sls: securedrop_salt.sd-viewer
 
 {% if grains['osrelease'] != '4.2' %}

--- a/securedrop_salt/sd-base-template.sls
+++ b/securedrop_salt/sd-base-template.sls
@@ -12,7 +12,7 @@ dom0-install-debian-minimal-template:
 # Clones a base templateVM from debian-13-minimal
 sd-base-template:
   qvm.vm:
-    - name: sd-base-{{ sdvars.distribution }}-template
+    - name: sd-base-debian-{{ sdvars.debian_version }}
     - clone:
       - source: debian-13-minimal
       - label: red

--- a/securedrop_salt/sd-base-template.sls
+++ b/securedrop_salt/sd-base-template.sls
@@ -4,17 +4,17 @@
 # Imports "sdvars" for environment config
 {% from 'securedrop_salt/sd-default-config.sls' import sdvars with context %}
 
-# Ensure debian-12-minimal is present for use as base template
+# Ensure debian-13-minimal is present for use as base template
 dom0-install-debian-minimal-template:
   qvm.template_installed:
-    - name: debian-12-minimal
+    - name: debian-13-minimal
 
-# Clones a base templateVM from debian-12-minimal
+# Clones a base templateVM from debian-13-minimal
 sd-base-template:
   qvm.vm:
     - name: sd-base-{{ sdvars.distribution }}-template
     - clone:
-      - source: debian-12-minimal
+      - source: debian-13-minimal
       - label: red
     - prefs:
       - default_dispvm: ""

--- a/securedrop_salt/sd-default-config.sls
+++ b/securedrop_salt/sd-default-config.sls
@@ -31,4 +31,4 @@
 {% endif %}
 
 # Append repo URL with appropriate distribution
-{% set _ = sdvars.update({"distribution": "bookworm"}) %}
+{% set _ = sdvars.update({"distribution": "trixie"}) %}

--- a/securedrop_salt/sd-default-config.sls
+++ b/securedrop_salt/sd-default-config.sls
@@ -31,4 +31,4 @@
 {% endif %}
 
 # Append repo URL with appropriate distribution
-{% set _ = sdvars.update({"distribution": "trixie"}) %}
+{% set _ = sdvars.update({"distribution": "trixie", "debian_version": "13"}) %}

--- a/securedrop_salt/sd-devices.sls
+++ b/securedrop_salt/sd-devices.sls
@@ -21,9 +21,9 @@ sd-devices-dvm:
       # Label color is set during initial configuration but
       # not enforced on every Salt run, in case of user customization.
       - label: red
-      - template: sd-large-{{ sdvars.distribution }}-template
+      - template: sd-large-debian-{{ sdvars.debian_version }}
     - prefs:
-      - template: sd-large-{{ sdvars.distribution }}-template
+      - template: sd-large-debian-{{ sdvars.debian_version }}
       - netvm: ""
       - template_for_dispvms: True
       - default_dispvm: ""
@@ -41,7 +41,7 @@ sd-devices-dvm:
       - default:  # Explictly remove (it had been enabled in past)
         - service.cups
     - require:
-      - qvm: sd-large-{{ sdvars.distribution }}-template
+      - qvm: sd-large-debian-{{ sdvars.debian_version }}
 
 sd-devices-create-named-dispvm:
   qvm.vm:

--- a/securedrop_salt/sd-gpg.sls
+++ b/securedrop_salt/sd-gpg.sls
@@ -28,9 +28,9 @@ sd-gpg:
       # Label color is set during initial configuration but
       # not enforced on every Salt run, in case of user customization.
       - label: purple
-      - template: sd-small-{{ sdvars.distribution }}-template
+      - template: sd-small-debian-{{ sdvars.debian_version }}
     - prefs:
-      - template: sd-small-{{ sdvars.distribution }}-template
+      - template: sd-small-debian-{{ sdvars.debian_version }}
       - netvm: ""
       - autostart: true
       - default_dispvm: ""

--- a/securedrop_salt/sd-log.sls
+++ b/securedrop_salt/sd-log.sls
@@ -51,9 +51,9 @@ install-sd-log:
       # Label color is set during initial configuration but
       # not enforced on every Salt run, in case of user customization.
       - label: red
-      - template: sd-small-{{ sdvars.distribution }}-template
+      - template: sd-small-debian-{{ sdvars.debian_version }}
     - prefs:
-      - template: sd-small-{{ sdvars.distribution }}-template
+      - template: sd-small-debian-{{ sdvars.debian_version }}
       - netvm: ""
       - autostart: true
       - default_dispvm: ""
@@ -73,7 +73,7 @@ install-sd-log:
         - sd-install-epoch: {{ sdlog_epoch }}
         - menu-items: "org.gnome.Nautilus.desktop"
     - require:
-      - qvm: sd-small-{{ sdvars.distribution }}-template
+      - qvm: sd-small-debian-{{ sdvars.debian_version }}
 
 {% if grains['osrelease'] != '4.2' %}
 sd-log-custom-persist:

--- a/securedrop_salt/sd-logging-setup.sls
+++ b/securedrop_salt/sd-logging-setup.sls
@@ -2,7 +2,7 @@
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 
 # TODO: parametrise this
-{% if grains['id'] in ["sd-small-trixie-template", "sd-large-trixie-template"] %}
+{% if grains['id'] in ["sd-small-debian-13", "sd-large-debian-13"] %}
 include:
   - securedrop_salt.fpf-apt-repo
 
@@ -16,7 +16,7 @@ install-securedrop-log-package:
 
 {% endif %}
 
-{% if grains['id'] == "sd-small-{}-template".format(grains['oscodename']) %}
+{% if grains['id'] == "sd-small-debian-{}".format(grains['osrelease']) %}
 install-redis-for-sd-log-template:
   pkg.installed:
     - pkgs:

--- a/securedrop_salt/sd-logging-setup.sls
+++ b/securedrop_salt/sd-logging-setup.sls
@@ -2,7 +2,7 @@
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 
 # TODO: parametrise this
-{% if grains['id'] in ["sd-small-bookworm-template", "sd-large-bookworm-template"] %}
+{% if grains['id'] in ["sd-small-trixie-template", "sd-large-trixie-template"] %}
 include:
   - securedrop_salt.fpf-apt-repo
 

--- a/securedrop_salt/sd-proxy.sls
+++ b/securedrop_salt/sd-proxy.sls
@@ -22,9 +22,9 @@ sd-proxy-dvm:
       # Label color is set during initial configuration but
       # not enforced on every Salt run, in case of user customization.
       - label: blue
-      - template: sd-small-{{ sdvars.distribution }}-template
+      - template: sd-small-debian-{{ sdvars.debian_version }}
     - prefs:
-      - template: sd-small-{{ sdvars.distribution }}-template
+      - template: sd-small-debian-{{ sdvars.debian_version }}
       - netvm: sys-firewall
       - template_for_dispvms: True
       - default_dispvm: ""
@@ -43,7 +43,7 @@ sd-proxy-dvm:
         - sd-workstation
         - sd-{{ sdvars.distribution }}
     - require:
-      - qvm: sd-small-{{ sdvars.distribution }}-template
+      - qvm: sd-small-debian-{{ sdvars.debian_version }}
 
 sd-proxy-create-named-dispvm:
   qvm.vm:

--- a/securedrop_salt/sd-viewer.sls
+++ b/securedrop_salt/sd-viewer.sls
@@ -29,9 +29,9 @@ sd-viewer:
       # Label color is set during initial configuration but
       # not enforced on every Salt run, in case of user customization.
       - label: green
-      - template: sd-large-{{ sdvars.distribution }}-template
+      - template: sd-large-debian-{{ sdvars.debian_version }}
     - prefs:
-      - template: sd-large-{{ sdvars.distribution }}-template
+      - template: sd-large-debian-{{ sdvars.debian_version }}
       - netvm: ""
       - template_for_dispvms: True
       - default_dispvm: ""
@@ -55,7 +55,7 @@ sd-viewer:
         - service.paxctld
         - service.securedrop-mime-handling
     - require:
-      - qvm: sd-large-{{ sdvars.distribution }}-template
+      - qvm: sd-large-debian-{{ sdvars.debian_version }}
 
 
 # Set sd-viewer as the global default_dispvm

--- a/securedrop_salt/sd-workstation-template.sls
+++ b/securedrop_salt/sd-workstation-template.sls
@@ -9,15 +9,15 @@ include:
 
 # Installs consolidated templateVMs:
 # Sets virt_mode and kernel to use custom hardened kernel.
-# - sd-small-{{ sdvars.distribution }}-template, to be used for
+# - sd-small-debian-{{ sdvars.debian_version }}, to be used for
 #   sd-app, sd-gpg, sd-log, and sd-proxy
-# - sd-large-{{ sdvars.distribution }}-template, to be used for
+# - sd-large-debian-{{ sdvars.debian_version }}, to be used for
 #   sd-export and sd-viewer
-sd-small-{{ sdvars.distribution }}-template:
+sd-small-debian-{{ sdvars.debian_version }}:
   qvm.vm:
-    - name: sd-small-{{ sdvars.distribution }}-template
+    - name: sd-small-debian-{{ sdvars.debian_version }}
     - clone:
-      - source: sd-base-{{ sdvars.distribution }}-template
+      - source: sd-base-debian-{{ sdvars.debian_version }}
       - label: red
     - prefs:
       - virt-mode: pvh
@@ -36,11 +36,11 @@ sd-small-{{ sdvars.distribution }}-template:
     - require:
       - sls: securedrop_salt.sd-base-template
 
-sd-large-{{ sdvars.distribution }}-template:
+sd-large-debian-{{ sdvars.debian_version }}:
   qvm.vm:
-    - name: sd-large-{{ sdvars.distribution }}-template
+    - name: sd-large-debian-{{ sdvars.debian_version }}
     - clone:
-      - source: sd-base-{{ sdvars.distribution }}-template
+      - source: sd-base-debian-{{ sdvars.debian_version }}
       - label: red
     - prefs:
       - virt-mode: pvh

--- a/securedrop_salt/sd-workstation-template.sls
+++ b/securedrop_salt/sd-workstation-template.sls
@@ -8,18 +8,14 @@ include:
   - securedrop_salt.sd-base-template
 
 # Installs consolidated templateVMs:
-# Sets virt_mode and kernel to use custom hardened kernel.
-# - sd-small-debian-{{ sdvars.debian_version }}, to be used for
-#   sd-app, sd-gpg, sd-log, and sd-proxy
-# - sd-large-debian-{{ sdvars.debian_version }}, to be used for
-#   sd-export and sd-viewer
-sd-small-debian-{{ sdvars.debian_version }}:
+{% for template_prefix in ["sd-small", "sd-large"] %}
+{{template_prefix}}-debian-{{ sdvars.debian_version }}:
   qvm.vm:
-    - name: sd-small-debian-{{ sdvars.debian_version }}
     - clone:
       - source: sd-base-debian-{{ sdvars.debian_version }}
       - label: red
     - prefs:
+      # Sets virt_mode and kernel to use custom hardened kernel.
       - virt-mode: pvh
       - kernel: 'pvgrub2-pvh'
       - default_dispvm: ""
@@ -35,26 +31,4 @@ sd-small-debian-{{ sdvars.debian_version }}:
         - service.paxctld
     - require:
       - sls: securedrop_salt.sd-base-template
-
-sd-large-debian-{{ sdvars.debian_version }}:
-  qvm.vm:
-    - name: sd-large-debian-{{ sdvars.debian_version }}
-    - clone:
-      - source: sd-base-debian-{{ sdvars.debian_version }}
-      - label: red
-    - prefs:
-      - virt-mode: pvh
-      - kernel: 'pvgrub2-pvh'
-      - default_dispvm: ""
-      {% if grains['osrelease'] != '4.2' %}
-      - devices_denied: '*******'
-      {% endif %}
-    - tags:
-      - add:
-        - sd-workstation
-        - sd-{{ sdvars.distribution }}
-    - features:
-      - enable:
-        - service.paxctld
-    - require:
-      - sls: securedrop_salt.sd-base-template
+{% endfor %}

--- a/securedrop_salt/sd-workstation.top
+++ b/securedrop_salt/sd-workstation.top
@@ -25,14 +25,14 @@ base:
     - securedrop_salt.sd-reset-whonix-prefs
     {% endif %}
 
-  sd-base-trixie-template:
+  sd-base-debian-13:
     - securedrop_salt.sd-base-template-packages
-  sd-small-trixie-template:
+  sd-small-debian-13:
     - securedrop_salt.sd-logging-setup
     - securedrop_salt.sd-app-files
     - securedrop_salt.sd-proxy-template-files
     - securedrop_salt.sd-gpg-template-files
-  sd-large-trixie-template:
+  sd-large-debian-13:
     - securedrop_salt.sd-logging-setup
     - securedrop_salt.sd-devices-files
     - securedrop_salt.sd-viewer-files

--- a/securedrop_salt/sd-workstation.top
+++ b/securedrop_salt/sd-workstation.top
@@ -25,14 +25,14 @@ base:
     - securedrop_salt.sd-reset-whonix-prefs
     {% endif %}
 
-  sd-base-bookworm-template:
+  sd-base-trixie-template:
     - securedrop_salt.sd-base-template-packages
-  sd-small-bookworm-template:
+  sd-small-trixie-template:
     - securedrop_salt.sd-logging-setup
     - securedrop_salt.sd-app-files
     - securedrop_salt.sd-proxy-template-files
     - securedrop_salt.sd-gpg-template-files
-  sd-large-bookworm-template:
+  sd-large-trixie-template:
     - securedrop_salt.sd-logging-setup
     - securedrop_salt.sd-devices-files
     - securedrop_salt.sd-viewer-files

--- a/securedrop_salt/securedrop-handle-upgrade
+++ b/securedrop_salt/securedrop-handle-upgrade
@@ -23,7 +23,7 @@ if [[ $TASK == "prepare" ]]; then
     # sd-app, we simply shutdown the machine as we want to preserve the data
     if qvm-check sd-app --quiet; then
         BASE_TEMPLATE=$(qvm-prefs sd-app template)
-        if [[ ! $BASE_TEMPLATE =~ "small-bookworm" ]]; then
+        if [[ ! $BASE_TEMPLATE =~ "small-trixie" ]]; then
             shutdown_if_running "sd-app"
         fi
     fi
@@ -36,7 +36,7 @@ if [[ $TASK == "prepare" ]]; then
     # provisioning process runs again and sets that value to sd-viewer
     if qvm-check --quiet sd-viewer; then
         BASE_TEMPLATE=$(qvm-prefs sd-viewer template)
-        if [[ ! $BASE_TEMPLATE =~ "large-bookworm" ]]; then
+        if [[ ! $BASE_TEMPLATE =~ "large-trixie" ]]; then
             qubes-prefs default_dispvm ''
             shutdown_if_running "sd-viewer"
             qvm-remove -f sd-viewer
@@ -45,7 +45,7 @@ if [[ $TASK == "prepare" ]]; then
 
     if qvm-check --quiet sd-devices; then
         BASE_TEMPLATE=$(qvm-prefs sd-devices-dvm template)
-        if [[ ! $BASE_TEMPLATE =~ "large-bookworm" ]]; then
+        if [[ ! $BASE_TEMPLATE =~ "large-trixie" ]]; then
             shutdown_if_running "sd-printers"
             shutdown_if_running "sd-devices"
             shutdown_if_running "sd-devices-dvm"
@@ -57,7 +57,7 @@ if [[ $TASK == "prepare" ]]; then
 
     if qvm-check --quiet sd-proxy-dvm; then
         BASE_TEMPLATE=$(qvm-prefs sd-proxy-dvm template)
-        if [[ ! $BASE_TEMPLATE =~ "large-bookworm" ]]; then
+        if [[ ! $BASE_TEMPLATE =~ "large-trixie" ]]; then
             shutdown_if_running "sd-proxy"
         fi
     fi
@@ -65,7 +65,7 @@ if [[ $TASK == "prepare" ]]; then
     # For sd-gpg, we simply shutdown the machine
     if qvm-check --quiet sd-gpg; then
         BASE_TEMPLATE=$(qvm-prefs sd-gpg template)
-        if [[ ! $BASE_TEMPLATE =~ "small-bookworm" ]]; then
+        if [[ ! $BASE_TEMPLATE =~ "small-trixie" ]]; then
             shutdown_if_running "sd-gpg"
         fi
     fi
@@ -73,7 +73,7 @@ if [[ $TASK == "prepare" ]]; then
     # Shut down sd-log last, since other VMs will autostart it by sending logs
     if qvm-check --quiet sd-log; then
         BASE_TEMPLATE=$(qvm-prefs sd-log template)
-        if [[ ! $BASE_TEMPLATE =~ "small-bookworm" ]]; then
+        if [[ ! $BASE_TEMPLATE =~ "small-trixie" ]]; then
             shutdown_if_running "sd-log"
         fi
     fi
@@ -82,7 +82,7 @@ elif [[ $TASK == "remove" ]]; then
     # before deleting it.
     # TODO: clean this up, we don't have separate templates anymore and nobody
     # will be upgrading from the original setup
-    for template in sd-small-bullseye-template sd-large-bullseye-template
+    for template in sd-small-bookworm-template sd-large-bookworm-template
     do
         if qvm-check "${template}" --quiet; then
             shutdown_if_running "${template}"

--- a/securedrop_salt/securedrop-handle-upgrade
+++ b/securedrop_salt/securedrop-handle-upgrade
@@ -38,6 +38,7 @@ if [[ $TASK == "prepare" ]]; then
         BASE_TEMPLATE=$(qvm-prefs sd-viewer template)
         if [[ ! $BASE_TEMPLATE =~ "debian-13" ]]; then
             qubes-prefs default_dispvm ''
+            qvm-prefs sd-app default_dispvm ''
             shutdown_if_running "sd-viewer"
             qvm-remove -f sd-viewer
         fi

--- a/securedrop_salt/securedrop-handle-upgrade
+++ b/securedrop_salt/securedrop-handle-upgrade
@@ -23,7 +23,7 @@ if [[ $TASK == "prepare" ]]; then
     # sd-app, we simply shutdown the machine as we want to preserve the data
     if qvm-check sd-app --quiet; then
         BASE_TEMPLATE=$(qvm-prefs sd-app template)
-        if [[ ! $BASE_TEMPLATE =~ "small-trixie" ]]; then
+        if [[ ! $BASE_TEMPLATE =~ "debian-13" ]]; then
             shutdown_if_running "sd-app"
         fi
     fi
@@ -36,7 +36,7 @@ if [[ $TASK == "prepare" ]]; then
     # provisioning process runs again and sets that value to sd-viewer
     if qvm-check --quiet sd-viewer; then
         BASE_TEMPLATE=$(qvm-prefs sd-viewer template)
-        if [[ ! $BASE_TEMPLATE =~ "large-trixie" ]]; then
+        if [[ ! $BASE_TEMPLATE =~ "debian-13" ]]; then
             qubes-prefs default_dispvm ''
             shutdown_if_running "sd-viewer"
             qvm-remove -f sd-viewer
@@ -45,7 +45,7 @@ if [[ $TASK == "prepare" ]]; then
 
     if qvm-check --quiet sd-devices; then
         BASE_TEMPLATE=$(qvm-prefs sd-devices-dvm template)
-        if [[ ! $BASE_TEMPLATE =~ "large-trixie" ]]; then
+        if [[ ! $BASE_TEMPLATE =~ "debian-13" ]]; then
             shutdown_if_running "sd-printers"
             shutdown_if_running "sd-devices"
             shutdown_if_running "sd-devices-dvm"
@@ -57,7 +57,7 @@ if [[ $TASK == "prepare" ]]; then
 
     if qvm-check --quiet sd-proxy-dvm; then
         BASE_TEMPLATE=$(qvm-prefs sd-proxy-dvm template)
-        if [[ ! $BASE_TEMPLATE =~ "large-trixie" ]]; then
+        if [[ ! $BASE_TEMPLATE =~ "debian-13" ]]; then
             shutdown_if_running "sd-proxy"
         fi
     fi

--- a/tests/base.py
+++ b/tests/base.py
@@ -176,8 +176,8 @@ class QubeWrapper:
         try:
             results = self.run(f"sudo systemctl is-active {service}")
         except subprocess.CalledProcessError as e:
-            if e.returncode == 3:
-                return False  # exit code 3 == inactive
+            if e.returncode in (3, 4):
+                return False  # exit code 3 == inactive, 4 == missing unit (so it's not running)
             else:
                 raise e
         return results == "active"

--- a/tests/base.py
+++ b/tests/base.py
@@ -15,10 +15,11 @@ from qubesadmin import Qubes
 from qubesadmin.vm import QubesVM
 
 # Reusable constant for DRY import across tests
-DEBIAN_VERSION = "trixie"
-SD_TEMPLATE_BASE = f"sd-base-{DEBIAN_VERSION}-template"
-SD_TEMPLATE_LARGE = f"sd-large-{DEBIAN_VERSION}-template"
-SD_TEMPLATE_SMALL = f"sd-small-{DEBIAN_VERSION}-template"
+DEBIAN_VERSION = 13
+DEBIAN_CODENAME = "trixie"
+SD_TEMPLATE_BASE = f"sd-base-debian-{DEBIAN_VERSION}"
+SD_TEMPLATE_LARGE = f"sd-large-debian-{DEBIAN_VERSION}"
+SD_TEMPLATE_SMALL = f"sd-small-debian-{DEBIAN_VERSION}"
 
 SD_TAG = "sd-workstation"  # Tag identifying SecureDrop Workstation-managed VMs
 
@@ -329,7 +330,7 @@ class Test_SD_VM_Common:
         """
         Asserts that the given AppVM is based on an OS listed in the
         SUPPORTED_<XX>_PLATFORMS list, as specified in tests.
-        All workstation-provisioned VMs should be based on DEBIAN_VERSION.
+        All workstation-provisioned VMs should be based on DEBIAN_CODENAME.
         """
 
         if qube.name.startswith("sys-"):
@@ -340,7 +341,7 @@ class Test_SD_VM_Common:
         if not search:
             raise RuntimeError(f"Unable to determine platform for {qube.name}")
         platform = search.group(1)
-        assert DEBIAN_VERSION in platform
+        assert DEBIAN_CODENAME in platform
 
     @pytest.mark.mime
     @pytest.mark.slow

--- a/tests/base.py
+++ b/tests/base.py
@@ -15,7 +15,7 @@ from qubesadmin import Qubes
 from qubesadmin.vm import QubesVM
 
 # Reusable constant for DRY import across tests
-DEBIAN_VERSION = "bookworm"
+DEBIAN_VERSION = "trixie"
 SD_TEMPLATE_BASE = f"sd-base-{DEBIAN_VERSION}-template"
 SD_TEMPLATE_LARGE = f"sd-large-{DEBIAN_VERSION}-template"
 SD_TEMPLATE_SMALL = f"sd-small-{DEBIAN_VERSION}-template"

--- a/tests/test_vm_sd_log.py
+++ b/tests/test_vm_sd_log.py
@@ -71,7 +71,7 @@ def test_logs_are_flowing(qube: QubeWrapper, sdw_tagged_vms: list[QubesVM]) -> N
 
     # base template doesn't have sd-log configured
     # TODO: test a sd-viewer based dispVM
-    skip = [f"sd-base-{DEBIAN_VERSION}-template", "sd-viewer"]
+    skip = [f"sd-base-debian-{DEBIAN_VERSION}", "sd-viewer"]
     # VMs we expect logs will not go to
     no_log_vms = ["sd-gpg", "sd-log"]
 

--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -9,7 +9,7 @@ from qubesadmin.vm import QubesVM
 from sdw_util.config_types import Dom0Config
 from tests.base import (
     CURRENT_FEDORA_TEMPLATE,
-    DEBIAN_VERSION,
+    DEBIAN_CODENAME,
     SD_TEMPLATE_LARGE,
     SD_TEMPLATE_SMALL,
     SD_VMS,
@@ -230,4 +230,4 @@ def assert_apt_source(vm: QubesVM, component: str, url: str, filename: str) -> N
 
     assert f"Components: {component}\n" in contents, f"{vm.name} wrong component"
     assert f"URIs: {url}\n" in contents, f"{vm.name} wrong URL"
-    assert f"Suites: {DEBIAN_VERSION}\n" in contents, f"{vm.name} wrong suite/codename"
+    assert f"Suites: {DEBIAN_CODENAME}\n" in contents, f"{vm.name} wrong suite/codename"


### PR DESCRIPTION
Fixes #1712. Blocked on trixie packages: https://github.com/freedomofpress/securedrop-client/issues/3461

Implementation decisions (open to discussion):
- **Kept debian-minimal template**: sd-admin uses debian-13, should we base both on the same?
- **Kept base template**: Originally mentioned in https://github.com/freedomofpress/securedrop-workstation/issues/1712#issuecomment-4615225178, it turns out there is another difference for having the base template: enabling custom kernel via provisioning, can only be done after the kernel package is installed inside the qube.
- **Kept the current names**, but also happy to use the opportunity to change them to something more descriptive (https://github.com/freedomofpress/securedrop-workstation/issues/1722)
 
## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
   :warning: this one requires docs edits. I see some `bookworm-template` references