### PR TITLE
Fix nightlies when there's only one version

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -49,7 +49,6 @@ jobs:
           if-no-files-found: error
 
   commit-and-push:
-    if: ${{ github.ref == 'refs/heads/main' }} # Skip when testing workflow
     runs-on: ubuntu-latest
     container: debian:bookworm
     needs:
@@ -79,10 +78,7 @@ jobs:
           private-key: ${{ secrets.FPF_BRANCH_UPDATER_APP_PRIVKEY }}
           repositories: securedrop-yum-test
 
-      - name: Commit and push
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          TARGET_REPO: freedomofpress/securedrop-yum-test
+      - name: Commit
         run: |
           git config --global user.email "securedrop@freedom.press"
           git config --global user.name "sdcibot-nightlies[bot]"
@@ -94,7 +90,17 @@ jobs:
           done
           git add .
           git diff-index --quiet HEAD || git commit -m "Automated SecureDrop workstation build"
-          # Sleep before we push so the token will have propagated across GitHub infra 
+
+      # Skip the push on dry runs (e.g. workflow-testing PRs); the commit above
+      # still validates the build/copy logic.
+      - name: Push
+        if: ${{ github.ref == 'refs/heads/main' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TARGET_REPO: freedomofpress/securedrop-yum-test
+        run: |
+          cd securedrop-yum-test
+          # Sleep before we push so the token will have propagated across GitHub infra
           sleep 5
           git push https://x-access-token:${GH_TOKEN}@github.com/${TARGET_REPO}.git main
 

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -61,7 +61,9 @@ jobs:
 
       - uses: actions/download-artifact@v8
         with:
-          pattern: "*"
+          pattern: "rpm-build-*"
+          merge-multiple: true
+          path: rpms
 
       - uses: actions/checkout@v6
         with:
@@ -85,8 +87,11 @@ jobs:
           git config --global user.email "securedrop@freedom.press"
           git config --global user.name "sdcibot-nightlies[bot]"
           cd securedrop-yum-test
-          mkdir -p workstation/dom0/f41-nightlies
-          cp -v ../rpm-build-41/*.rpm workstation/dom0/f41-nightlies/
+          for version in fc41; do
+            dest="workstation/dom0/${version/fc/f}-nightlies"
+            mkdir -p "$dest"
+            cp -v ../rpms/*.${version}.*.rpm "$dest/"
+          done
           git add .
           git diff-index --quiet HEAD || git commit -m "Automated SecureDrop workstation build"
           # Sleep before we push so the token will have propagated across GitHub infra 


### PR DESCRIPTION
Fixes #1743.

See commit messages for description

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] commit-and-push job passes 
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
