### PR TITLE
Rename sd-admin's template use `debian-13` in name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,8 +128,8 @@ sd-admin: assert-dom0 ## Provision sd-admin VM and install securedrop-admin
 	@echo "Creating sd-admin template and AppVM..."
 	sudo qubesctl --show-output -- state.sls admin_salt.sd-admin
 	@echo "Installing packages inside sd-admin-debian-13..."
-	sudo qubesctl --show-output --skip-dom0 --targets sd-admin-trixie-template -- state.sls admin_salt.sd-admin-packages
-	qvm-shutdown --wait -- sd-admin-trixie-template
+	sudo qubesctl --show-output --skip-dom0 --targets sd-admin-debian-13 -- state.sls admin_salt.sd-admin-packages
+	qvm-shutdown --wait -- sd-admin-debian-13
 
 clone: assert-dom0 ## Builds rpm && pulls the latest repo from work VM to dom0
 	@./scripts/clone-to-dom0

--- a/admin_salt/sd-admin-packages.sls
+++ b/admin_salt/sd-admin-packages.sls
@@ -3,7 +3,7 @@
 
 ##
 # Configures the FPF apt repository and installs securedrop-admin
-# inside the sd-admin-trixie-template VM.
+# inside the sd-admin-debian-13 VM.
 #
 # Mirrors the approach in securedrop_salt/fpf-apt-repo.sls and
 # securedrop_salt/sd-base-template-packages.sls, but uses duplicated

--- a/admin_salt/sd-admin-template.sls
+++ b/admin_salt/sd-admin-template.sls
@@ -9,9 +9,9 @@ dom0-install-debian-13-template:
 
 # N.B. hardcoding "trixie" rather than reading from sdvars to decouple
 # the sd-admin config from the rest of the SDW config during prototyping.
-sd-admin-trixie-template:
+sd-admin-debian-13:
   qvm.vm:
-    - name: sd-admin-trixie-template
+    - name: sd-admin-debian-13
     - clone:
       - source: debian-13
       - label: red

--- a/admin_salt/sd-admin.sls
+++ b/admin_salt/sd-admin.sls
@@ -17,9 +17,9 @@ sd-admin:
     - name: sd-admin
     - present:
       - label: red
-      - template: sd-admin-trixie-template
+      - template: sd-admin-debian-13
     - prefs:
-      - template: sd-admin-trixie-template
+      - template: sd-admin-debian-13
       - netvm: sys-firewall
       - autostart: false
       - default_dispvm: ""
@@ -28,4 +28,4 @@ sd-admin:
         - sd-workstation
         - sd-admin
     - require:
-      - qvm: sd-admin-trixie-template
+      - qvm: sd-admin-debian-13

--- a/admin_salt/sd-admin.top
+++ b/admin_salt/sd-admin.top
@@ -6,5 +6,5 @@ base:
     - admin_salt.sd-admin-template
     - admin_salt.sd-admin
 
-  sd-admin-trixie-template:
+  sd-admin-debian-13:
     - admin_salt.sd-admin-packages


### PR DESCRIPTION
Follow the convention established in #1722:
- old: `sd-admin-trixie-template`
- new: `sd-admin-debian-13`

This way it's consistent with the other templates: sd-viewer-debian-13 and sd-inbox-debian-13

Fixes #1722

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
Prep:
1. sd-dev: `make build-admin-rpm`
2. dom0: 
   - `make clone-norpm`
   - `install install-admin-rpm`

Testing:
 - [ ]  in dom0: `make sd-admin` runs successfully
 - [ ] `sd-admin` is based on `sd-admin-debian-13` 

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
