### PR TITLE
Inbox now requires two tabs to move from password to TOTP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,7 @@ run-app: assert-dom0 run-deps ## Run SecureDrop Inbox (automatic login)
 	@xdotool key Tab
 	@xdotool type "correct horse battery staple profanity oil chewy"
 	@xdotool key Tab
+	@xdotool key Tab
 	@xdotool type $(shell oathtool --totp --base32 JHCOGO7VCER3EJ4L)
 	@xdotool key Return
 


### PR DESCRIPTION
Because of the accessiblity fixes to make the "show password" button tab-navigatable.


## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* Using Inbox 1.4.0-rc1, `make run-app` works and successfully logs in.
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
