### PR TITLE
Remove Qube 4.2 references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
       fail-fast: false
       matrix: &qubes_release
         qubes_release:
-          - { name: "Qubes 4.2", fedora_ver: "37", python_ver: "3.11" }
           - { name: "Qubes 4.3", fedora_ver: "41", python_ver: "3.13" }
 
     container:

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -25,7 +25,6 @@ jobs:
       fail-fast: false
       matrix:
         fedora_version:
-          - 37  # Qubes 4.2
           - 41  # Qubes 4.3
     container:
       image: quay.io/fedora/fedora:${{ matrix.fedora_version }}
@@ -86,8 +85,6 @@ jobs:
           git config --global user.email "securedrop@freedom.press"
           git config --global user.name "sdcibot-nightlies[bot]"
           cd securedrop-yum-test
-          mkdir -p workstation/dom0/f37-nightlies
-          cp -v ../rpm-build-37/*.rpm workstation/dom0/f37-nightlies/
           mkdir -p workstation/dom0/f41-nightlies
           cp -v ../rpm-build-41/*.rpm workstation/dom0/f41-nightlies/
           git add .
@@ -121,7 +118,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        qubes_version: ["4.2", "4.3"]
+        qubes_version: ["4.3"]
     with:
       environment: "dev"
       git_ref: ${{ needs.get-main-commit.outputs.main-commit}}

--- a/.github/workstation-ci.yml
+++ b/.github/workstation-ci.yml
@@ -1,2 +1,0 @@
-# for <https://github.com/freedomofpress/securedrop-workstation-ci>
-qubes: "4.2"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DEFAULT_GOAL: help
-PYTHON3 := $(if $(shell bash -c "command -v python3.11"), python3.11, python3)
-# If we're on anything but Fedora 37/41, execute some commands in a container
-# Note: if your development environment is Fedora 37 based, you may want to
+PYTHON3 := $(if $(shell bash -c "command -v python3.13"), python3.13, python3)
+# If we're on anything but Fedora 41, execute some commands in a container
+# Note: if your development environment is Fedora 41 based, you may want to
 # manually prepend ./scripts/container.sh to commands you want to execute
 CONTAINER := $(if $(shell grep -E "(Thirty Seven|Forty One)" /etc/fedora-release),,./scripts/container.sh)
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ However, the Qubes OS approach is not without downsides. It stands and falls wit
 
 ## Project status
 
-SecureDrop Workstation is in open beta. We continue to move towards general availability of SecureDrop Workstation based on users' feedback and experience. The current version is compatible with Qubes 4.2 and work is ongoing on 4.3 compatibility. The mainline of this repo will be in flux and not suitable for production deployment until the work is completed and audited.
+SecureDrop Workstation is in open beta. We continue to move towards general availability of SecureDrop Workstation based on users' feedback and experience. The current version is compatible with Qubes OS 4.3. The mainline of this repo will be in flux and not suitable for production deployment until the work is completed and audited.
 
-For now, if you want to try SecureDrop Workstation's functionality we recommend following the installation instructions at [https://workstation.securedrop.org](https://workstation.securedrop.org), which will guide you through installing the latest stable version of SecureDrop Workstation on Qubes 4.2.
+For now, if you want to try SecureDrop Workstation's functionality we recommend following the installation instructions at [https://workstation.securedrop.org](https://workstation.securedrop.org), which will guide you through installing the latest stable version of SecureDrop Workstation.
 
 ## Architecture
 
@@ -104,7 +104,7 @@ that contains component code for all of the packages we ship in individual VMs o
 
 ## Installation
 
-Installing this project is involved. It requires an up-to-date Qubes 4.2 installation running on a machine with at least 16GB of RAM (32 GB recommended).
+Installing this project is involved. It requires an up-to-date Qubes 4.3 installation running on a machine with at least 16GB of RAM (32 GB recommended).
 
 **The project is currently in open beta. See our [blog post](https://securedrop.org/news/securedrop-workstation-1_0_0-released/) for more information. If you are interested in using SecureDrop Workstation, please reach out to us via the [contact form](https://securedrop.org/help/).**
 

--- a/bootstrap/Dockerfile
+++ b/bootstrap/Dockerfile
@@ -1,4 +1,4 @@
-ARG FEDORA_VERSION=37
+ARG FEDORA_VERSION=41
 FROM quay.io/fedora/fedora:${FEDORA_VERSION}
 
 # Install "make" so that we can run the makefile targets for dev deps.

--- a/poetry.lock
+++ b/poetry.lock
@@ -26,7 +26,6 @@ files = [
 
 [package.dependencies]
 idna = ">=2.8"
-typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 
 [package.extras]
 trio = ["trio (>=0.32.0)"]
@@ -1325,80 +1324,12 @@ docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
 tests = ["coverage[toml] (==7.10.7)", "pytest (>=8.4.2,<9.0.0)"]
 
 [[package]]
-name = "pyqt5"
-version = "5.15.9"
-description = "Python bindings for the Qt cross platform application toolkit"
-optional = false
-python-versions = ">=3.7"
-groups = ["system-package-equivalents"]
-markers = "python_version == \"3.11\""
-files = [
-    {file = "PyQt5-5.15.9-cp37-abi3-macosx_10_13_x86_64.whl", hash = "sha256:883ba5c8a348be78c8be6a3d3ba014c798e679503bce00d76c666c2dc6afe828"},
-    {file = "PyQt5-5.15.9-cp37-abi3-manylinux_2_17_x86_64.whl", hash = "sha256:dd5ce10e79fbf1df29507d2daf99270f2057cdd25e4de6fbf2052b46c652e3a5"},
-    {file = "PyQt5-5.15.9-cp37-abi3-win32.whl", hash = "sha256:e45c5cc15d4fd26ab5cb0e5cdba60691a3e9086411f8e3662db07a5a4222a696"},
-    {file = "PyQt5-5.15.9-cp37-abi3-win_amd64.whl", hash = "sha256:e030d795df4cbbfcf4f38b18e2e119bcc9e177ef658a5094b87bb16cac0ce4c5"},
-    {file = "PyQt5-5.15.9.tar.gz", hash = "sha256:dc41e8401a90dc3e2b692b411bd5492ab559ae27a27424eed4bd3915564ec4c0"},
-]
-
-[package.dependencies]
-PyQt5-Qt5 = ">=5.15.2"
-PyQt5-sip = ">=12.11,<13"
-
-[[package]]
-name = "pyqt5-qt5"
-version = "5.15.2"
-description = "The subset of a Qt installation needed by PyQt5."
-optional = false
-python-versions = "*"
-groups = ["system-package-equivalents"]
-markers = "python_version == \"3.11\""
-files = [
-    {file = "PyQt5_Qt5-5.15.2-py3-none-macosx_10_13_intel.whl", hash = "sha256:76980cd3d7ae87e3c7a33bfebfaee84448fd650bad6840471d6cae199b56e154"},
-    {file = "PyQt5_Qt5-5.15.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:1988f364ec8caf87a6ee5d5a3a5210d57539988bf8e84714c7d60972692e2f4a"},
-    {file = "PyQt5_Qt5-5.15.2-py3-none-win32.whl", hash = "sha256:9cc7a768b1921f4b982ebc00a318ccb38578e44e45316c7a4a850e953e1dd327"},
-    {file = "PyQt5_Qt5-5.15.2-py3-none-win_amd64.whl", hash = "sha256:750b78e4dba6bdf1607febedc08738e318ea09e9b10aea9ff0d73073f11f6962"},
-]
-
-[[package]]
-name = "pyqt5-sip"
-version = "12.11.0"
-description = "The sip module support for PyQt5"
-optional = false
-python-versions = ">=3.7"
-groups = ["system-package-equivalents"]
-markers = "python_version == \"3.11\""
-files = [
-    {file = "PyQt5_sip-12.11.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f1f9e312ff8284d6dfebc5366f6f7d103f84eec23a4da0be0482403933e68660"},
-    {file = "PyQt5_sip-12.11.0-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:4031547dfb679be309094bfa79254f5badc5ddbe66b9ad38e319d84a7d612443"},
-    {file = "PyQt5_sip-12.11.0-cp310-cp310-win32.whl", hash = "sha256:ad21ca0ee8cae2a41b61fc04949dccfab6fe008749627d94e8c7078cb7a73af1"},
-    {file = "PyQt5_sip-12.11.0-cp310-cp310-win_amd64.whl", hash = "sha256:3126c84568ab341c12e46ded2230f62a9a78752a70fdab13713f89a71cd44f73"},
-    {file = "PyQt5_sip-12.11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:bd733667098cac70e89279d9c239106d543fb480def62a44e6366ccb8f68510b"},
-    {file = "PyQt5_sip-12.11.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:ec1d8ce50be76c5c1d1c86c6dc0ccacc2446172dde98b663a17871f532f9bd44"},
-    {file = "PyQt5_sip-12.11.0-cp311-cp311-win32.whl", hash = "sha256:43dfe6dd409e713edeb67019b85419a7a0dc9923bfc451d6cf3778471c122532"},
-    {file = "PyQt5_sip-12.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:afa4ffffc54e306669bf2b66ea37abbc56c5cdda4f3f474d20324e3634302b12"},
-    {file = "PyQt5_sip-12.11.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0f77655c62ec91d47c2c99143f248624d44dd2d8a12d016e7c020508ad418aca"},
-    {file = "PyQt5_sip-12.11.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ec5e9ef78852e1f96f86d7e15c9215878422b83dde36d44f1539a3062942f19c"},
-    {file = "PyQt5_sip-12.11.0-cp37-cp37m-win32.whl", hash = "sha256:d12b81c3a08abf7657a2ebc7d3649852a1f327eb2146ebadf45930486d32e920"},
-    {file = "PyQt5_sip-12.11.0-cp37-cp37m-win_amd64.whl", hash = "sha256:b69a1911f768b489846335e31e49eb34795c6b5a038ca24d894d751e3b0b44da"},
-    {file = "PyQt5_sip-12.11.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:51e377789d59196213eddf458e6927f33ba9d217b614d17d20df16c9a8b2c41c"},
-    {file = "PyQt5_sip-12.11.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:4e5c1559311515291ea0ab0635529f14536954e3b973a7c7890ab7e4de1c2c23"},
-    {file = "PyQt5_sip-12.11.0-cp38-cp38-win32.whl", hash = "sha256:9bca450c5306890cb002fe36bbca18f979dd9e5b810b766dce8e3ce5e66ba795"},
-    {file = "PyQt5_sip-12.11.0-cp38-cp38-win_amd64.whl", hash = "sha256:f6b72035da4e8fecbb0bc4a972e30a5674a9ad5608dbddaa517e983782dbf3bf"},
-    {file = "PyQt5_sip-12.11.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:9356260d4feb60dbac0ab66f8a791a0d2cda1bf98c9dec8e575904a045fbf7c5"},
-    {file = "PyQt5_sip-12.11.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:205f3e1b3eea3597d8e878936c1a06e04bd23a59e8b179ee806465d72eea3071"},
-    {file = "PyQt5_sip-12.11.0-cp39-cp39-win32.whl", hash = "sha256:686071be054e5be6ca5aaaef7960931d4ba917277e839e2e978c7cbe3f43bb6e"},
-    {file = "PyQt5_sip-12.11.0-cp39-cp39-win_amd64.whl", hash = "sha256:42320e7a94b1085ed85d49794ed4ccfe86f1cae80b44a894db908a8aba2bc60e"},
-    {file = "PyQt5_sip-12.11.0.tar.gz", hash = "sha256:b4710fd85b57edef716cc55fae45bfd5bfac6fc7ba91036f1dcc3f331ca0eb39"},
-]
-
-[[package]]
 name = "pyqt6"
 version = "6.8.1"
 description = "Python bindings for the Qt cross platform application toolkit"
 optional = false
 python-versions = ">=3.9"
 groups = ["system-package-equivalents"]
-markers = "python_version > \"3.11\""
 files = [
     {file = "PyQt6-6.8.1-cp39-abi3-macosx_10_14_universal2.whl", hash = "sha256:0425f9eebdd5d4e57ab36424c9382f2ea06670c3c550fa0028c2b19bd0a1d7bd"},
     {file = "PyQt6-6.8.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:36bf48e3df3a6ff536e703315d155480ef4e260396eb5469eb7a875bc5bb7ab4"},
@@ -1419,7 +1350,6 @@ description = "The subset of a Qt installation needed by PyQt6."
 optional = false
 python-versions = "*"
 groups = ["system-package-equivalents"]
-markers = "python_version > \"3.11\""
 files = [
     {file = "PyQt6_Qt6-6.8.2-py3-none-macosx_10_14_x86_64.whl", hash = "sha256:470dd4211fe5a67b0565e0202e7aa67816e5dcf7d713528b88327adaebd0934e"},
     {file = "PyQt6_Qt6-6.8.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:40cda901a3e1617e79225c354fe9d89b80249f0a6c6aaa18b40938e05bbf7d1f"},
@@ -1436,7 +1366,6 @@ description = "The sip module support for PyQt6"
 optional = false
 python-versions = ">=3.9"
 groups = ["system-package-equivalents"]
-markers = "python_version > \"3.11\""
 files = [
     {file = "PyQt6_sip-13.9.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e996d320744ca8342cad6f9454345330d4f06bce129812d032bda3bad6967c5c"},
     {file = "PyQt6_sip-13.9.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2ab85aaf155828331399c59ebdd4d3b0358e42c08250e86b43d56d9873df148a"},
@@ -1728,7 +1657,6 @@ files = [
 [package.dependencies]
 attrs = ">=22.2.0"
 rpds-py = ">=0.7.0"
-typing-extensions = {version = ">=4.4.0", markers = "python_version < \"3.13\""}
 
 [[package]]
 name = "requests"
@@ -2109,7 +2037,6 @@ files = [
 
 [package.dependencies]
 anyio = ">=3.6.2,<5"
-typing-extensions = {version = ">=4.10.0", markers = "python_version < \"3.13\""}
 
 [package.extras]
 full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
@@ -2355,5 +2282,5 @@ files = [
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.11"
-content-hash = "9ff597f0c34de26401d60873c6c445c2717de80e664013c8d213d7abcd6d87ae"
+python-versions = ">=3.13"
+content-hash = "d7dfb38f143aac0a7824f6dfd9b61b746855c95b36e3641109a5cd4305ca10d0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-requires-python = ">=3.11"
+requires-python = ">=3.13"
 name = "securedrop-workstation-dom0-config"
 dynamic = [ "version", "classifiers" ]
 description = ""
@@ -29,13 +29,10 @@ semgrep = "*"
 # In production these are installed as a system package so match the
 # versions exactly.
 # NOTE: 'python_version' used as a proxy for the Qubes version:
-#    - python 3.11 => Fedora 37 => Qubes 4.2
 #    - python 3.13 => Fedora 41 => Qubes 4.3
-PyQt5 = {version = "=5.15.9", markers = "python_version <= '3.11'" }
-PyQt5-Qt5 = {version = "=5.15.2", markers = "python_version <= '3.11'" }
-PyQt5-sip = {version = "=12.11.0", markers = "python_version <= '3.11'" }
-PyQt6 = {version = "=6.8.1", markers = "python_version > '3.11'" }
-PyQt6-sip = {version = "=13.9.1", markers = "python_version > '3.11'" }
+#    - python 3.?? => Fedora ?? => Qubes ?
+PyQt6 = {version = "=6.8.1", markers = "python_version >= '3.13'" }
+PyQt6-sip = {version = "=13.9.1", markers = "python_version >= '3.13'" }
 
 [tool.ruff]
 line-length = 100
@@ -108,7 +105,7 @@ ignore = [
 ]
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.13"
 # In-tree stubs (currently: qubesadmin) live under stubs/.
 mypy_path = "stubs"
 # Other dom0-only deps (dnf, qubesdb, systemd, ...) still lack stubs.

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -2,7 +2,7 @@ TOPLEVEL=$(git rev-parse --show-toplevel)
 export TOPLEVEL
 PROJECT="securedrop-workstation-dom0-config"
 export PROJECT
-export FEDORA_VERSION="${FEDORA_VERSION:-37}"
+export FEDORA_VERSION="${FEDORA_VERSION:-41}"
 
 OCI_RUN_ARGUMENTS="${OCI_RUN_ARGUMENTS:-}"
 export OCI_RUN_ARGUMENTS

--- a/securedrop_salt/sd-app.sls
+++ b/securedrop_salt/sd-app.sls
@@ -30,9 +30,7 @@ sd-app:
       - template: sd-small-debian-{{ sdvars.debian_version }}
       - netvm: ""
       - default_dispvm: "sd-viewer"
-      {% if grains['osrelease'] != '4.2' %}
       - devices_denied: '*******'
-      {% endif %}
     - tags:
       - add:
         - sd-client
@@ -48,7 +46,6 @@ sd-app:
       - qvm: sd-small-debian-{{ sdvars.debian_version }}
       - sls: securedrop_salt.sd-viewer
 
-{% if grains['osrelease'] != '4.2' %}
 sd-app-custom-persist:
   qvm.features:
     - name: sd-app
@@ -60,7 +57,6 @@ sd-app-custom-persist:
       - custom-persist.app_db_wal: file:user:user:0600:/home/user/.config/SecureDrop/db.sqlite-wal
       - custom-persist.app_db_shm: file:user:user:0600:/home/user/.config/SecureDrop/db.sqlite-shm
       - custom-persist.app_downloaded_files: dir:user:user:0700:/home/user/.config/SecureDrop/files
-{% endif %}
 
 sd-app-config:
   qvm.features:

--- a/securedrop_salt/sd-base-template.sls
+++ b/securedrop_salt/sd-base-template.sls
@@ -18,9 +18,7 @@ sd-base-template:
       - label: red
     - prefs:
       - default_dispvm: ""
-      {% if grains['osrelease'] != '4.2' %}
       - devices_denied: '*******'
-      {% endif %}
     - tags:
       - add:
         - sd-workstation

--- a/securedrop_salt/sd-devices.sls
+++ b/securedrop_salt/sd-devices.sls
@@ -27,10 +27,8 @@ sd-devices-dvm:
       - netvm: ""
       - template_for_dispvms: True
       - default_dispvm: ""
-      {% if grains['osrelease'] != '4.2' %}
       # Prevent device attachment (on the actual disposable attachments are expected)
       - devices_denied: '*******'
-      {% endif %}
     - tags:
       - add:
         - sd-workstation

--- a/securedrop_salt/sd-dom0-files.sls
+++ b/securedrop_salt/sd-dom0-files.sls
@@ -40,16 +40,15 @@ dom0-securedrop-launcher-desktop-shortcut:
     - group: {{ gui_user }}
     - mode: 755
 
-{% if grains['osrelease'] != '4.2' %}
 # Dismiss "security warning" when opening any desktop icons
 # as it is not a true security mitigation in Qubes. See #1582
+# NOTE: After Qubes 4.3 there may be a more sane way of working around this.
 dom0-dismiss-desktop-icon-prompt:
   cmd.run:
     - name: /usr/bin/securedrop/update-xfce-settings dismiss-desktop-icon-prompt
     - runas: {{ gui_user }}
     - require:
       - file: dom0-securedrop-launcher-desktop-shortcut
-{% endif %}
 
 dom0-environment-directory:
   file.directory:

--- a/securedrop_salt/sd-gpg.sls
+++ b/securedrop_salt/sd-gpg.sls
@@ -34,9 +34,7 @@ sd-gpg:
       - netvm: ""
       - autostart: true
       - default_dispvm: ""
-      {% if grains['osrelease'] != '4.2' %}
       - devices_denied: '*******'
-      {% endif %}
     - features:
       - enable:
         - service.securedrop-logging-disabled
@@ -51,7 +49,6 @@ sd-gpg:
       - sls: securedrop_salt.sd-workstation-template
       - sls: securedrop_salt.sd-upgrade-templates
 
-{% if grains['osrelease'] != '4.2' %}
 sd-gpg-custom-persist:
   qvm.features:
     - name: sd-gpg
@@ -59,4 +56,3 @@ sd-gpg-custom-persist:
       - service.custom-persist
     - set:
       - custom-persist.gnupg_dir: dir:user:user:0700:/home/user/.gnupg
-{% endif %}

--- a/securedrop_salt/sd-log.sls
+++ b/securedrop_salt/sd-log.sls
@@ -57,9 +57,7 @@ install-sd-log:
       - netvm: ""
       - autostart: true
       - default_dispvm: ""
-      {% if grains['osrelease'] != '4.2' %}
       - devices_denied: '*******'
-      {% endif %}
     - tags:
       - add:
         - sd-workstation
@@ -69,21 +67,13 @@ install-sd-log:
         - service.redis
         - service.securedrop-logging-disabled
         - service.securedrop-log-server
+        - service.custom-persist
       - set:
         - sd-install-epoch: {{ sdlog_epoch }}
         - menu-items: "org.gnome.Nautilus.desktop"
+        - custom-persist.logs: dir:user:user:0755:/home/user/QubesIncomingLogs
     - require:
       - qvm: sd-small-debian-{{ sdvars.debian_version }}
-
-{% if grains['osrelease'] != '4.2' %}
-sd-log-custom-persist:
-  qvm.features:
-    - name: sd-log
-    - enable:
-      - service.custom-persist
-    - set:
-      - custom-persist.logs: dir:user:user:0755:/home/user/QubesIncomingLogs
-{% endif %}
 
 # The private volume size should be set in config.json
 sd-log-private-volume-size:

--- a/securedrop_salt/sd-proxy.sls
+++ b/securedrop_salt/sd-proxy.sls
@@ -28,9 +28,7 @@ sd-proxy-dvm:
       - netvm: sys-firewall
       - template_for_dispvms: True
       - default_dispvm: ""
-      {% if grains['osrelease'] != '4.2' %}
       - devices_denied: '*******'
-      {% endif %}
     - features:
       - set:
         {% if d.environment == "prod" %}
@@ -57,9 +55,7 @@ sd-proxy-create-named-dispvm:
       - netvm: sys-firewall
       - autostart: true
       - default_dispvm: ""
-      {% if grains['osrelease'] != '4.2' %}
       - devices_denied: '*******'
-      {% endif %}
     - features:
       - enable:
         - service.securedrop-mime-handling

--- a/securedrop_salt/sd-viewer.sls
+++ b/securedrop_salt/sd-viewer.sls
@@ -35,9 +35,7 @@ sd-viewer:
       - netvm: ""
       - template_for_dispvms: True
       - default_dispvm: ""
-      {% if grains['osrelease'] != '4.2' %}
       - devices_denied: '*******'
-      {% endif %}
     - tags:
       - add:
         - sd-workstation

--- a/securedrop_salt/sd-workstation-template.sls
+++ b/securedrop_salt/sd-workstation-template.sls
@@ -19,9 +19,7 @@ include:
       - virt-mode: pvh
       - kernel: 'pvgrub2-pvh'
       - default_dispvm: ""
-      {% if grains['osrelease'] != '4.2' %}
       - devices_denied: '*******'
-      {% endif %}
     - tags:
       - add:
         - sd-workstation

--- a/tests/base.py
+++ b/tests/base.py
@@ -9,7 +9,6 @@ import re
 import subprocess
 from collections.abc import Iterable, Iterator
 
-import dnf
 import pytest
 from qubesadmin import Qubes
 from qubesadmin.vm import QubesVM
@@ -360,9 +359,6 @@ class Test_SD_VM_Common:
                 actual_app == expected_app
             ), f"MIME type {mime_type}: expected {expected_app}, got {actual_app}"
 
-    @pytest.mark.skipif(
-        dnf.rpm.detect_releasever("/") == "4.2", reason="Feature only available in Qubes >= 4.3"
-    )
     def test_mock_device_attach_deny(
         self, qube: QubeWrapper, mock_block_device: str, qubesd_log: Iterator[str]
     ) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,10 +23,6 @@ from tests.base import (
 
 PROJ_ROOT = Path(__file__).parent.parent
 
-skip_on_qubes_4_2 = pytest.mark.skipif(
-    dnf.rpm.detect_releasever("/") == "4.2", reason="Feature only available in Qubes >= 4.3"
-)
-
 
 @pytest.fixture
 def qubes_ver() -> str:

--- a/tests/test_dom0_rpm_repo.py
+++ b/tests/test_dom0_rpm_repo.py
@@ -43,7 +43,7 @@ def test_rpm_releasever_substitution() -> None:
     URL structure.
     """
     qubes_version = dnf.rpm.detect_releasever("/")
-    assert qubes_version in ["4.2", "4.3"]
+    assert qubes_version in ["4.3"]
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_dom0_salt_config.py
+++ b/tests/test_dom0_salt_config.py
@@ -5,8 +5,6 @@ from pathlib import Path
 
 import pytest
 
-from tests.conftest import skip_on_qubes_4_2
-
 DESKTOP_FILE_NAME = "press.freedom.SecureDropUpdater.desktop"
 
 
@@ -26,7 +24,6 @@ def test_is_topfile_enabled() -> None:
         pytest.fail("Error checking topfiles")
 
 
-@skip_on_qubes_4_2
 @pytest.mark.provisioning
 def test_trust_desktop_launcher() -> None:
     desktop_file = Path.home() / "Desktop" / DESKTOP_FILE_NAME

--- a/tests/test_rpc_policy.py
+++ b/tests/test_rpc_policy.py
@@ -96,9 +96,7 @@ def test_policy_from_sdgpg_to_dom0_allowed(sdw_tagged_vms: list[QubesVM], qubes_
     """Securedrop.GetSecretKeys only allowed in: sd-gpg -> dom0"""
 
     for qube in sdw_tagged_vms:
-        dom0 = "@adminvm" if qubes_ver == "4.2" else "dom0"
-
-        allowed = policy_exists(qube.name, dom0, "securedrop.GetSecretKeys")
+        allowed = policy_exists(qube.name, "dom0", "securedrop.GetSecretKeys")
         if qube.name == "sd-gpg":
             assert allowed
         else:

--- a/tests/test_vm_sd_viewer.py
+++ b/tests/test_vm_sd_viewer.py
@@ -19,7 +19,6 @@ from tests.base import (
 from tests.base import (
     Test_SD_VM_Common as Test_SD_Viewer_Common,  # noqa: F401 [HACK: import so base tests run]
 )
-from tests.conftest import skip_on_qubes_4_2
 
 EXPECTED_N_PRELOADED_VMS = [
     1,  # 16GB system (less than recommended)
@@ -164,7 +163,6 @@ def test_sd_viewer_config(all_vms: VMCollection, dom0_config: Dom0Config) -> Non
         assert vm.features.get("internal") == "1"
 
 
-@skip_on_qubes_4_2
 @pytest.mark.provisioning
 def test_preloading_assumptions(all_vms: VMCollection) -> None:
     # sd-viewer as default_dispvm is makes it preload implicitly
@@ -175,7 +173,6 @@ def test_preloading_assumptions(all_vms: VMCollection) -> None:
     assert preload_dispvm_max in EXPECTED_N_PRELOADED_VMS
 
 
-@skip_on_qubes_4_2
 @pytest.mark.provisioning
 def test_preloading_enabled(all_vms: VMCollection, qube: QubeWrapper) -> None:
     """

--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -11,7 +11,6 @@ from tests.base import (
     SD_UNTAGGED_DEPRECATED_VMS,
     SD_VMS,
 )
-from tests.conftest import skip_on_qubes_4_2
 
 
 @pytest.mark.provisioning
@@ -34,7 +33,6 @@ def test_all_sdw_vms_present(all_vms: VMCollection, sdw_tagged_vms: list[QubesVM
         assert all_vms.get(vm_name) is None, f"Qube '{vm_name}' expected"
 
 
-@skip_on_qubes_4_2
 @pytest.mark.provisioning
 def test_expected_persistence(sdw_tagged_vms: list[QubesVM]) -> None:
     """Make sure SD qubes are either disposable or have custom-persist enabled"""


### PR DESCRIPTION
Fixes #1718

> **NOTE:** we may need to adjust the required jobs, because we're removing some.
> This is also why the jobs look stale:
>    <img width="802" height="146" alt="Screenshot 2026-06-11 at 18-52-35 Remove Qube 4 2 references by deeplow · Pull Request #1724 · freedomofpress_securedrop-workstation" src="https://github.com/user-attachments/assets/e776c999-9657-441e-ab6c-e9d31d9691f1" />



## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
- [x] make `build-rpm` builds Qubes 4.3 package
- [x] Tests pass
- [ ] No other Qubes 4.2 references found in code
- [x] No Qubes 4.2 CI jobs
- [x] Python 3.13 is minimum python version (dev environment may need to be bumped to Debian 13 if not already)

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
