### PR TITLE
Fix `make staging` in Qubes 4.3 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,11 +63,11 @@ install-rpm: assert-dom0 ## Install locally-built rpm (dev) or download publishe
 	@rpm -q securedrop-workstation-keyring || sudo qubes-dom0-update -y --clean securedrop-workstation-keyring
 ifeq ($(RPM_INSTALL_STRATEGY),dev)
 	@echo "Install dependencies and locally-built rpm"
-	@sudo qubes-dom0-update --clean -y grub2-xen-pvh
+	@rpm -q grub2-xen-pvh || sudo qubes-dom0-update --clean -y grub2-xen-pvh
 	@./scripts/prep-dev
 else
 	@echo "Install published rpm"
-	@sudo qubes-dom0-update -y securedrop-workstation-dom0-config
+	@rpm -q securedrop-workstation-dom0-config || sudo qubes-dom0-update -y securedrop-workstation-dom0-config
 endif
 	@echo "Provide instance-specific configuration and run sdw-admin --apply."
 

--- a/scripts/bootstrap-keyring.py
+++ b/scripts/bootstrap-keyring.py
@@ -42,7 +42,7 @@ def rpm_import(key_file: Path) -> None:
 def is_key_imported(rpm_id: str) -> bool:
     """Check rpmdb for key with givem rpm_id."""
     try:
-        subprocess.check_call(["rpm", "-q", rpm_id])
+        subprocess.check_call(["rpm", "-q", "--quiet", rpm_id])
         return True
     except subprocess.CalledProcessError:
         return False
@@ -50,13 +50,15 @@ def is_key_imported(rpm_id: str) -> bool:
 
 def dom0_install_keyring(env: str | None = None) -> None:
     """Use qubes-dom0-update to install keyring package."""
-    args = ["sudo", "qubes-dom0-update", "--clean", "-y"]
+    package_name = f"{KEYRING_PACKAGENAME}-{env}" if env else KEYRING_PACKAGENAME
 
+    if is_key_imported(package_name):
+        print(f"Package {package_name} is already installed.")
+        return
+
+    args = ["sudo", "qubes-dom0-update", "--clean", "-y"]
     if env:
-        package_name = f"{KEYRING_PACKAGENAME}-{env}"
         args.append(f"--enablerepo={package_name}")
-    else:
-        package_name = KEYRING_PACKAGENAME
     args.append(package_name)
     subprocess.check_call(args)
 


### PR DESCRIPTION
I was getting a crash when running `make staging`, complaining that `/var/lib/qubes/updates/repodata/repomd.xml` did not exist.

With the help of Claude Sonnet 4.6, it turns out this is because `qubes-dom0-update --clean` deletes `/var/lib/qubes/updates/`, and it only recreates it when a package needs to be installed.

This fixes it by skipping running `qubes-dom0-update` when the package (like `securedrop-workstation-keyring-staging`) is already installed, which prevents it from deleting `repomd.xml`, allowing the installation to proceed.