### PR TITLE
Update test_mime_types for switch to gnome-text-editor

### DIFF
--- a/tests/vars/sd-viewer.mimeapps
+++ b/tests/vars/sd-viewer.mimeapps
@@ -1,5 +1,5 @@
 [Default Applications]
-text/plain=org.gnome.gedit.desktop
+text/plain=org.gnome.TextEditor.desktop
 text/csv=libreoffice-base.desktop
 application/vnd.oasis.opendocument.text=libreoffice-base.desktop
 application/vnd.oasis.opendocument.spreadsheet=libreoffice-base.desktop
@@ -11,7 +11,7 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document=libreoff
 application/vnd.openxmlformats-officedocument.spreadsheetml.sheet=libreoffice-base.desktop
 application/vnd.openxmlformats-officedocument.presentationml.presentation=libreoffice-base.desktop
 application/pdf=org.gnome.Evince.desktop
-application/x-desktop=org.gnome.gedit.desktop
+application/x-desktop=org.gnome.TextEditor.desktop
 audio/mp4=audacious.desktop
 audio/mpeg=audacious.desktop
 audio/x-vorbis+ogg=audacious.desktop


### PR DESCRIPTION
Refs <https://github.com/freedomofpress/securedrop-client/pull/3524>.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] test passes in OpenQA
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
