### PR TITLE
Remove client classic references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,18 +189,6 @@ ifeq ($(OATHTOOL_PATH),)
 	@false
 endif
 
-PHONY: run-client
-run-client: assert-dom0 run-deps ## Run client application (automatic login)
-	qvm-run --service sd-app qubes.StartApp+press.freedom.SecureDropClient
-	@sleep 3
-	@xdotool type "journalist"
-	@xdotool key Tab
-	@xdotool type "correct horse battery staple profanity oil chewy"
-	@xdotool key Tab
-	@xdotool key Tab
-	@xdotool type $(shell oathtool --totp --base32 JHCOGO7VCER3EJ4L)
-	@xdotool key Return
-
 PHONY: run-app
 run-app: assert-dom0 run-deps ## Run SecureDrop Inbox (automatic login)
 	qvm-run --service sd-app qubes.StartApp+press.freedom.SecureDropApp

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ This repo also contains the following developer-facing components:
 
 SecureDrop Workstation has a companion repository, [SecureDrop Client](https://github.com/freedomofpress/securedrop-client/),
 that contains component code for all of the packages we ship in individual VMs once they have been provisioned:
-- The [SecureDrop Client](https://github.com/freedomofpress/securedrop-client/tree/main/client#readme) is installed in `sd-app` and will be used to access the SecureDrop server *Journalist Interface* via the SecureDrop proxy.
+- The [SecureDrop Inbox](https://github.com/freedomofpress/securedrop-client/tree/main/app#readme) is installed in `sd-app` and will be used to access the SecureDrop server *Journalist Interface* via the SecureDrop proxy.
 - The [SecureDrop Proxy](https://github.com/freedomofpress/securedrop-client/tree/main/proxy#readme) is installed in `sd-proxy` to communicate to the SecureDrop server *Journalist Interface* via Tor.
 - [SecureDrop Export](https://github.com/freedomofpress/securedrop-client/tree/main/export#readme) is installed in `sd-devices` and `sd-printers`. They are used to exporting files and manage printing.
 - The *SecureDrop Client* opens all submissions in the networkless, disposable `sd-viewer` VM
@@ -170,10 +170,10 @@ The *Display VM* (sd-viewer) is disposable, does not have network access, and is
 * An adversary can exhaust storage in the centralized logging VM (`sd-log`).
 
 #### What compromise of the *App VM* (`sd-app`) can achieve
-The *App VM* is where securedrop-client resides. It does not have network access, and the Qubes split-gpg mechanism permits access to GPG keys from this VM.
+The *App VM* is where SecureDrop Inbox resides. It does not have network access, and the Qubes split-gpg mechanism permits access to GPG keys from this VM.
 * An adversary can view all decrypted submissions.
 * An adversary can decrypt arbitrary encrypted submissions.
-* An adversary can interact with the SecureDrop *Journalist Interface* or modify SecureDrop client code.
+* An adversary can interact with the SecureDrop *Journalist Interface* or modify SecureDrop Inbox code.
 * An adversary can attempt to elevate their privileges and escape the VM.
 * An adversary can exhaust storage in the centralized logging VM (`sd-log`).
 

--- a/files/press.freedom.SecureDropUpdater.desktop
+++ b/files/press.freedom.SecureDropUpdater.desktop
@@ -4,4 +4,4 @@ Type=Application
 Terminal=false
 Icon=securedrop
 Name=SecureDrop Inbox
-Exec=sdw-updater --launch-app
+Exec=sdw-updater

--- a/files/sdw-login.py
+++ b/files/sdw-login.py
@@ -4,7 +4,6 @@ Utility script for SecureDrop Workstation. Launches the SecureDrop Workstation
 updater on boot. It will prompt users to apply template and dom0 updates
 """
 
-import argparse
 import logging
 import os
 import subprocess
@@ -15,22 +14,9 @@ logger = logging.getLogger(SCRIPT_NAME)
 logging.basicConfig(level=logging.INFO)
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--launch-app", action="store_true")
-    args = parser.parse_args()
-
+if __name__ == "__main__":
     # Wait for the dom0 GUI widgets to load
     # If we don't wait, a "Houston, we have a problem..." message is displayed
     # to the user.
     time.sleep(5)
-
-    cmd = ["sdw-updater"]
-    if args.launch_app:
-        cmd.append("--launch-app")
-
-    subprocess.check_call(cmd)
-
-
-if __name__ == "__main__":
-    main()
+    subprocess.check_call(["sdw-updater"])

--- a/files/sdw-notify.py
+++ b/files/sdw-notify.py
@@ -67,7 +67,7 @@ def show_update_warning() -> None:
     # has opted to check for updates.
     if result == NotifyApp.NotifyStatus.CHECK_UPDATES:
         log.info("Launching Preflight Updater")
-        updater = UpdaterApp.UpdaterApp(launch_app=True)
+        updater = UpdaterApp.UpdaterApp()
         updater.show()
         sys.exit(app.exec())
     elif result == NotifyApp.NotifyStatus.DEFER_UPDATES:

--- a/files/sdw-updater.py
+++ b/files/sdw-updater.py
@@ -20,17 +20,16 @@ def parse_argv(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--skip-delta", type=int)
     parser.add_argument("--skip-netcheck", action="store_true")
-    parser.add_argument("--launch-app", action="store_true")
     return parser.parse_args(argv)
 
 
-def launch_updater(should_skip_netcheck: bool = False, launch_app: bool = False) -> None:
+def launch_updater(should_skip_netcheck: bool = False) -> None:
     """
     Start the updater GUI.
     """
 
     app = QApplication(sys.argv)
-    form = UpdaterApp(should_skip_netcheck, launch_app)
+    form = UpdaterApp(should_skip_netcheck)
     form.show()
     sys.exit(app.exec())
 
@@ -65,9 +64,9 @@ def main(argv: list[str]) -> None:
     interval = int(args.skip_delta)
 
     if should_launch_updater(interval):
-        launch_updater(args.skip_netcheck, args.launch_app)
+        launch_updater(args.skip_netcheck)
     else:
-        launch_securedrop_client(app=args.launch_app)
+        launch_securedrop_client()
 
 
 if __name__ == "__main__":

--- a/files/sdw-updater.py
+++ b/files/sdw-updater.py
@@ -10,7 +10,7 @@ except ImportError:
 
 from sdw_updater import Updater
 from sdw_updater.Updater import is_qubes_mid_upgrade, should_launch_updater
-from sdw_updater.UpdaterApp import UpdaterApp, launch_securedrop_client
+from sdw_updater.UpdaterApp import UpdaterApp, launch_securedrop_inbox
 from sdw_util import Util
 
 DEFAULT_INTERVAL = 28800  # 8hr default for update interval
@@ -66,7 +66,7 @@ def main(argv: list[str]) -> None:
     if should_launch_updater(interval):
         launch_updater(args.skip_netcheck)
     else:
-        launch_securedrop_client()
+        launch_securedrop_inbox()
 
 
 if __name__ == "__main__":

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -101,7 +101,8 @@ install -m 755 -d %{buildroot}%{_sharedstatedir}/%{name}/
 install -m 755 -d %{buildroot}%{_userunitdir}/
 install -m 755 -d %{buildroot}%{_unitdir}
 install -m 755 -d %{buildroot}%{_userpresetdir}/
-install -m 644 files/press.freedom.SecureDropUpdater.desktop %{buildroot}%{_datadir}/applications/
+install -m 644 files/press.freedom.SecureDropUpdater.desktop %{buildroot}/%{_datadir}/applications/
+install -m 644 files/press.freedom.SecureDropUpdater.desktop %{buildroot}/srv/salt/securedrop_salt/press.freedom.SecureDropUpdater.desktop
 install -m 644 files/securedrop-128x128.png %{buildroot}%{_datadir}/icons/hicolor/128x128/apps/securedrop.png
 install -m 644 files/securedrop-scalable.svg %{buildroot}%{_datadir}/icons/hicolor/scalable/apps/securedrop.svg
 install -m 755 files/sdw-updater.py %{buildroot}%{_bindir}/sdw-updater

--- a/sdw_notify/NotifyApp.py
+++ b/sdw_notify/NotifyApp.py
@@ -33,7 +33,7 @@ class NotifyDialog(QMessageBox):
 
     Constructor takes a boolean parameter, `is_sdapp_stopped`, which determines
     whether a longer error message indicating the updater's impact on a
-    currently-running client session will be shown.
+    currently-running inbox session will be shown.
     """
 
     def __init__(self, is_sdapp_stopped: bool):

--- a/sdw_updater/Updater.py
+++ b/sdw_updater/Updater.py
@@ -42,7 +42,7 @@ detail_log = Util.get_logger(prefix=DETAIL_LOGGER_PREFIX, module=__name__)
 def _get_current_vms() -> dict[str, str]:
     debian_version = "bookworm"
 
-    # The are the TemplateVMs that require full patch level at boot in order to start the client,
+    # The are the TemplateVMs that require full patch level at boot in order to start the inbox,
     # as well as their associated TemplateVMs.
     # In the future, we could use qvm-prefs to extract this information.
     return {
@@ -470,11 +470,11 @@ def should_launch_updater(interval: int) -> bool:
             sdlog.info("Update interval expired: launching updater.")
             return True
         if status["status"] == UpdateStatus.UPDATES_OK.value:
-            sdlog.info("Updates OK and interval not expired, launching client.")
+            sdlog.info("Updates OK and interval not expired, launching inbox.")
             return False
         if status["status"] == UpdateStatus.REBOOT_REQUIRED.value:
             if last_required_reboot_performed():
-                sdlog.info("Required reboot performed, updating status and launching client.")
+                sdlog.info("Required reboot performed, updating status and launching inbox.")
                 _write_updates_status_flag_to_disk(UpdateStatus.UPDATES_OK)
                 return False
 

--- a/sdw_updater/UpdaterApp.py
+++ b/sdw_updater/UpdaterApp.py
@@ -18,7 +18,7 @@ from sdw_util import Util
 logger = Util.get_logger(module=__name__)
 
 
-def launch_securedrop_client() -> None:
+def launch_securedrop_inbox() -> None:
     """
     Helper function to launch the SecureDrop Inbox
     """
@@ -56,9 +56,9 @@ class UpdaterApp(QDialog, Ui_UpdaterDialog):
         self.cancelButton.show()
         self.cancelButton.clicked.connect(self.exit_updater)
 
-        self.clientOpenButton.setEnabled(False)
-        self.clientOpenButton.hide()
-        self.clientOpenButton.clicked.connect(launch_securedrop_client)
+        self.inboxOpenButton.setEnabled(False)
+        self.inboxOpenButton.hide()
+        self.inboxOpenButton.clicked.connect(launch_securedrop_inbox)
 
         self.rebootButton.setEnabled(False)
         self.rebootButton.hide()
@@ -92,9 +92,9 @@ class UpdaterApp(QDialog, Ui_UpdaterDialog):
             self.headline.setText(strings.headline_status_reboot_required)
             self.proposedActionDescription.setText(strings.description_status_reboot_required)
         elif result["recommended_action"] == UpdateStatus.UPDATES_OK:
-            logger.info("VMs have been succesfully updated, OK to start client")
-            self.clientOpenButton.setEnabled(True)
-            self.clientOpenButton.show()
+            logger.info("VMs have been succesfully updated, OK to start inbox")
+            self.inboxOpenButton.setEnabled(True)
+            self.inboxOpenButton.show()
             self.cancelButton.setEnabled(True)
             self.cancelButton.show()
             self.headline.setText(strings.headline_status_updates_complete)

--- a/sdw_updater/UpdaterApp.py
+++ b/sdw_updater/UpdaterApp.py
@@ -18,23 +18,16 @@ from sdw_util import Util
 logger = Util.get_logger(module=__name__)
 
 
-def launch_securedrop_client(app: bool = False) -> None:
+def launch_securedrop_client() -> None:
     """
-    Helper function to launch the SecureDrop Client or Inbox ("app")
+    Helper function to launch the SecureDrop Inbox
     """
-    if app:
-        desktop_file = "press.freedom.SecureDropApp"
-        app_name = "SecureDrop Inbox"
-    else:
-        desktop_file = "press.freedom.SecureDropClient"
-        app_name = "SecureDrop client"
-
     try:
-        logger.info(f"Launching {app_name}")
+        logger.info("Launching SecureDrop Inbox")
         subprocess.Popen(["qvm-start", "sd-proxy"])
-        subprocess.Popen(["qvm-run", "sd-app", f"gtk-launch {desktop_file}"])
+        subprocess.Popen(["qvm-run", "sd-app", "gtk-launch press.freedom.SecureDropApp"])
     except subprocess.CalledProcessError as e:
-        logger.error(f"Error while launching {app_name}")
+        logger.error("Error while launching SecureDrop Inbox")
         logger.error(str(e))
     sys.exit(0)
 
@@ -43,14 +36,12 @@ class UpdaterApp(QDialog, Ui_UpdaterDialog):
     def __init__(
         self,
         should_skip_netcheck: bool = False,
-        launch_app: bool = False,
         parent: Any = None,
     ) -> None:
         super().__init__(parent)
 
         self.progress = 0
         self._skip_netcheck = should_skip_netcheck
-        self._launch_app = launch_app
         self.setupUi(self)
 
         # We use a single dialog with button visibility toggled at different
@@ -67,10 +58,7 @@ class UpdaterApp(QDialog, Ui_UpdaterDialog):
 
         self.clientOpenButton.setEnabled(False)
         self.clientOpenButton.hide()
-        # Connect button to launch either client or app based on launch_app flag
-        self.clientOpenButton.clicked.connect(
-            lambda: launch_securedrop_client(app=self._launch_app)
-        )
+        self.clientOpenButton.clicked.connect(launch_securedrop_client)
 
         self.rebootButton.setEnabled(False)
         self.rebootButton.hide()
@@ -79,10 +67,7 @@ class UpdaterApp(QDialog, Ui_UpdaterDialog):
         self.show()
 
         self.headline.setText(strings.headline_introduction)
-        if self._launch_app:
-            self.proposedActionDescription.setText(strings.description_introduction_app)
-        else:
-            self.proposedActionDescription.setText(strings.description_introduction)
+        self.proposedActionDescription.setText(strings.description_introduction)
 
         self.progress += 1
         self.progressBar.setProperty("value", self.progress)
@@ -113,23 +98,13 @@ class UpdaterApp(QDialog, Ui_UpdaterDialog):
             self.cancelButton.setEnabled(True)
             self.cancelButton.show()
             self.headline.setText(strings.headline_status_updates_complete)
-            if self._launch_app:
-                self.proposedActionDescription.setText(
-                    strings.description_status_updates_complete_app
-                )
-            else:
-                self.proposedActionDescription.setText(strings.description_status_updates_complete)
+            self.proposedActionDescription.setText(strings.description_status_updates_complete)
         else:
             logger.info("Error upgrading VMs")
             self.cancelButton.setEnabled(True)
             self.cancelButton.show()
             self.headline.setText(strings.headline_status_updates_failed)
-            if self._launch_app:
-                self.proposedActionDescription.setText(
-                    strings.description_status_updates_failed_app
-                )
-            else:
-                self.proposedActionDescription.setText(strings.description_status_updates_failed)
+            self.proposedActionDescription.setText(strings.description_status_updates_failed)
 
     @pyqtSlot(int)
     def update_progress_bar(self, value: int) -> None:

--- a/sdw_updater/UpdaterAppUiQt6.py
+++ b/sdw_updater/UpdaterAppUiQt6.py
@@ -38,11 +38,11 @@ class Ui_UpdaterDialog:
             20, 10, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Fixed
         )
         self.gridLayout.addItem(spacerItem, 1, 1, 1, 5)
-        self.clientOpenButton = QtWidgets.QPushButton(parent=UpdaterDialog)
-        self.clientOpenButton.setStyleSheet("")
-        self.clientOpenButton.setAutoDefault(True)
-        self.clientOpenButton.setObjectName("clientOpenButton")
-        self.gridLayout.addWidget(self.clientOpenButton, 7, 4, 1, 1)
+        self.inboxOpenButton = QtWidgets.QPushButton(parent=UpdaterDialog)
+        self.inboxOpenButton.setStyleSheet("")
+        self.inboxOpenButton.setAutoDefault(True)
+        self.inboxOpenButton.setObjectName("inboxOpenButton")
+        self.gridLayout.addWidget(self.inboxOpenButton, 7, 4, 1, 1)
         self.proposedActionDescription = QtWidgets.QLabel(parent=UpdaterDialog)
         sizePolicy = QtWidgets.QSizePolicy(
             QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Minimum
@@ -115,7 +115,7 @@ class Ui_UpdaterDialog:
         UpdaterDialog.setWindowTitle(
             _translate("UpdaterDialog", "SecureDrop Workstation preflight updater")
         )
-        self.clientOpenButton.setText(_translate("UpdaterDialog", "Continue"))
+        self.inboxOpenButton.setText(_translate("UpdaterDialog", "Continue"))
         self.proposedActionDescription.setText(_translate("UpdaterDialog", "Description goes here"))
         self.rebootButton.setText(_translate("UpdaterDialog", "Reboot"))
         self.applyUpdatesButton.setText(_translate("UpdaterDialog", "Start Updates"))

--- a/sdw_updater/sdw_updater.ui
+++ b/sdw_updater/sdw_updater.ui
@@ -54,7 +54,7 @@
       </spacer>
      </item>
      <item row="7" column="4">
-      <widget class="QPushButton" name="clientOpenButton">
+      <widget class="QPushButton" name="inboxOpenButton">
        <property name="styleSheet">
         <string notr="true"/>
        </property>

--- a/sdw_updater/strings.py
+++ b/sdw_updater/strings.py
@@ -27,7 +27,7 @@ description_status_updates_failed = (
     "There was an error downloading or installing updates for your workstation. "
     "The SecureDrop Inbox cannot be started at this time. Please contact your administrator."
 )
-# Post-update actions (launching client, reboot)
+# Post-update actions (launching inbox, reboot)
 headline_status_reboot_required = "All updates complete!"
 description_status_reboot_required = (
     "You need to reboot the computer for updates to be completed. "

--- a/sdw_updater/strings.py
+++ b/sdw_updater/strings.py
@@ -2,14 +2,6 @@ headline_introduction = "Preflight security updates"
 description_introduction = (
     "<p>To keep your Workstation safe, daily software updates are required.</p> "
     "<p>This typically takes between 10 and 30 minutes. You cannot use the SecureDrop "
-    "Client or any of its VMs while the updater is running.</p>"
-    "<p><span style='color:#E62354;'><b>Interrupting software updates may break "
-    "the Workstation.</b></span> Please cancel and return later if you are pressed "
-    "for time.</p>"
-)
-description_introduction_app = (
-    "<p>To keep your Workstation safe, daily software updates are required.</p> "
-    "<p>This typically takes between 10 and 30 minutes. You cannot use the SecureDrop "
     "Inbox or any of its VMs while the updater is running.</p>"
     "<p><span style='color:#E62354;'><b>Interrupting software updates may break "
     "the Workstation.</b></span> Please cancel and return later if you are pressed "
@@ -27,18 +19,11 @@ description_status_applying_updates = (
 
 headline_status_updates_complete = "All updates complete!"
 description_status_updates_complete = (
-    "Click <em>Continue</em> to launch the SecureDrop Client. No reboot is necessary."
-)
-description_status_updates_complete_app = (
     "Click <em>Continue</em> to launch the SecureDrop Inbox. No reboot is necessary."
 )
 
 headline_status_updates_failed = "Security updates failed"
 description_status_updates_failed = (
-    "There was an error downloading or installing updates for your workstation. "
-    "The SecureDrop Client cannot be started at this time. Please contact your administrator."
-)
-description_status_updates_failed_app = (
     "There was an error downloading or installing updates for your workstation. "
     "The SecureDrop Inbox cannot be started at this time. Please contact your administrator."
 )

--- a/securedrop_salt/press.freedom.SecureDropUpdater.desktop
+++ b/securedrop_salt/press.freedom.SecureDropUpdater.desktop
@@ -1,7 +1,0 @@
-[Desktop Entry]
-Version=1.0
-Type=Application
-Terminal=false
-Icon=securedrop
-Name=SecureDrop Inbox
-Exec=/usr/bin/sdw-updater

--- a/securedrop_salt/press.freedom.SecureDropUpdater.desktop
+++ b/securedrop_salt/press.freedom.SecureDropUpdater.desktop
@@ -4,4 +4,4 @@ Type=Application
 Terminal=false
 Icon=securedrop
 Name=SecureDrop Inbox
-Exec={{ desktop_exec }}
+Exec=/usr/bin/sdw-updater

--- a/securedrop_salt/sd-app-files.sls
+++ b/securedrop_salt/sd-app-files.sls
@@ -12,8 +12,6 @@ include:
   - securedrop_salt.fpf-apt-repo
   - securedrop_salt.sd-logging-setup
 
-{% import_json "securedrop_salt/config.json" as d %}
-
 # FPF repo is setup in "securedrop-workstation-$sdvars.distribution" template,
 # and then cloned as "sd-small-$sdvars.distribution-template"
 install-securedrop-app-package:

--- a/securedrop_salt/sd-dom0-files.sls
+++ b/securedrop_salt/sd-dom0-files.sls
@@ -25,7 +25,7 @@ dom0-login-autostart-desktop-file:
     - context:
         desktop_name: SDWLogin
         desktop_comment: Updates SecureDrop Workstation DispVMs at login
-        desktop_exec: /usr/bin/sdw-login --launch-app
+        desktop_exec: /usr/bin/sdw-login
     - user: {{ gui_user }}
     - group: {{ gui_user }}
     - mode: 664
@@ -35,10 +35,7 @@ dom0-login-autostart-desktop-file:
 dom0-securedrop-launcher-desktop-shortcut:
   file.managed:
     - name: /home/{{ gui_user }}/Desktop/press.freedom.SecureDropUpdater.desktop
-    - source: "salt://securedrop_salt/press.freedom.SecureDropUpdater.desktop.j2"
-    - template: jinja
-    - context:
-        desktop_exec: sdw-updater --launch-app
+    - source: "salt://securedrop_salt/press.freedom.SecureDropUpdater.desktop"
     - user: {{ gui_user }}
     - group: {{ gui_user }}
     - mode: 755


### PR DESCRIPTION
Fixes #1685 by undoing the relevant parts of commit: 62a8e9e, 62a8e9e and 7174bdd

OpenQA tests: https://openqa.qubes-os.org/tests/183633

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
- [ ] Desktop icon launches sdw-updater
  - [ ] Updater strings don't mention (old) client as you go through it
  - [ ] Inbox is launched at the end
- [ ] Visual code review
- [ ] Threat model change in README continues to make sense

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
