### PR TITLE
[1.8.0] Backport "Disable .top in postinst and re-enable in sdw-admin"

### DIFF
--- a/files/sdw-admin.py
+++ b/files/sdw-admin.py
@@ -108,6 +108,12 @@ def provision_and_configure() -> None:
     """
     Applies the salt state.highstate on dom0 and all VMs
     """
+
+    # HACK: enable top as a workaround for #1763. In release 1.8.0 post-inst disabled
+    # the top file and it gets re-enabled in sdw-admin. This may be removed after the
+    # release.
+    run_cmd(["sudo", "qubesctl", "top.enable", "securedrop_salt.sd-workstation"])
+
     provision("Provisioning Fedora-based system VMs", "securedrop_salt.sd-sys-vms")
     provision("Provisioning base template", "securedrop_salt.sd-base-template")
     configure("Configuring base template", ["sd-base-debian-13"])

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -191,7 +191,7 @@ install -m 644 securedrop_salt/apt-test_freedom_press.sources.j2 %{buildroot}/sr
 # Update Salt Configuration
 qubesctl saltutil.clear_cache -l quiet --out quiet > /dev/null || true
 qubesctl saltutil.sync_all refresh=true -l quiet --out quiet > /dev/null || true
-qubesctl top.enable securedrop_salt.sd-workstation > /dev/null ||:
+qubesctl top.disable securedrop_salt.sd-workstation > /dev/null ||:
 
 # Force full run of all Salt states - uncomment in release branch
 # mkdir -p /tmp/sdw-migrations

--- a/securedrop_salt/sd-remove-unused-qubes.sls
+++ b/securedrop_salt/sd-remove-unused-qubes.sls
@@ -5,9 +5,9 @@
 # WARNING: only remove when complete reinstall is assumed (e.g. 1.0.0 release)
 # This is because the workstation may have been offline for a while
 # and skipped some salt updates.
+# FIXME: sd-small-bookworm-template and sd-large-bookworm-template are not removed
+# yet because the old updater still expects them to be around (#1771)
 {% set qubes_for_removal = [
-  "sd-small-bookworm-template",
-  "sd-large-bookworm-template",
   "sd-base-bookworm-template",
   "sd-retain-logvm",
   "sd-whonix",


### PR DESCRIPTION
Backports changes introduced in https://github.com/freedomofpress/securedrop-workstation/pull/1769.

:warning: **Some nuance:**  In theory we could not even have those in main as they are a temporary workaround, but @legoktm thought of the edge-case of someone not using the system for a while and then jumping to the next version directly. This means that we need to keep this in until we're confident everyone has migrated.
* This also means that we may need to make every workstation release a "migration" release. Otherwise `sdw-admin.py` does not run and that is what re-enables the top file again :warning:. Does it make sense to through it in here? Or as a separate PR. If separate, CI may fail.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
- [ ] base branch is `main` (Note: this was a PR we merged into the release branch directly rather than the other way around)
- [ ] confirm nothing is missing from https://github.com/freedomofpress/securedrop-workstation/pull/1769