### PR TITLE
Rename templates: `sd-small`/`sd-large` → `sd-inbox`/`sd-viewer`

### DIFF
--- a/files/sdw-admin.py
+++ b/files/sdw-admin.py
@@ -199,16 +199,17 @@ def sync_appmenus() -> None:
     Sync appmenus now that all packages are installed
     TODO: this should be done by salt or debs, but we do it manually here because it's
     not straightforward to run a dom0 salt state after VMs run.
-    n.b. none of the small VMs are shown in the menu on prod, but nice to have it synced
+    n.b. none of the sd-inbox-based VMs are shown in the menu on prod,
+    but nice to have it synced.
     """
 
-    run_cmd(["qvm-start", "--skip-if-running", "sd-small-debian-13"])
-    run_cmd(["qvm-sync-appmenus", "sd-small-debian-13"])
-    run_cmd(["qvm-shutdown", "sd-small-debian-13"])
+    run_cmd(["qvm-start", "--skip-if-running", "sd-inbox-debian-13"])
+    run_cmd(["qvm-sync-appmenus", "sd-inbox-debian-13"])
+    run_cmd(["qvm-shutdown", "sd-inbox-debian-13"])
 
-    run_cmd(["qvm-start", "--skip-if-running", "sd-large-debian-13"])
-    run_cmd(["qvm-sync-appmenus", "sd-large-debian-13"])
-    run_cmd(["qvm-shutdown", "sd-large-debian-13"])
+    run_cmd(["qvm-start", "--skip-if-running", "sd-viewer-debian-13"])
+    run_cmd(["qvm-sync-appmenus", "sd-viewer-debian-13"])
+    run_cmd(["qvm-shutdown", "sd-viewer-debian-13"])
 
     # These are the ones we show in prod VMs, so sync explicitly
     run_cmd(["qvm-sync-appmenus", "--regenerate-only", "sd-devices"])

--- a/launcher/tests/test_util.py
+++ b/launcher/tests/test_util.py
@@ -252,7 +252,7 @@ def test_is_sdapp_halted_yes(os_release_fixture, version_contains):
     """
     output = bytes(
         "NAME     STATE     CLASS     LABEL     TEMPLATE\nsd-app"
-        f"    Halted    AppVM   yellow     sd-small-debian-{DEBIAN_VERSION}\n",
+        f"    Halted    AppVM   yellow     sd-inbox-debian-{DEBIAN_VERSION}\n",
         "utf-8",
     )
 
@@ -277,7 +277,7 @@ def test_is_sdapp_halted_no(os_release_fixture, version_contains):
     """
     output = bytes(
         "NAME     STATE     CLASS     LABEL     TEMPLATE\nsd-app"
-        f"    Paused    AppVM   yellow     sd-small-debian-{DEBIAN_VERSION}\n",
+        f"    Paused    AppVM   yellow     sd-inbox-debian-{DEBIAN_VERSION}\n",
         "utf-8",
     )
 

--- a/scripts/switch-apt-source.py
+++ b/scripts/switch-apt-source.py
@@ -22,8 +22,8 @@ SOURCES_DIR = Path(__file__).parent.parent / "securedrop_salt"
 OPTIONS = ["dev", "staging", "prod"]
 CODENAME = "trixie"
 TEMPLATES = [
-    "sd-small-debian-13",
-    "sd-large-debian-13",
+    "sd-inbox-debian-13",
+    "sd-viewer-debian-13",
 ]
 TEST_COMPONENTS = {
     "dev": "main nightlies",

--- a/scripts/try-client-pr.py
+++ b/scripts/try-client-pr.py
@@ -8,8 +8,8 @@ import tempfile
 from pathlib import Path
 
 BUILD_VM = os.environ.get("SECUREDROP_DEV_VM", "sd-dev")
-SMALL_TEMPLATE = "sd-small-debian-13"
-LARGE_TEMPLATE = "sd-large-debian-13"
+INBOX_TEMPLATE = "sd-inbox-debian-13"
+VIEWER_TEMPLATE = "sd-viewer-debian-13"
 
 
 def run_in_vm(command: list[str], vmname: str, capture_output: bool = False) -> str | None:
@@ -151,8 +151,8 @@ def main() -> None:
         print(f"Package: {package_name} - {deb_file}")
 
     # Install the deb files in template VMs
-    install_debs_in_template(deb_files, SMALL_TEMPLATE)
-    install_debs_in_template(deb_files, LARGE_TEMPLATE)
+    install_debs_in_template(deb_files, INBOX_TEMPLATE)
+    install_debs_in_template(deb_files, VIEWER_TEMPLATE)
 
     # Shutdown
     all_vms = subprocess.check_output(

--- a/sdw_updater/Updater.py
+++ b/sdw_updater/Updater.py
@@ -47,13 +47,13 @@ def _get_current_vms() -> dict[str, str]:
     # In the future, we could use qvm-prefs to extract this information.
     return {
         "fedora": "fedora-43-xfce",
-        "sd-viewer": f"sd-large-debian-{debian_version}",
-        "sd-app": f"sd-small-debian-{debian_version}",
-        "sd-log": f"sd-small-debian-{debian_version}",
-        "sd-devices": f"sd-large-debian-{debian_version}",
-        "sd-printers": f"sd-large-debian-{debian_version}",
-        "sd-proxy": f"sd-small-debian-{debian_version}",
-        "sd-gpg": f"sd-small-debian-{debian_version}",
+        "sd-viewer": f"sd-viewer-debian-{debian_version}",
+        "sd-app": f"sd-inbox-debian-{debian_version}",
+        "sd-log": f"sd-inbox-debian-{debian_version}",
+        "sd-devices": f"sd-viewer-debian-{debian_version}",
+        "sd-printers": f"sd-viewer-debian-{debian_version}",
+        "sd-proxy": f"sd-inbox-debian-{debian_version}",
+        "sd-gpg": f"sd-inbox-debian-{debian_version}",
     }
 
 

--- a/securedrop_salt/sd-app-files.sls
+++ b/securedrop_salt/sd-app-files.sls
@@ -5,7 +5,7 @@
 # sd-app-files
 # ========
 #
-# Moves files into place on sd-small-debian-$sdvars.debian_version
+# Moves files into place on sd-inbox-debian-$sdvars.debian_version
 #
 ##
 include:
@@ -13,7 +13,7 @@ include:
   - securedrop_salt.sd-logging-setup
 
 # FPF repo is setup in base template, and then cloned as
-# "sd-small-debian-$sdvars.debian_version"
+# "sd-inbox-debian-$sdvars.debian_version"
 install-securedrop-app-package:
   pkg.installed:
     - pkgs:

--- a/securedrop_salt/sd-app.sls
+++ b/securedrop_salt/sd-app.sls
@@ -25,9 +25,9 @@ sd-app:
       # Label color is set during initial configuration but
       # not enforced on every Salt run, in case of user customization.
       - label: yellow
-      - template: sd-small-debian-{{ sdvars.debian_version }}
+      - template: sd-inbox-debian-{{ sdvars.debian_version }}
     - prefs:
-      - template: sd-small-debian-{{ sdvars.debian_version }}
+      - template: sd-inbox-debian-{{ sdvars.debian_version }}
       - netvm: ""
       - default_dispvm: "sd-viewer"
       {% if grains['osrelease'] != '4.2' %}
@@ -45,7 +45,7 @@ sd-app:
         - service.paxctld
         - service.securedrop-mime-handling
     - require:
-      - qvm: sd-small-debian-{{ sdvars.debian_version }}
+      - qvm: sd-inbox-debian-{{ sdvars.debian_version }}
       - sls: securedrop_salt.sd-viewer
 
 {% if grains['osrelease'] != '4.2' %}

--- a/securedrop_salt/sd-devices.sls
+++ b/securedrop_salt/sd-devices.sls
@@ -21,9 +21,9 @@ sd-devices-dvm:
       # Label color is set during initial configuration but
       # not enforced on every Salt run, in case of user customization.
       - label: red
-      - template: sd-large-debian-{{ sdvars.debian_version }}
+      - template: sd-viewer-debian-{{ sdvars.debian_version }}
     - prefs:
-      - template: sd-large-debian-{{ sdvars.debian_version }}
+      - template: sd-viewer-debian-{{ sdvars.debian_version }}
       - netvm: ""
       - template_for_dispvms: True
       - default_dispvm: ""
@@ -41,7 +41,7 @@ sd-devices-dvm:
       - default:  # Explictly remove (it had been enabled in past)
         - service.cups
     - require:
-      - qvm: sd-large-debian-{{ sdvars.debian_version }}
+      - qvm: sd-viewer-debian-{{ sdvars.debian_version }}
 
 sd-devices-create-named-dispvm:
   qvm.vm:

--- a/securedrop_salt/sd-gpg.sls
+++ b/securedrop_salt/sd-gpg.sls
@@ -28,9 +28,9 @@ sd-gpg:
       # Label color is set during initial configuration but
       # not enforced on every Salt run, in case of user customization.
       - label: purple
-      - template: sd-small-debian-{{ sdvars.debian_version }}
+      - template: sd-inbox-debian-{{ sdvars.debian_version }}
     - prefs:
-      - template: sd-small-debian-{{ sdvars.debian_version }}
+      - template: sd-inbox-debian-{{ sdvars.debian_version }}
       - netvm: ""
       - autostart: true
       - default_dispvm: ""

--- a/securedrop_salt/sd-log.sls
+++ b/securedrop_salt/sd-log.sls
@@ -51,9 +51,9 @@ install-sd-log:
       # Label color is set during initial configuration but
       # not enforced on every Salt run, in case of user customization.
       - label: red
-      - template: sd-small-debian-{{ sdvars.debian_version }}
+      - template: sd-inbox-debian-{{ sdvars.debian_version }}
     - prefs:
-      - template: sd-small-debian-{{ sdvars.debian_version }}
+      - template: sd-inbox-debian-{{ sdvars.debian_version }}
       - netvm: ""
       - autostart: true
       - default_dispvm: ""
@@ -73,7 +73,7 @@ install-sd-log:
         - sd-install-epoch: {{ sdlog_epoch }}
         - menu-items: "org.gnome.Nautilus.desktop"
     - require:
-      - qvm: sd-small-debian-{{ sdvars.debian_version }}
+      - qvm: sd-inbox-debian-{{ sdvars.debian_version }}
 
 {% if grains['osrelease'] != '4.2' %}
 sd-log-custom-persist:

--- a/securedrop_salt/sd-logging-setup.sls
+++ b/securedrop_salt/sd-logging-setup.sls
@@ -2,7 +2,7 @@
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 
 # TODO: parametrise this
-{% if grains['id'] in ["sd-small-debian-13", "sd-large-debian-13"] %}
+{% if grains['id'] in ["sd-inbox-debian-13", "sd-viewer-debian-13"] %}
 include:
   - securedrop_salt.fpf-apt-repo
 
@@ -16,7 +16,7 @@ install-securedrop-log-package:
 
 {% endif %}
 
-{% if grains['id'] == "sd-small-debian-{}".format(grains['osrelease']) %}
+{% if grains['id'] == "sd-inbox-debian-{}".format(grains['osrelease']) %}
 install-redis-for-sd-log-template:
   pkg.installed:
     - pkgs:

--- a/securedrop_salt/sd-proxy.sls
+++ b/securedrop_salt/sd-proxy.sls
@@ -22,9 +22,9 @@ sd-proxy-dvm:
       # Label color is set during initial configuration but
       # not enforced on every Salt run, in case of user customization.
       - label: blue
-      - template: sd-small-debian-{{ sdvars.debian_version }}
+      - template: sd-inbox-debian-{{ sdvars.debian_version }}
     - prefs:
-      - template: sd-small-debian-{{ sdvars.debian_version }}
+      - template: sd-inbox-debian-{{ sdvars.debian_version }}
       - netvm: sys-firewall
       - template_for_dispvms: True
       - default_dispvm: ""
@@ -43,7 +43,7 @@ sd-proxy-dvm:
         - sd-workstation
         - sd-{{ sdvars.distribution }}
     - require:
-      - qvm: sd-small-debian-{{ sdvars.debian_version }}
+      - qvm: sd-inbox-debian-{{ sdvars.debian_version }}
 
 sd-proxy-create-named-dispvm:
   qvm.vm:

--- a/securedrop_salt/sd-viewer.sls
+++ b/securedrop_salt/sd-viewer.sls
@@ -29,9 +29,9 @@ sd-viewer:
       # Label color is set during initial configuration but
       # not enforced on every Salt run, in case of user customization.
       - label: green
-      - template: sd-large-debian-{{ sdvars.debian_version }}
+      - template: sd-viewer-debian-{{ sdvars.debian_version }}
     - prefs:
-      - template: sd-large-debian-{{ sdvars.debian_version }}
+      - template: sd-viewer-debian-{{ sdvars.debian_version }}
       - netvm: ""
       - template_for_dispvms: True
       - default_dispvm: ""
@@ -55,7 +55,7 @@ sd-viewer:
         - service.paxctld
         - service.securedrop-mime-handling
     - require:
-      - qvm: sd-large-debian-{{ sdvars.debian_version }}
+      - qvm: sd-viewer-debian-{{ sdvars.debian_version }}
 
 
 # Set sd-viewer as the global default_dispvm

--- a/securedrop_salt/sd-workstation-template.sls
+++ b/securedrop_salt/sd-workstation-template.sls
@@ -8,7 +8,7 @@ include:
   - securedrop_salt.sd-base-template
 
 # Installs consolidated templateVMs:
-{% for template_prefix in ["sd-small", "sd-large"] %}
+{% for template_prefix in ["sd-inbox", "sd-viewer"] %}
 {{template_prefix}}-debian-{{ sdvars.debian_version }}:
   qvm.vm:
     - clone:

--- a/securedrop_salt/sd-workstation.top
+++ b/securedrop_salt/sd-workstation.top
@@ -27,12 +27,12 @@ base:
 
   sd-base-debian-13:
     - securedrop_salt.sd-base-template-packages
-  sd-small-debian-13:
+  sd-inbox-debian-13:
     - securedrop_salt.sd-logging-setup
     - securedrop_salt.sd-app-files
     - securedrop_salt.sd-proxy-template-files
     - securedrop_salt.sd-gpg-template-files
-  sd-large-debian-13:
+  sd-viewer-debian-13:
     - securedrop_salt.sd-logging-setup
     - securedrop_salt.sd-devices-files
     - securedrop_salt.sd-viewer-files

--- a/securedrop_salt/securedrop-handle-upgrade
+++ b/securedrop_salt/securedrop-handle-upgrade
@@ -83,7 +83,7 @@ elif [[ $TASK == "remove" ]]; then
     # before deleting it.
     # TODO: clean this up, we don't have separate templates anymore and nobody
     # will be upgrading from the original setup
-    for template in sd-small-bookworm-template sd-large-bookworm-template
+    for template in sd-inbox-bookworm-template sd-viewer-bookworm-template
     do
         if qvm-check "${template}" --quiet; then
             shutdown_if_running "${template}"

--- a/tests/base.py
+++ b/tests/base.py
@@ -18,15 +18,15 @@ from qubesadmin.vm import QubesVM
 DEBIAN_VERSION = 13
 DEBIAN_CODENAME = "trixie"
 SD_TEMPLATE_BASE = f"sd-base-debian-{DEBIAN_VERSION}"
-SD_TEMPLATE_LARGE = f"sd-large-debian-{DEBIAN_VERSION}"
-SD_TEMPLATE_SMALL = f"sd-small-debian-{DEBIAN_VERSION}"
+SD_VIEWER_TEMPLATE = f"sd-viewer-debian-{DEBIAN_VERSION}"
+SD_INBOX_TEMPLATE = f"sd-inbox-debian-{DEBIAN_VERSION}"
 
 SD_TAG = "sd-workstation"  # Tag identifying SecureDrop Workstation-managed VMs
 
 # Expectations regarding VMs' existence and versions
 SD_VMS = ["sd-gpg", "sd-log", "sd-proxy", "sd-app", "sd-viewer", "sd-devices", "sd-printers"]
 SD_DVM_TEMPLATES = ["sd-devices-dvm", "sd-proxy-dvm"]
-SD_TEMPLATES = [SD_TEMPLATE_BASE, SD_TEMPLATE_LARGE, SD_TEMPLATE_SMALL]
+SD_TEMPLATES = [SD_TEMPLATE_BASE, SD_VIEWER_TEMPLATE, SD_INBOX_TEMPLATE]
 SD_UNTAGGED_DEPRECATED_VMS = ["sd-retain-logvm"]
 
 CURRENT_FEDORA_VERSION = "43"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,9 +15,9 @@ from qubesadmin.vm import QubesVM
 from sdw_util.config_types import Dom0Config
 from tests.base import (
     CURRENT_FEDORA_TEMPLATE,
+    SD_INBOX_TEMPLATE,
     SD_TEMPLATE_BASE,
-    SD_TEMPLATE_LARGE,
-    SD_TEMPLATE_SMALL,
+    SD_VIEWER_TEMPLATE,
     is_workstation_qube,
 )
 
@@ -98,8 +98,8 @@ def cleanup(request: pytest.FixtureRequest, sdw_tagged_vms: list[QubesVM]) -> It
     app = Qubes()
     for vm_name in [
         SD_TEMPLATE_BASE,
-        SD_TEMPLATE_LARGE,
-        SD_TEMPLATE_SMALL,
+        SD_VIEWER_TEMPLATE,
+        SD_INBOX_TEMPLATE,
         CURRENT_FEDORA_TEMPLATE,
     ]:
         try:

--- a/tests/test_vm_sd_app.py
+++ b/tests/test_vm_sd_app.py
@@ -8,8 +8,8 @@ from qubesadmin.app import VMCollection
 
 from sdw_util.config_types import Dom0Config
 from tests.base import (
+    SD_INBOX_TEMPLATE,
     SD_TAG,
-    SD_TEMPLATE_SMALL,
     QubeWrapper,
 )
 from tests.base import (
@@ -67,7 +67,7 @@ def test_sd_app_config(dom0_config: Dom0Config, qube: QubeWrapper, all_vms: VMCo
     vm = all_vms["sd-app"]
     nvm = vm.netvm
     assert nvm is None
-    assert vm.template.name == SD_TEMPLATE_SMALL
+    assert vm.template.name == SD_INBOX_TEMPLATE
     assert not vm.provides_network
     assert not vm.template_for_dispvms
     assert "service.securedrop-log-server" not in vm.features

--- a/tests/test_vm_sd_gpg.py
+++ b/tests/test_vm_sd_gpg.py
@@ -12,8 +12,8 @@ from qubesadmin.app import VMCollection
 
 from sdw_util.config_types import Dom0Config
 from tests.base import (
+    SD_INBOX_TEMPLATE,
     SD_TAG,
-    SD_TEMPLATE_SMALL,
     QubeWrapper,
 )
 from tests.base import (
@@ -133,7 +133,7 @@ def test_sd_gpg_config(all_vms: VMCollection) -> None:
     nvm = vm.netvm
     assert nvm is None
     # No sd-gpg-template, since keyring is managed in $HOME
-    assert vm.template.name == SD_TEMPLATE_SMALL
+    assert vm.template.name == SD_INBOX_TEMPLATE
     assert vm.autostart
     assert not vm.provides_network
     assert not vm.template_for_dispvms

--- a/tests/test_vm_sd_log.py
+++ b/tests/test_vm_sd_log.py
@@ -14,8 +14,8 @@ from qubesadmin.vm import QubesVM
 from sdw_util.config_types import Dom0Config
 from tests.base import (
     DEBIAN_VERSION,
+    SD_INBOX_TEMPLATE,
     SD_TAG,
-    SD_TEMPLATE_SMALL,
     QubeWrapper,
 )
 from tests.base import (
@@ -118,7 +118,7 @@ def test_sd_log_config(qube: QubeWrapper, dom0_config: Dom0Config, all_vms: VMCo
     vm = all_vms["sd-log"]
     nvm = vm.netvm
     assert nvm is None
-    assert vm.template.name == SD_TEMPLATE_SMALL
+    assert vm.template.name == SD_INBOX_TEMPLATE
     assert vm.autostart
     assert not vm.provides_network
     assert not vm.template_for_dispvms

--- a/tests/test_vm_sd_proxy.py
+++ b/tests/test_vm_sd_proxy.py
@@ -8,8 +8,8 @@ from qubesadmin.app import VMCollection
 
 from sdw_util.config_types import Dom0Config
 from tests.base import (
+    SD_INBOX_TEMPLATE,
     SD_TAG,
-    SD_TEMPLATE_SMALL,
     QubeWrapper,
 )
 from tests.base import (
@@ -112,7 +112,7 @@ def test_sd_proxy_dvm_config(all_vms: VMCollection, dom0_config: Dom0Config) -> 
     assert vm.template_for_dispvms
     assert vm.netvm is not None
     assert vm.netvm.name == "sys-firewall"
-    assert vm.template.name == SD_TEMPLATE_SMALL
+    assert vm.template.name == SD_INBOX_TEMPLATE
     assert vm.default_dispvm is None
     assert SD_TAG in vm.tags
     assert not vm.autostart

--- a/tests/test_vm_sd_viewer.py
+++ b/tests/test_vm_sd_viewer.py
@@ -13,7 +13,7 @@ from qubesadmin.app import VMCollection
 from sdw_util.config_types import Dom0Config
 from tests.base import (
     SD_TAG,
-    SD_TEMPLATE_LARGE,
+    SD_VIEWER_TEMPLATE,
     QubeWrapper,
 )
 from tests.base import (
@@ -119,7 +119,7 @@ def test_logging_configured(qube: QubeWrapper) -> None:
 def test_redis_packages_not_installed(qube: QubeWrapper) -> None:
     """
     Only the log collector, i.e. sd-log, needs redis, so redis will be
-    present in small template, but not in large.
+    present in the inbox template, but not in the viewer.
     """
     assert not qube.package_is_installed("redis")
     assert not qube.package_is_installed("redis-server")
@@ -150,7 +150,7 @@ def test_sd_viewer_config(all_vms: VMCollection, dom0_config: Dom0Config) -> Non
     vm = all_vms["sd-viewer"]
     nvm = vm.netvm
     assert nvm is None
-    assert vm.template.name == SD_TEMPLATE_LARGE
+    assert vm.template.name == SD_VIEWER_TEMPLATE
     assert not vm.provides_network
     assert vm.template_for_dispvms
     assert SD_TAG in vm.tags

--- a/tests/test_vms_exist.py
+++ b/tests/test_vms_exist.py
@@ -4,11 +4,11 @@ from qubesadmin.vm import QubesVM
 
 from tests.base import (
     SD_DVM_TEMPLATES,
+    SD_INBOX_TEMPLATE,
     SD_TAG,
-    SD_TEMPLATE_LARGE,
-    SD_TEMPLATE_SMALL,
     SD_TEMPLATES,
     SD_UNTAGGED_DEPRECATED_VMS,
+    SD_VIEWER_TEMPLATE,
     SD_VMS,
 )
 from tests.conftest import skip_on_qubes_4_2
@@ -108,20 +108,20 @@ def test_whonix_vms_reset(whonix_vm_name: str, all_vms: VMCollection) -> None:
 
 
 @pytest.mark.provisioning
-def test_sd_small_template(all_vms: VMCollection) -> None:
+def test_sd_inbox_template(all_vms: VMCollection) -> None:
     """
-    Confirm that the "small" version of the SDW TemplateVM is configured correctly.
+    Confirm that the "inbox" version of the SDW TemplateVM is configured correctly.
     """
-    vm = all_vms[SD_TEMPLATE_SMALL]
+    vm = all_vms[SD_INBOX_TEMPLATE]
     assert vm.netvm is None
     assert SD_TAG in vm.tags
 
 
 @pytest.mark.provisioning
-def test_sd_large_template(all_vms: VMCollection) -> None:
+def test_sd_viewer_template(all_vms: VMCollection) -> None:
     """
-    Confirm that the "large" version of the SDW TemplateVM is configured correctly.
+    Confirm that the "viewer" version of the SDW TemplateVM is configured correctly.
     """
-    vm = all_vms[SD_TEMPLATE_LARGE]
+    vm = all_vms[SD_VIEWER_TEMPLATE]
     assert vm.netvm is None
     assert SD_TAG in vm.tags

--- a/tests/test_vms_platform.py
+++ b/tests/test_vms_platform.py
@@ -10,8 +10,8 @@ from sdw_util.config_types import Dom0Config
 from tests.base import (
     CURRENT_FEDORA_TEMPLATE,
     DEBIAN_CODENAME,
-    SD_TEMPLATE_LARGE,
-    SD_TEMPLATE_SMALL,
+    SD_INBOX_TEMPLATE,
+    SD_VIEWER_TEMPLATE,
     SD_VMS,
 )
 
@@ -137,8 +137,8 @@ def test_qubes_vm_update_ran_on_fedora_template(all_vms: VMCollection) -> None:
     "vm_name",
     [
         CURRENT_FEDORA_TEMPLATE,
-        SD_TEMPLATE_LARGE,
-        SD_TEMPLATE_SMALL,
+        SD_VIEWER_TEMPLATE,
+        SD_INBOX_TEMPLATE,
     ],
 )
 def test_os_eol(vm_name: str, all_vms: VMCollection) -> None:
@@ -188,8 +188,8 @@ def test_sd_vm_apt_sources(dom0_config: Dom0Config, all_vms: VMCollection) -> No
     Test that the three templates we install our apt sources into are correct
     """
     for vm_name in [
-        SD_TEMPLATE_SMALL,
-        SD_TEMPLATE_LARGE,
+        SD_INBOX_TEMPLATE,
+        SD_VIEWER_TEMPLATE,
     ]:
         vm = all_vms[vm_name]
 


### PR DESCRIPTION
Completes the template rename discussed in #1722.

**NOTE:** I decided to split this one off from #1712 because it's a large one, but pretty repetitive. I'll have another one to tackle in #1712. Upgrade is still expected to fail in this PR. (CC @legoktm)

## Test plan
- [ ] look in the code if there are no more missing `small` / `large` references

Post-merge:
  - [ ] docs changes to fix old template name references

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
