### PR TITLE
Fix device attachment denial detection

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -372,13 +372,15 @@ class Test_SD_VM_Common:
 
         # Device attachment expected to fail (generic qubes)
         with pytest.raises(subprocess.CalledProcessError) as exc_info:
-            subprocess.check_output(
+            subprocess.run(
                 ["qvm-block", "attach", qube.name, mock_block_device],
-                stderr=subprocess.STDOUT,  # Capture qubesd error message
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,  # Capture qubesd error message
+                check=True,
                 text=True,
             )
 
-        assert "Error: Got empty response from qubesd" in exc_info.value.stdout
+        assert "Error: Got empty response from qubesd" in exc_info.stderr
 
         # Previous error too generic: Dig into journal logs to confirm attachment denial
         expected_re = re.compile(


### PR DESCRIPTION
Subprocess was not properly capturing stderr.

Fixes #1579

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
TBD

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
