### PR TITLE
Fix install over different versions in prep-script

### DIFF
--- a/scripts/prep-dev
+++ b/scripts/prep-dev
@@ -37,7 +37,10 @@ fi
 
 echo "Deploying Salt config..."
 sudo dnf clean all
-if rpm -q "$rpm_name" > /dev/null 2>&1; then
+
+# Full name needed to compare against installed version
+pkg_full_name=$(basename "$latest_rpm" | sed -e 's/.rpm//g')
+if rpm -q "$pkg_full_name" > /dev/null 2>&1; then
     echo "Reinstalling $latest_rpm ..."
     sudo dnf reinstall -y "$latest_rpm"
 else


### PR DESCRIPTION
Fixes #1746

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
- [x] Version upgrades works:
  - [x] install latest prod
  - [x] checkout this repo in `sd-dev`
  - [x] run `make clone && ./scripts/prep-dev` observe failure to install (if running full `make dev` this might have been harder to spot):
      ```
      [...]
      Packages for argument 'securedrop-workstation-dom0-config-1.8.0rc1-1.fc41.noarch' available, but not installed.
      ```
- [x] Reinstalling same version
   - [x] run `./scripts/prep-dev` multiple times and ensure it keeps reinstalling the package
- [ ] Downgrades (not really a common scenario, so not sure if worth testing)
 
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
