### PR TITLE
try-client-pr: Remove obsolete Inbox special-casing

### DIFF
--- a/scripts/try-client-pr.py
+++ b/scripts/try-client-pr.py
@@ -106,9 +106,6 @@ def install_debs_in_template(all_deb_paths: list[str], template_vm: str) -> None
     )
     assert dpkg_output is not None  # noqa: S101
     wanted_packages = dpkg_output.splitlines()
-    if "securedrop-client" in wanted_packages:
-        # If this is the VM where the client is installed, also install the app
-        wanted_packages.append("securedrop-app")
     print(f"Going to install into {template_vm}: {', '.join(wanted_packages)}")
 
     template_deb_paths = []


### PR DESCRIPTION
Before we used to install the Inbox by default we special-cased it by piggybacking off the securedrop-client package. Except that package is gone now, so this code is totally obsolete.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] visual review is fine
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
