### PR TITLE
Move upgrade script back into salt

### DIFF
--- a/files/sdw-admin.py
+++ b/files/sdw-admin.py
@@ -10,9 +10,6 @@ import json
 import os
 import subprocess
 import sys
-from collections.abc import Callable, Iterator
-from contextlib import ContextDecorator, contextmanager
-from typing import Literal
 
 from qubesadmin import Qubes
 from qubesadmin.vm import QubesVM
@@ -145,110 +142,6 @@ def run_cmd(args: list[str]) -> None:
         raise SDWAdminException(f"Error while running {' '.join(args)}")
 
 
-@contextmanager
-def suppress_preloaded_disposables() -> Iterator[None]:
-    """
-    Temporarily disable preloaded disposables during provisioning
-    """
-    print("[info] Temporarily disabling preloaded disposables")
-
-    # Save current settings
-    dom0 = Qubes().domains["dom0"]
-    original_preload_dispvm_max = dom0.features.get("preload-dispvm-max", "0")
-
-    # Disable preloaded disposables
-    dom0.features["preload-dispvm-max"] = "0"
-
-    try:
-        yield
-    finally:
-        print("[info] Re-enabling preloaded disposables")
-
-        # Reset to original settings
-        dom0.features["preload-dispvm-max"] = original_preload_dispvm_max
-
-
-class template_upgrade_handler(ContextDecorator):
-    """
-    Temporarily prevents startup of managed qubes
-
-    Necessary during provisioning, particularly in template changes, where
-    all qubes dependent on a template (including disposables only
-    indirectly based on it) need to be shut down, otherwise provisioning fails.
-
-    NOTE: deferred template changes may make this redundant
-    https://github.com/qubesos/qubes-issues/issues/8070
-    """
-
-    def __enter__(self) -> Callable[..., ContextDecorator]:
-        self.app = Qubes()
-
-        self.skip_upgrade_handler = self.template_upgrades_needed()
-        if self.skip_upgrade_handler:
-            return self
-
-        print("[info] Temporarily disabling startup for managed qubes.")
-        # Exclude:
-        #   - the ones already with prohibit-start for unrelated reasons
-        #   - preloaded disposables
-        self.excluded = [
-            q
-            for q in self.app.domains
-            if "sd-workstation" in q.tags
-            if ("prohibit-start" in q.features or not is_managed(q))
-        ]
-
-        affected_qubes = self.affected_qubes()
-        for qube in affected_qubes:
-            qube.features["prohibit-start"] = "disabled during set up"
-
-        # Use of qvm-shutdown since it can somewhat handle dependencies
-        shutdown_list = [q.name for q in affected_qubes]
-        if shutdown_list:
-            run_cmd(["qvm-shutdown", "--wait", "--"] + shutdown_list)
-
-        return self
-
-    def __exit__(self, *exc: object) -> Literal[False]:
-        # No cleanup needed, because it never ran
-        if self.skip_upgrade_handler:
-            return False
-
-        print("[info] Re-enabling startup for managed qubes.")
-
-        # Obtain the list again since:
-        #  - some qubes may have been removed (e.g. old templates)
-        #  - some cloned qubes may have inherited prohibit-startup
-        for qube in self.affected_qubes():
-            if "prohibit-start" in qube.features:
-                del qube.features["prohibit-start"]
-
-        return False
-
-    def affected_qubes(self) -> list[QubesVM]:
-        # IMPORTANT: List of qubes may have changed
-        self.app.domains.refresh_cache(force=True)
-
-        return [
-            q
-            for q in self.app.domains
-            if ("sd-workstation" in q.tags and q not in self.excluded and is_managed(q))
-        ]
-
-    def template_upgrades_needed(self) -> bool:
-        # NOTE: a more clever detection is warranted, but inspecting what salt is going
-        # to do is not a particular thing salt is good at. This is left here for when
-        # re-implemented with another IaC tool that doesn't need wrapper scripts like these.
-        templ_current_version_checks = [
-            q.features["os-version"] == DEBIAN_VERSION
-            for q in Qubes().domains
-            if ("sd-workstation" in q.tags and q.klass == "TemplateVM")
-        ]
-
-        # Ignore if all templates are using the intended version
-        return all(templ_current_version_checks)
-
-
 def provision(step_description: str, salt_state: str) -> None:
     """
     Create, change or delete qubes
@@ -259,7 +152,6 @@ def provision(step_description: str, salt_state: str) -> None:
     )
 
 
-@template_upgrade_handler()
 def provision_all() -> None:
     """
     Provision all enabled salt states
@@ -701,8 +593,7 @@ def main() -> None:
         validate_config(SCRIPTS_PATH)
         copy_config()
         refresh_salt()
-        with suppress_preloaded_disposables():
-            provision_and_configure()
+        provision_and_configure()
         print("Provisioning complete. Please reboot to complete the installation.")
 
     elif args.uninstall:

--- a/files/sdw-admin.py
+++ b/files/sdw-admin.py
@@ -14,6 +14,7 @@ import sys
 from qubesadmin import Qubes
 from qubesadmin.vm import QubesVM
 
+from sdw_updater.Updater import DEBIAN_VERSION
 from sdw_util.config_types import ValidationError
 
 # The max concurrency reduction (4->2) was required to avoid "did not return clean data"
@@ -26,7 +27,6 @@ DEFAULT_SD_LOG_GB = 5
 SCRIPTS_PATH = "/usr/share/securedrop-workstation-dom0-config/"
 SALT_PATH = "/srv/salt/securedrop_salt/"
 
-DEBIAN_VERSION = "13"
 BASE_TEMPLATE = f"debian-{DEBIAN_VERSION}-minimal"
 
 SUBMISSION_KEY = "sd-journalist.sec"

--- a/files/sdw-admin.py
+++ b/files/sdw-admin.py
@@ -37,13 +37,6 @@ TAILS_GIT_JOURNALIST_INTERFACE_CONFIG = (
     TAILS_PATH + "Persistent/securedrop/install_files/ansible-base/app-journalist.auth_private"
 )
 
-# Salt pillar override to make sure dom0 states do not re-enable
-# preloaded dispvms. Needed due to inclusion of 'qvm.preload-disposables'
-# indirectly via 'qvm.default-dvm'. Removing this does not mean preloaded
-# disposables are disabled. Just that they don't get enabled on provisioning.
-# FIXME: https://github.com/freedomofpress/securedrop-workstation/issues/1523
-PILLAR_DISABLE_PRELOAD = {"qvm": {"dom0": {"preload": False}}}
-
 sys.path.insert(1, os.path.join(SCRIPTS_PATH, "scripts/"))
 from validate_config import SDWConfigValidator  # noqa: E402
 
@@ -148,7 +141,7 @@ def provision(step_description: str, salt_state: str) -> None:
     """
     qubesctl_call(
         step_description,
-        ["--", "state.sls", salt_state, f"pillar={json.dumps(PILLAR_DISABLE_PRELOAD)}"],
+        ["--", "state.sls", salt_state],
     )
 
 
@@ -158,7 +151,7 @@ def provision_all() -> None:
     """
     qubesctl_call(
         "Set up dom0 config files, including RPC policies, and create VMs",
-        ["state.highstate", f"pillar={json.dumps(PILLAR_DISABLE_PRELOAD)}"],
+        ["state.highstate"],
     )
 
 

--- a/sdw_updater/Updater.py
+++ b/sdw_updater/Updater.py
@@ -38,22 +38,22 @@ MIGRATION_DIR = "/tmp/sdw-migrations"
 sdlog = Util.get_logger(module=__name__)
 detail_log = Util.get_logger(prefix=DETAIL_LOGGER_PREFIX, module=__name__)
 
+DEBIAN_VERSION = "13"
+
 
 def _get_current_vms() -> dict[str, str]:
-    debian_version = "13"
-
     # The are the TemplateVMs that require full patch level at boot in order to start the inbox,
     # as well as their associated TemplateVMs.
     # In the future, we could use qvm-prefs to extract this information.
     return {
         "fedora": "fedora-43-xfce",
-        "sd-viewer": f"sd-viewer-debian-{debian_version}",
-        "sd-app": f"sd-inbox-debian-{debian_version}",
-        "sd-log": f"sd-inbox-debian-{debian_version}",
-        "sd-devices": f"sd-viewer-debian-{debian_version}",
-        "sd-printers": f"sd-viewer-debian-{debian_version}",
-        "sd-proxy": f"sd-inbox-debian-{debian_version}",
-        "sd-gpg": f"sd-inbox-debian-{debian_version}",
+        "sd-viewer": f"sd-viewer-debian-{DEBIAN_VERSION}",
+        "sd-app": f"sd-inbox-debian-{DEBIAN_VERSION}",
+        "sd-log": f"sd-inbox-debian-{DEBIAN_VERSION}",
+        "sd-devices": f"sd-viewer-debian-{DEBIAN_VERSION}",
+        "sd-printers": f"sd-viewer-debian-{DEBIAN_VERSION}",
+        "sd-proxy": f"sd-inbox-debian-{DEBIAN_VERSION}",
+        "sd-gpg": f"sd-inbox-debian-{DEBIAN_VERSION}",
     }
 
 

--- a/securedrop_salt/sd-sys-vms.sls
+++ b/securedrop_salt/sd-sys-vms.sls
@@ -4,13 +4,22 @@
 # Ensures that sys-* VMs (viz. sys-net, sys-firewall, sys-usb) use
 # an up-to-date version of Fedora, in order to receive security updates.
 
-include:
-  # Import the upstream Qubes-maintained default-dispvm to ensure Fedora-based
-  # DispVM is created.
-  # WARNING: this includes indirectly 'qvm.preload-disposables', which reverts
-  # any temporary disabling of disposable preloading. To avoid this, the pillar
-  # 'qvm:dom0:preload' needs to be overridden as 'false'.
-  - qvm.default-dispvm
+# Import the upstream Qubes-maintained default-dispvm to ensure Fedora-based
+# DispVM is created.
+# WARNING: this includes indirectly 'qvm.preload-disposables', which reverts
+# any temporary disabling of disposable preloading. To avoid this, the pillar
+# 'qvm:dom0:preload' needs to be overridden as 'false'. Removing this does not
+# mean preloaded disposables are disabled. Just that they don't get enabled
+# on provisioning.
+# FIXME: https://github.com/freedomofpress/securedrop-workstation/issues/1523
+default_dvm_with_custom_pillar:
+  module.run:
+    - state.apply:
+      - mods: qvm.default-dispvm
+      - pillar:
+          qvm:
+            dom0:
+              preload: false
 
 # 4.2 fedora template is fedora-NN-xfce, but let's keep the dvm names to
 # follow simple - like sd-fedora-NN-dvm
@@ -61,7 +70,7 @@ set-fedora-default-template-version:
     - name: qubes-prefs default_template {{ sd_fedora_base_template }}
     - require:
       - qvm: dom0-install-fedora-template
-      - sls: qvm.default-dispvm
+      - module: default_dvm_with_custom_pillar
 
 # On 4.1, several sys qubes are disposable by default - since we also want to
 # upgrade the templates for those, we need to ensure that the respective dvms

--- a/securedrop_salt/sd-upgrade-templates.sls
+++ b/securedrop_salt/sd-upgrade-templates.sls
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+{% import_json "securedrop_salt/config.json" as d %}
+{% if d.environment == "dev" %}
+  {% set cmd_opts = "--debug" %}
+{% else %}
+  {% set cmd_opts = "" %}
+{% endif %}
+
+
+run-prep-upgrade-scripts:
+  cmd.run:
+    - name: /srv/salt/securedrop_salt/template_upgrade_helper.py start {{ cmd_opts }}
+    - order: first
+    - failhard: True
+
+
+run-post-upgrade-scripts:
+  cmd.run:
+    - name: /srv/salt/securedrop_salt/template_upgrade_helper.py finish {{ cmd_opts }}
+    - order: last
+    - failhard: False  # Ensure this always runs so cleanup happens
+

--- a/securedrop_salt/sd-workstation.top
+++ b/securedrop_salt/sd-workstation.top
@@ -9,6 +9,7 @@ base:
     - securedrop_salt.sd-dom0-files
     - securedrop_salt.sd-base-template
     - securedrop_salt.sd-workstation-template
+    - securedrop_salt.sd-upgrade-templates
     - securedrop_salt.sd-log
     - securedrop_salt.sd-devices
     - securedrop_salt.sd-printers

--- a/securedrop_salt/template_upgrade_helper.py
+++ b/securedrop_salt/template_upgrade_helper.py
@@ -33,6 +33,16 @@ app = qubesadmin.Qubes()
 
 
 def start_template_upgrade() -> None:
+    """
+    Temporarily prevents startup of managed qubes
+
+    Necessary during provisioning, particularly in template changes, where
+    all qubes dependent on a template (including disposables only
+    indirectly based on it) need to be shut down, otherwise provisioning fails.
+
+    NOTE: deferred template changes may make this redundant
+    https://github.com/qubesos/qubes-issues/issues/8070
+    """
     # Exclude:
     #   - the ones already with prohibit-start for unrelated reason
     #   - preloaded disposables

--- a/securedrop_salt/template_upgrade_helper.py
+++ b/securedrop_salt/template_upgrade_helper.py
@@ -24,7 +24,7 @@ from sdw_updater.Updater import DEBIAN_VERSION
 # Logging set up
 log = logging.getLogger(Path(__file__).name)
 
-PROHIBIT_START_REASON = "disabled during set up"
+PROHIBIT_START_REASON = "SDW: disabled during set up"
 PRELOAD_MAX_TMP_FEAT_NAME = "preload-dispvm-max-saved"
 
 app = qubesadmin.Qubes()

--- a/securedrop_salt/template_upgrade_helper.py
+++ b/securedrop_salt/template_upgrade_helper.py
@@ -26,6 +26,12 @@ log = logging.getLogger(Path(__file__).name)
 
 PROHIBIT_START_REASON = "SDW: disabled during set up"
 
+# If the script gets abruptly executed at the right point we may loose
+# the actual number of disposable VMs. Either that or it was never set
+# for some unexplicable circumstance. Since 32GB is the recommended RAM
+# having 2 as the default (in case of breakage) it should be acceptable.
+SANE_N_DISPVMS = "2"
+
 # qubes-feature name to temporarily hold the number of preloeaded disposables
 PRELOAD_MAX_TMP_FEAT_NAME = "preload-dispvm-max-saved"
 
@@ -117,7 +123,9 @@ def start_suppress_preloaded_disposables() -> None:
     dom0 = app.domains["dom0"]
 
     # Save current settings (use dom0 features as way to save state)
-    dom0.features[PRELOAD_MAX_TMP_FEAT_NAME] = dom0.features.get("preload-dispvm-max", "0")
+    dom0.features[PRELOAD_MAX_TMP_FEAT_NAME] = dom0.features.get(
+        "preload-dispvm-max", SANE_N_DISPVMS
+    )
 
     # Disable preloaded disposables (they will start shutting down immediately)
     dom0.features["preload-dispvm-max"] = "0"
@@ -141,7 +149,9 @@ def finish_suppress_preloaded_disposables() -> None:
     dom0 = app.domains["dom0"]
 
     # Reset to original settings
-    dom0.features["preload-dispvm-max"] = dom0.features.get(PRELOAD_MAX_TMP_FEAT_NAME, "2")
+    dom0.features["preload-dispvm-max"] = dom0.features.get(
+        PRELOAD_MAX_TMP_FEAT_NAME, SANE_N_DISPVMS
+    )
     if dom0.features.get(PRELOAD_MAX_TMP_FEAT_NAME) is None:
         del dom0.features[PRELOAD_MAX_TMP_FEAT_NAME]
 

--- a/securedrop_salt/template_upgrade_helper.py
+++ b/securedrop_salt/template_upgrade_helper.py
@@ -1,0 +1,160 @@
+#!/usr/bin/python3
+"""
+Temporarily prevents startup of managed qubes
+
+Necessary during provisioning, particularly in template changes, where
+all qubes dependent on a template (including disposables only
+indirectly based on it) need to be shut down, otherwise provisioning fails.
+
+NOTE: deferred template changes may make this redundant
+https://github.com/qubesos/qubes-issues/issues/8070
+"""
+
+import argparse
+import logging
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import qubesadmin
+
+from sdw_updater.Updater import DEBIAN_VERSION
+
+# Logging set up
+log = logging.getLogger(Path(__file__).name)
+
+PROHIBIT_START_REASON = "disabled during set up"
+PRELOAD_MAX_TMP_FEAT_NAME = "preload-dispvm-max-saved"
+
+app = qubesadmin.Qubes()
+
+
+def start_template_upgrade() -> None:
+    # Exclude:
+    #   - the ones already with prohibit-start for unrelated reason
+    #   - preloaded disposables
+    affected_qubes = [
+        q
+        for q in app.domains
+        if (
+            "sd-workstation" in q.tags
+            and "prohibit-start" not in q.features
+            and not getattr(q, "is_preload", False)
+        )
+    ]
+
+    log.info(
+        "Temporarily disabling startup for managed qubes: "
+        + ",".join([q.name for q in affected_qubes])
+    )
+    for qube in affected_qubes:
+        qube.features["prohibit-start"] = PROHIBIT_START_REASON
+
+    # Use of qvm-shutdown since it can somewhat handle dependencies
+    shutdown_list = [q.name for q in affected_qubes]
+    if shutdown_list:
+        try:
+            subprocess.run(["qvm-shutdown", "--wait", "--"] + shutdown_list, check=True)
+        except subprocess.CalledProcessError:
+            # Some qubes may take too long to shut down. See
+            # https://github.com/freedomofpress/securedrop-workstation/issues/1751
+            stubborn_qubes = [q.name for q in affected_qubes if not q.is_halted()]
+            log.debug(f"Killing stubborn qubes: {stubborn_qubes}")
+            subprocess.run(["qvm-kill", "--"] + stubborn_qubes, check=True)
+
+
+def finish_template_upgrade() -> None:
+    log.info("Re-enabling startup for managed qubes.")
+
+    # Obtain the list again since:
+    #  - some qubes may have been removed (e.g. old templates)
+    #  - some cloned qubes may have inherited prohibit-startup
+    for qube in app.domains:
+        if qube.features.get("prohibit-start") == PROHIBIT_START_REASON:
+            del qube.features["prohibit-start"]
+
+
+def template_upgrades_needed() -> bool:
+    # NOTE: a more clever detection is warranted, but inspecting what salt is going
+    # to do is not a particular thing salt is good at. This is left here for when
+    # re-implemented with another IaC tool that doesn't need wrapper scripts like these.
+    templ_current_version_checks = [
+        q.features["os-version"] == DEBIAN_VERSION
+        for q in app.domains
+        if ("sd-workstation" in q.tags and q.klass == "TemplateVM")
+    ]
+
+    # Ignore if all templates are using the intended version
+    is_needed = not all(templ_current_version_checks)
+
+    log.debug(f"Upgrade templates: {is_needed}")
+    return is_needed
+
+
+def start_suppress_preloaded_disposables() -> None:
+    """
+    Temporarily disable preloaded disposables during provisioning
+
+    This is necessary due to the risk due to a race due to preloaded disposables starting right
+    after there's a template switch, but failing to, due to their dvm template having
+    prohibit-start. This would leave unstarted 'dispXXXX' on disk with 'sd-workstation' tags but
+    that don't report as being preloaded.
+    """
+    log.info("Temporarily disabling preloaded disposables")
+    dom0 = app.domains["dom0"]
+
+    # Save current settings (use dom0 features as way to save state)
+    dom0.features[PRELOAD_MAX_TMP_FEAT_NAME] = dom0.features.get("preload-dispvm-max", "0")
+
+    # Disable preloaded disposables (they will start shutting down immediately)
+    dom0.features["preload-dispvm-max"] = "0"
+
+    # Wait for preload disposables to shut down
+    for attempt in range(1, 11):
+        if not any([q for q in app.domains if getattr(q, "is_preload", False)]):
+            break
+
+        log.debug("Waiting for preloaded disposables to shut down...")
+        time.sleep(3)
+
+
+def finish_suppress_preloaded_disposables() -> None:
+    """
+    Re-enable preloaded disposable qubes
+
+    NOTE: this must be safe to run even if start did not run (in case of partial failure)
+    """
+    log.info("Re-enabling preloaded disposables")
+    dom0 = app.domains["dom0"]
+
+    # Reset to original settings
+    dom0.features["preload-dispvm-max"] = dom0.features.get(PRELOAD_MAX_TMP_FEAT_NAME, "2")
+    if dom0.features.get(PRELOAD_MAX_TMP_FEAT_NAME) is None:
+        del dom0.features[PRELOAD_MAX_TMP_FEAT_NAME]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("action", choices=["start", "finish"])
+    parser.add_argument("--debug", "-d", action="store_true", help="enable debug output")
+    args = parser.parse_args()
+
+    if args.debug:
+        logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.INFO)
+
+    if args.action == "start":
+        if template_upgrades_needed():
+            start_suppress_preloaded_disposables()
+            start_template_upgrade()
+        else:
+            log.info("Template upgrade not necessary")
+    elif args.action == "finish":
+        finish_template_upgrade()
+        finish_suppress_preloaded_disposables()
+
+
+if __name__ == "__main__":
+    main()

--- a/securedrop_salt/template_upgrade_helper.py
+++ b/securedrop_salt/template_upgrade_helper.py
@@ -25,6 +25,8 @@ from sdw_updater.Updater import DEBIAN_VERSION
 log = logging.getLogger(Path(__file__).name)
 
 PROHIBIT_START_REASON = "SDW: disabled during set up"
+
+# qubes-feature name to temporarily hold the number of preloeaded disposables
 PRELOAD_MAX_TMP_FEAT_NAME = "preload-dispvm-max-saved"
 
 app = qubesadmin.Qubes()


### PR DESCRIPTION
Necessary due to updater bug https://github.com/freedomofpress/securedrop-workstation/issues/1763. In short, dom0 highstate needs to be fully independent until we fix it.

Implementation:
- have a template upgrade script (like the old bash one), but with a slightly different trick for precedence — use of `order:first` and `order: last`.
- Uses the python logic to shut down all qubes and prevent startup during provisioning.
  - no longer context-manager-based (script needs to be called twice: the start portion and finish portion)
  - Finish portion expected to always pass

## Test plan
- [ ] start with prod 1.7.1
- [ ] then set it to staging, but we cannot running `sdw-admin --apply`, so we need a hack (otherwise configuration will fail due missing packages)
  - `echo "copy_config()" | (cd /usr/bin/ && python3 -i sdw-admin --validate)`
- [ ] install local RPM from this branch by running `make clone && ./scripts/prep-dev && sudo qubesctl state.highstate`
  - This simulates what the updater does when applying the dom0 state 
- [ ] preloaded disposables work after running
- [ ] starting sd-qubes works (NOTE: we may not actually be able to do this due [to a bug](https://github.com/freedomofpress/securedrop-workstation/issues/1763#issuecomment-4938440282))
- [ ] Inject fault mid-provisiong (`qubesctl state.highstate`) and ensure the salt state `run-post-upgrade-scripts` still runs, regardless (therefore, re-enabling the templates and preloaded disposables)
 
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
