### PR TITLE
Skip test_mock_device_attach_deny for now because it's broken

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -359,7 +359,7 @@ class Test_SD_VM_Common:
                 actual_app == expected_app
             ), f"MIME type {mime_type}: expected {expected_app}, got {actual_app}"
 
-    @pytest.mark.skip(reason="broken")
+    @pytest.mark.skip(reason="Broken in CI. Tracked as #1579")
     def test_mock_device_attach_deny(
         self, qube: QubeWrapper, mock_block_device: str, qubesd_log: Iterator[str]
     ) -> None:

--- a/tests/base.py
+++ b/tests/base.py
@@ -359,6 +359,7 @@ class Test_SD_VM_Common:
                 actual_app == expected_app
             ), f"MIME type {mime_type}: expected {expected_app}, got {actual_app}"
 
+    @pytest.mark.skip(reason="broken")
     def test_mock_device_attach_deny(
         self, qube: QubeWrapper, mock_block_device: str, qubesd_log: Iterator[str]
     ) -> None:


### PR DESCRIPTION
It's obscuring other failures that we should be paying more attention to.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
