### PR TITLE
Use %triggerun to enable migration flag for all pre-1.8.0 upgrades

### DIFF
--- a/files/sdw-admin.py
+++ b/files/sdw-admin.py
@@ -109,9 +109,9 @@ def provision_and_configure() -> None:
     Applies the salt state.highstate on dom0 and all VMs
     """
 
-    # HACK: enable top as a workaround for #1763. In release 1.8.0 post-inst disabled
-    # the top file and it gets re-enabled in sdw-admin. This may be removed after the
-    # release.
+    # HACK: Workaround for #1763 in which we disable the top file during RPM upgrade
+    # to workaround pre-1.8.1 updaters. This can be removed once we no longer support
+    # the old updater versions.
     run_cmd(["sudo", "qubesctl", "top.enable", "securedrop_salt.sd-workstation"])
 
     provision("Provisioning Fedora-based system VMs", "securedrop_salt.sd-sys-vms")

--- a/launcher/tests/test_updater.py
+++ b/launcher/tests/test_updater.py
@@ -569,6 +569,38 @@ def test_apply_dom0_state_failure(mocked_info, mocked_error, mocked_subprocess):
     mocked_error.assert_has_calls(log_error_calls)
 
 
+@mock.patch("subprocess.check_output", side_effect=[b""])
+@mock.patch("sdw_updater.Updater.sdlog.error")
+@mock.patch("sdw_updater.Updater.sdlog.info")
+def test_enable_dom0_state_success(mocked_info, mocked_error, mocked_subprocess):
+    assert Updater.enable_dom0_state() == UpdateStatus.UPDATES_OK
+    log_call_list = [call("Enabling dom0 top file"), call("dom0 top file enabled")]
+    mocked_subprocess.assert_called_once_with(
+        ["sudo", "qubesctl", "top.enable", "securedrop_salt.sd-workstation"]
+    )
+    mocked_info.assert_has_calls(log_call_list)
+    assert not mocked_error.called
+
+
+@mock.patch(
+    "subprocess.check_output",
+    side_effect=[subprocess.CalledProcessError(1, cmd="check_output", output=b"")],
+)
+@mock.patch("sdw_updater.Updater.sdlog.error")
+@mock.patch("sdw_updater.Updater.sdlog.info")
+def test_enable_dom0_state_failure(mocked_info, mocked_error, mocked_subprocess):
+    assert Updater.enable_dom0_state() == UpdateStatus.UPDATES_FAILED
+    log_error_calls = [
+        call("Failed to enable dom0 top file. See updater-detail.log for details."),
+        call("Command 'check_output' returned non-zero exit status 1."),
+    ]
+    mocked_subprocess.assert_called_once_with(
+        ["sudo", "qubesctl", "top.enable", "securedrop_salt.sd-workstation"]
+    )
+    mocked_info.assert_called_once_with("Enabling dom0 top file")
+    mocked_error.assert_has_calls(log_error_calls)
+
+
 @mock.patch("os.path.exists", return_value=True)
 @mock.patch("os.listdir", return_value=["apple", "banana"])
 @mock.patch("sdw_updater.Updater.sdlog.info")

--- a/launcher/tests/test_updaterapp.py
+++ b/launcher/tests/test_updaterapp.py
@@ -30,6 +30,7 @@ def test_run_full_update_dom0_update_failure_exits_early(
     assert not migration_is_required_mock.called
 
 
+@mock.patch("sdw_updater.Updater.enable_dom0_state", return_value=UpdateStatus.UPDATES_OK)
 @mock.patch("sdw_updater.Updater.apply_updates_dom0", return_value=UpdateStatus.UPDATES_OK)
 @mock.patch("sdw_updater.Updater.apply_dom0_state", return_value=UpdateStatus.UPDATES_FAILED)
 @mock.patch("sdw_updater.Updater.migration_is_required", return_value=False)
@@ -41,6 +42,7 @@ def test_run_full_update_dom0_state_failure_exits_early(
     migration_required_mock,
     apply_dom0_state_mock,
     apply_updates_dom0_mock,
+    enable_dom0_state_mock,
 ):
     results = UpdaterApp.UpgradeThread().run_full_update()
     assert overall_update_status(results) == UpdateStatus.UPDATES_FAILED
@@ -51,6 +53,7 @@ def test_run_full_update_dom0_state_failure_exits_early(
     assert not apply_updates_templates_mock.called
 
 
+@mock.patch("sdw_updater.Updater.enable_dom0_state", return_value=UpdateStatus.UPDATES_OK)
 @mock.patch("sdw_updater.Updater.apply_updates_dom0", return_value=UpdateStatus.UPDATES_OK)
 @mock.patch("sdw_updater.Updater.apply_dom0_state")
 @mock.patch("sdw_updater.Updater.migration_is_required", return_value=True)
@@ -62,6 +65,7 @@ def test_run_full_update_migration_install_failure_exits_early(
     migration_required_mock,
     apply_dom0_state_mock,
     apply_updates_dom0_mock,
+    enable_dom0_state_mock,
 ):
     results = UpdaterApp.UpgradeThread().run_full_update()
     assert overall_update_status(results) == UpdateStatus.UPDATES_FAILED
@@ -74,6 +78,7 @@ def test_run_full_update_migration_install_failure_exits_early(
     assert not apply_updates_templates_mock.called
 
 
+@mock.patch("sdw_updater.Updater.enable_dom0_state", return_value=UpdateStatus.UPDATES_OK)
 @mock.patch("sdw_updater.Updater.apply_updates_dom0", return_value=UpdateStatus.UPDATES_OK)
 @mock.patch("sdw_updater.Updater.apply_dom0_state")
 @mock.patch("sdw_updater.Updater.migration_is_required", return_value=True)
@@ -85,6 +90,7 @@ def test_run_full_update_success_migration(
     migration_required_mock,
     apply_dom0_state_mock,
     apply_updates_dom0_mock,
+    enable_dom0_state_mock,
 ):
     results = UpdaterApp.UpgradeThread().run_full_update()
     assert overall_update_status(results) == UpdateStatus.UPDATES_OK
@@ -92,6 +98,7 @@ def test_run_full_update_success_migration(
 
 
 @mock.patch("sdw_updater.Updater.run_full_install")
+@mock.patch("sdw_updater.Updater.enable_dom0_state", return_value=UpdateStatus.UPDATES_OK)
 @mock.patch("sdw_updater.Updater.apply_updates_dom0", return_value=UpdateStatus.UPDATES_OK)
 @mock.patch("sdw_updater.Updater.apply_dom0_state", return_value=UpdateStatus.UPDATES_OK)
 @mock.patch("sdw_updater.Updater.migration_is_required", return_value=False)
@@ -101,11 +108,43 @@ def test_run_full_update_success_no_migration(
     migration_is_required_mock,
     apply_dom0_state_mock,
     apply_updates_dom0_mock,
+    enable_dom0_state_mock,
     run_full_install_mock,
 ):
     results = UpdaterApp.UpgradeThread().run_full_update()
     assert overall_update_status(results) == UpdateStatus.UPDATES_OK
     assert not run_full_install_mock.called
+
+
+@mock.patch("sdw_updater.Updater.enable_dom0_state", return_value=UpdateStatus.UPDATES_OK)
+@mock.patch("sdw_updater.Updater.apply_updates_dom0", return_value=UpdateStatus.UPDATES_OK)
+@mock.patch("sdw_updater.Updater.apply_dom0_state", return_value=UpdateStatus.UPDATES_OK)
+@mock.patch("sdw_updater.Updater.migration_is_required", return_value=False)
+@mock.patch("sdw_updater.Updater.apply_updates_templates", return_value=UpdateStatus.UPDATES_OK)
+def test_run_full_update_enables_dom0_state_before_applying_it(
+    apply_updates_templates_mock,
+    migration_required_mock,
+    apply_dom0_state_mock,
+    apply_updates_dom0_mock,
+    enable_dom0_state_mock,
+):
+    """
+    The top file must be enabled before the dom0 states are applied, otherwise
+    the states would be skipped.
+    """
+    manager = mock.Mock()
+    manager.attach_mock(enable_dom0_state_mock, "enable_dom0_state")
+    manager.attach_mock(apply_dom0_state_mock, "apply_dom0_state")
+    manager.attach_mock(migration_required_mock, "migration_is_required")
+
+    results = UpdaterApp.UpgradeThread().run_full_update()
+
+    assert overall_update_status(results) == UpdateStatus.UPDATES_OK
+    assert manager.mock_calls == [
+        mock.call.enable_dom0_state(),
+        mock.call.migration_is_required(),
+        mock.call.apply_dom0_state(),
+    ]
 
 
 @mock.patch("sdw_util.Util.get_qubes_version", return_value="4.1")

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -191,11 +191,6 @@ install -m 644 securedrop_salt/apt-test_freedom_press.sources.j2 %{buildroot}/sr
 # Update Salt Configuration
 qubesctl saltutil.clear_cache -l quiet --out quiet > /dev/null || true
 qubesctl saltutil.sync_all refresh=true -l quiet --out quiet > /dev/null || true
-qubesctl top.disable securedrop_salt.sd-workstation > /dev/null ||:
-
-# Force full run of all Salt states - uncomment in release branch
-mkdir -p /tmp/sdw-migrations
-touch /tmp/sdw-migrations/debian-13-bump
 
 # Enable service that conditionally removes our systemd-logind customizations
 # on dev machines only.
@@ -219,6 +214,16 @@ if [ $1 -eq 0 ]; then
     %systemd_user_preun securedrop-user-xfce-settings.service
     %systemd_user_preun sdw-notify.timer
 fi
+
+# This trigger allows us to conditionally run code based on the
+# version we are upgrading from. The version conditional should
+# be bumped whenever there is some change in the release that
+# requires a full `sdw-admin --apply` run.
+%triggerun -- %{name} < 1.8.0
+mkdir -p /tmp/sdw-migrations
+touch /tmp/sdw-migrations/debian-13-bump
+# Disable top to workaround a bug in the 1.8.0 upgrade; sdw-admin will re-enable it
+qubesctl top.disable securedrop_salt.sd-workstation
 
 %changelog
 * Mon Jul 20 2026 SecureDrop Team <securedrop@freedom.press> - 1.9.0rc1

--- a/sdw_updater/Updater.py
+++ b/sdw_updater/Updater.py
@@ -415,6 +415,29 @@ def overall_update_status(results: dict[str, UpdateStatus]) -> UpdateStatus:
     return UpdateStatus.UPDATES_OK
 
 
+def enable_dom0_state() -> UpdateStatus:
+    """
+    Ensure the salt top file is enabled; this is mostly to ensure that if for
+    whatever reason the pre-1.8.0 disable wasn't undone in sdw-admin, we're still
+    running those states
+    """
+    sdlog.info("Enabling dom0 top file")
+    cmd = ["sudo", "qubesctl", "top.enable", "securedrop_salt.sd-workstation"]
+    cmd_for_log = " ".join(cmd)
+    try:
+        output = subprocess.check_output(cmd)
+        sdlog.info("dom0 top file enabled")
+        clean_output = Util.cleanup_for_log(output.decode("utf-8").strip())
+        detail_log.info(f"Output from command: {cmd_for_log}\n{clean_output}")
+        return UpdateStatus.UPDATES_OK
+    except subprocess.CalledProcessError as e:
+        sdlog.error(f"Failed to enable dom0 top file. See {DETAIL_LOG_FILE} for details.")
+        sdlog.error(str(e))
+        clean_output = Util.cleanup_for_log(e.output.decode("utf-8").strip())
+        detail_log.error(f"Output from failed command: {cmd_for_log}\n{clean_output}")
+        return UpdateStatus.UPDATES_FAILED
+
+
 def apply_dom0_state() -> UpdateStatus:
     """
     Applies the dom0 state to ensure dom0 and AppVMs are properly

--- a/sdw_updater/UpdaterApp.py
+++ b/sdw_updater/UpdaterApp.py
@@ -250,6 +250,7 @@ class UpgradeThread(QThread):
         # Pre-populate results with all available steps for early exits
         results = {
             "dom0": UpdateStatus.UPDATES_REQUIRED,
+            "enable_dom0": UpdateStatus.UPDATES_REQUIRED,
             "apply_dom0": UpdateStatus.UPDATES_REQUIRED,
             "apply_all": UpdateStatus.UPDATES_REQUIRED,
             "templates": UpdateStatus.UPDATES_REQUIRED,
@@ -263,6 +264,12 @@ class UpgradeThread(QThread):
             return results  # Fail early
 
         self.progress_signal.emit(10)
+
+        # Re-enable the dom0 top file just in case
+        results["enable_dom0"] = Updater.enable_dom0_state()
+        if results["enable_dom0"] == UpdateStatus.UPDATES_FAILED:
+            return results
+        self.progress_signal.emit(11)
 
         if Updater.migration_is_required():
             # Progress bar will freeze for ~15m during full state run


### PR DESCRIPTION
_This is rebased on top of #1784, which must be merged first_

We want all upgrades from a pre-1.8.0 version to trigger a full migration for the trixie switch. %triggerun is a good fit for this as per rpm-scriptlets(7), which says triggers are "often used for version specific migration tasks".

Fixes #1780.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
Pre-1.8.0 case:
* [x] Manually fetch 1.7.1 RPM and install it (running --apply is not necessary)
* [x] Build this PR via `make clone` and manually install the RPM with `sudo dnf install ./path....`
* [x] Run `sudo qubes-dom0-update` and install the new RPM; observe that migration flag is created
* [ ] (added by @deeplow) `sudo qubesctl top.enabled` should NOT list `/srv/salt/_tops/base/securedrop_salt.sd-workstation.top`

Post-1.8.0 case:
* [x] Install 1.8.0 RPM (running --apply is not necessary)
* [x] Build this PR via `make clone` and manually install the RPM with `sudo dnf install ./path....`
* [ ] Run `sudo qubes-dom0-update` and install the new RPM; observe that migration flag is NOT created
* [ ] (added by @deeplow) `sudo qubesctl top.enabled` should list `/srv/salt/_tops/base/securedrop_salt.sd-workstation.top`

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
