### PR TITLE
Disable .top in postinst and re-enable in sdw-admin

### DIFF
--- a/files/sdw-admin.py
+++ b/files/sdw-admin.py
@@ -108,6 +108,12 @@ def provision_and_configure() -> None:
     """
     Applies the salt state.highstate on dom0 and all VMs
     """
+
+    # HACK: enable top as a workaround for #1763. In release 1.8.0 post-inst disabled
+    # the top file and it gets re-enabled in sdw-admin. This may be removed after the
+    # release.
+    run_cmd(["sudo", "qubesctl", "top.enable", "securedrop_salt.sd-workstation"])
+
     provision("Provisioning Fedora-based system VMs", "securedrop_salt.sd-sys-vms")
     provision("Provisioning base template", "securedrop_salt.sd-base-template")
     configure("Configuring base template", ["sd-base-debian-13"])

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -191,7 +191,7 @@ install -m 644 securedrop_salt/apt-test_freedom_press.sources.j2 %{buildroot}/sr
 # Update Salt Configuration
 qubesctl saltutil.clear_cache -l quiet --out quiet > /dev/null || true
 qubesctl saltutil.sync_all refresh=true -l quiet --out quiet > /dev/null || true
-qubesctl top.enable securedrop_salt.sd-workstation > /dev/null ||:
+qubesctl top.disable securedrop_salt.sd-workstation > /dev/null ||:
 
 # Force full run of all Salt states - uncomment in release branch
 mkdir -p /tmp/sdw-migrations

--- a/securedrop_salt/sd-remove-unused-qubes.sls
+++ b/securedrop_salt/sd-remove-unused-qubes.sls
@@ -5,9 +5,9 @@
 # WARNING: only remove when complete reinstall is assumed (e.g. 1.0.0 release)
 # This is because the workstation may have been offline for a while
 # and skipped some salt updates.
+# FIXME: sd-small-bookworm-template and sd-large-bookworm-template are not removed
+# yet because the old updater still expects them to be around (#1771)
 {% set qubes_for_removal = [
-  "sd-small-bookworm-template",
-  "sd-large-bookworm-template",
   "sd-base-bookworm-template",
   "sd-retain-logvm",
   "sd-whonix",


### PR DESCRIPTION
Work around issue #1763 with the simple approach of disabling the top file. The issue was that a dom0 highstate would always run before a migration update and this was blocking a release with template changes (they can't just run fully with a highstate due to the need to install the base template -> configure it to install the kernel -> clone as individual templates). Otherwise the qubes don't boot as they don't have a kernel installed.

This workaround simply disables the sd-workstation.top, to bypass the problematic issue with the updater and then re-enables it in sdw-admin apply.

Fixes #1762 (although not as the issue originally phrases it)

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] Install a 1.7.1 prod system, but set config.json set to "staging" (so trixie debs are available)
* [ ] Fetch this branch, run `make clone` so it's in dom0 and there's a built RPM
* [ ] install the `rpm` and `createrepo-c` packages in your sd-dev VM (if fedora based, `rpm-sign` + `createrepo_c`)
* [ ] check out the "2026-07-yum-qa-local-upgrade" branch in this repo and get it in dom0 with `make clone-norpm` (don't clobber the previously built one)
* [ ] run the new `./scripts/local-rpm-server.sh` which should create a signing key and inject a local RPM repo
* [ ] run `sudo qubes-dom0-update --check-only` and see that it hits our local server and shows an update to 1.8.0-rc1
* [ ] launch the updater with `sdw-updater --skip-delta 0` and start it
* [ ] wait ...
* [ ] upgrade should finish successfully and all templates should be debian-13 based w/ bookworm templates gone 

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
