### PR TITLE
Do not run dom0 states independently if full migration is needed

### DIFF
--- a/launcher/tests/test_updaterapp.py
+++ b/launcher/tests/test_updaterapp.py
@@ -21,7 +21,9 @@ def app():
 
 @mock.patch("sdw_updater.Updater.apply_updates_dom0", return_value=UpdateStatus.UPDATES_FAILED)
 @mock.patch("sdw_updater.Updater.apply_dom0_state")
-def test_run_full_update_fail_early_1(apply_dom0_state_mock, apply_updates_dom0_mock):
+def test_run_full_update_dom0_update_failure_exits_early(
+    apply_dom0_state_mock, apply_updates_dom0_mock
+):
     results = UpdaterApp.UpgradeThread().run_full_update()
     assert overall_update_status(results) == UpdateStatus.UPDATES_FAILED
     assert apply_updates_dom0_mock.called
@@ -33,7 +35,7 @@ def test_run_full_update_fail_early_1(apply_dom0_state_mock, apply_updates_dom0_
 @mock.patch("sdw_updater.Updater.migration_is_required", return_value=False)
 @mock.patch("sdw_updater.Updater.run_full_install")
 @mock.patch("sdw_updater.Updater.apply_updates_templates")
-def test_run_full_update_fail_early_3(
+def test_run_full_update_dom0_state_failure_exits_early(
     apply_updates_templates_mock,
     run_full_install_mock,
     migration_required_mock,
@@ -54,7 +56,7 @@ def test_run_full_update_fail_early_3(
 @mock.patch("sdw_updater.Updater.migration_is_required", return_value=True)
 @mock.patch("sdw_updater.Updater.run_full_install", return_value=UpdateStatus.UPDATES_FAILED)
 @mock.patch("sdw_updater.Updater.apply_updates_templates")
-def test_run_full_update_fail_early_4(
+def test_run_full_update_migration_install_failure_exits_early(
     apply_updates_templates_mock,
     run_full_install_mock,
     migration_required_mock,

--- a/launcher/tests/test_updaterapp.py
+++ b/launcher/tests/test_updaterapp.py
@@ -20,14 +20,14 @@ def app():
 
 
 @mock.patch("sdw_updater.Updater.apply_updates_dom0", return_value=UpdateStatus.UPDATES_FAILED)
-@mock.patch("sdw_updater.Updater.apply_dom0_state")
+@mock.patch("sdw_updater.Updater.migration_is_required")
 def test_run_full_update_dom0_update_failure_exits_early(
-    apply_dom0_state_mock, apply_updates_dom0_mock
+    migration_is_required_mock, apply_updates_dom0_mock
 ):
     results = UpdaterApp.UpgradeThread().run_full_update()
     assert overall_update_status(results) == UpdateStatus.UPDATES_FAILED
     assert apply_updates_dom0_mock.called
-    assert not apply_dom0_state_mock.called
+    assert not migration_is_required_mock.called
 
 
 @mock.patch("sdw_updater.Updater.apply_updates_dom0", return_value=UpdateStatus.UPDATES_OK)
@@ -52,7 +52,7 @@ def test_run_full_update_dom0_state_failure_exits_early(
 
 
 @mock.patch("sdw_updater.Updater.apply_updates_dom0", return_value=UpdateStatus.UPDATES_OK)
-@mock.patch("sdw_updater.Updater.apply_dom0_state", return_value=UpdateStatus.UPDATES_OK)
+@mock.patch("sdw_updater.Updater.apply_dom0_state")
 @mock.patch("sdw_updater.Updater.migration_is_required", return_value=True)
 @mock.patch("sdw_updater.Updater.run_full_install", return_value=UpdateStatus.UPDATES_FAILED)
 @mock.patch("sdw_updater.Updater.apply_updates_templates")
@@ -75,7 +75,7 @@ def test_run_full_update_migration_install_failure_exits_early(
 
 
 @mock.patch("sdw_updater.Updater.apply_updates_dom0", return_value=UpdateStatus.UPDATES_OK)
-@mock.patch("sdw_updater.Updater.apply_dom0_state", return_value=UpdateStatus.UPDATES_OK)
+@mock.patch("sdw_updater.Updater.apply_dom0_state")
 @mock.patch("sdw_updater.Updater.migration_is_required", return_value=True)
 @mock.patch("sdw_updater.Updater.run_full_install", return_value=UpdateStatus.UPDATES_OK)
 @mock.patch("sdw_updater.Updater.apply_updates_templates", return_value=UpdateStatus.UPDATES_OK)
@@ -88,20 +88,24 @@ def test_run_full_update_success_migration(
 ):
     results = UpdaterApp.UpgradeThread().run_full_update()
     assert overall_update_status(results) == UpdateStatus.UPDATES_OK
+    assert not apply_dom0_state_mock.called
 
 
+@mock.patch("sdw_updater.Updater.run_full_install")
 @mock.patch("sdw_updater.Updater.apply_updates_dom0", return_value=UpdateStatus.UPDATES_OK)
 @mock.patch("sdw_updater.Updater.apply_dom0_state", return_value=UpdateStatus.UPDATES_OK)
 @mock.patch("sdw_updater.Updater.migration_is_required", return_value=False)
 @mock.patch("sdw_updater.Updater.apply_updates_templates", return_value=UpdateStatus.UPDATES_OK)
 def test_run_full_update_success_no_migration(
     apply_updates_templates_mock,
-    run_full_install_mock,
+    migration_is_required_mock,
     apply_dom0_state_mock,
     apply_updates_dom0_mock,
+    run_full_install_mock,
 ):
     results = UpdaterApp.UpgradeThread().run_full_update()
     assert overall_update_status(results) == UpdateStatus.UPDATES_OK
+    assert not run_full_install_mock.called
 
 
 @mock.patch("sdw_util.Util.get_qubes_version", return_value="4.1")

--- a/launcher/tests/test_updaterapp.py
+++ b/launcher/tests/test_updaterapp.py
@@ -30,19 +30,6 @@ def test_run_full_update_fail_early_1(apply_dom0_state_mock, apply_updates_dom0_
 
 @mock.patch("sdw_updater.Updater.apply_updates_dom0", return_value=UpdateStatus.UPDATES_OK)
 @mock.patch("sdw_updater.Updater.apply_dom0_state", return_value=UpdateStatus.UPDATES_FAILED)
-@mock.patch("sdw_updater.Updater.migration_is_required")
-def test_run_full_update_fail_early_2(
-    migration_required_mock, apply_dom0_state_mock, apply_updates_dom0_mock
-):
-    results = UpdaterApp.UpgradeThread().run_full_update()
-    assert overall_update_status(results) == UpdateStatus.UPDATES_FAILED
-    assert apply_updates_dom0_mock.called
-    assert apply_dom0_state_mock.called
-    assert not migration_required_mock.called
-
-
-@mock.patch("sdw_updater.Updater.apply_updates_dom0", return_value=UpdateStatus.UPDATES_OK)
-@mock.patch("sdw_updater.Updater.apply_dom0_state", return_value=UpdateStatus.UPDATES_FAILED)
 @mock.patch("sdw_updater.Updater.migration_is_required", return_value=False)
 @mock.patch("sdw_updater.Updater.run_full_install")
 @mock.patch("sdw_updater.Updater.apply_updates_templates")
@@ -56,6 +43,7 @@ def test_run_full_update_fail_early_3(
     results = UpdaterApp.UpgradeThread().run_full_update()
     assert overall_update_status(results) == UpdateStatus.UPDATES_FAILED
     assert apply_updates_dom0_mock.called
+    assert migration_required_mock.called
     assert apply_dom0_state_mock.called
     assert not run_full_install_mock.called
     assert not apply_updates_templates_mock.called
@@ -76,7 +64,9 @@ def test_run_full_update_fail_early_4(
     results = UpdaterApp.UpgradeThread().run_full_update()
     assert overall_update_status(results) == UpdateStatus.UPDATES_FAILED
     assert apply_updates_dom0_mock.called
-    assert apply_dom0_state_mock.called
+    assert (
+        not apply_dom0_state_mock.called
+    ), "dom0 states not individually invoked during full updater run"
     assert migration_required_mock.called
     assert run_full_install_mock.called
     assert not apply_updates_templates_mock.called

--- a/sdw_updater/UpdaterApp.py
+++ b/sdw_updater/UpdaterApp.py
@@ -255,22 +255,15 @@ class UpgradeThread(QThread):
             "templates": UpdateStatus.UPDATES_REQUIRED,
         }
 
-        # Update dom0 first, then apply dom0 state. If full state run
-        # is required, the dom0 state will drop a flag.
+        # Update dom0 first, if the migration flag is dropped,
+        # do a full salt run, otherwise just the dom0 states.
         self.progress_signal.emit(5)
         results["dom0"] = Updater.apply_updates_dom0()
         if results["dom0"] == UpdateStatus.UPDATES_FAILED:
             return results  # Fail early
 
-        # apply dom0 state
         self.progress_signal.emit(10)
-        # add to results dict, if it fails it will show error message
-        results["apply_dom0"] = Updater.apply_dom0_state()
-        if results["apply_dom0"] == UpdateStatus.UPDATES_FAILED:
-            return results  # Fail early
 
-        self.progress_signal.emit(15)
-        # rerun full config if dom0 checks determined it's required
         if Updater.migration_is_required():
             # Progress bar will freeze for ~15m during full state run
             self.progress_signal.emit(35)
@@ -280,12 +273,20 @@ class UpgradeThread(QThread):
                 return results  # Fail early
 
             self.progress_signal.emit(75)
+            results["apply_dom0"] = UpdateStatus.UPDATES_OK  # dom0 handled via full salt run
 
             templates_progress_callback = self.templates_progress_callback_factory(
                 progress_start=75,
                 progress_end=90,
             )
         else:
+            # Full salt run not needed, just run dom0 states
+            results["apply_dom0"] = Updater.apply_dom0_state()
+            if results["apply_dom0"] == UpdateStatus.UPDATES_FAILED:
+                return results  # Fail early
+
+            self.progress_signal.emit(15)
+
             results["apply_all"] = UpdateStatus.UPDATES_OK  # No updates
             templates_progress_callback = self.templates_progress_callback_factory(
                 progress_start=15,


### PR DESCRIPTION
This unnecessarily forces us to stick everything in the dom0 state and adds duplication in that the dom0 states end up getting run twice.

Fixes #1763.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] Manually drop an updater flag in /tmp/sdw-migrations 
* [x] Run `sdw-updater --skip-delta 0`
* [x] Review updater log and see that it did not run dom0 states and only ran full sdw-admin --apply
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
