### PR TITLE
Obtain list of templates to update on the fly instead of hardcoding

### DIFF
--- a/launcher/tests/conftest.py
+++ b/launcher/tests/conftest.py
@@ -56,35 +56,79 @@ skip_in_dom0 = pytest.mark.skipif(
 )
 
 
+SD_TAG = "sd-workstation"
+MOCK_FEDORA_TEMPLATE = "fedora-XX-xfce"
+
+# SecureDrop-managed TemplateVMs, all tagged `sd-workstation`.
+MOCK_SDW_TEMPLATES = [
+    "sd-base-debian-XX",
+    "sd-inbox-debian-XX",
+    "sd-viewer-debian-XX",
+]
+
+# SecureDrop-managed AppVMs (tagged) mapped to their template.
+MOCK_SDW_APPVMS = {
+    "sd-app": "sd-inbox-debian-XX",
+    "sd-log": "sd-inbox-debian-XX",
+    "sd-proxy": "sd-inbox-debian-XX",
+    "sd-gpg": "sd-inbox-debian-XX",
+    "sd-viewer": "sd-viewer-debian-XX",
+    "sd-devices": "sd-viewer-debian-XX",
+    "sd-printers": "sd-viewer-debian-XX",
+}
+
+
 @pytest.fixture
 def mocked_qubes_app(mocker):
+    from qubesadmin.tests import mock_app
     from qubesadmin.tests.mock_app import MockQube, QubesTestWrapper
+
+    # The mock only registers `admin.vm.tag.Get` calls for tags it knows about,
+    # so register `sd-workstation` to allow `"sd-workstation" in vm.tags` checks
+    # against untagged VMs (e.g. the Fedora template).
+    if SD_TAG not in mock_app.POSSIBLE_TAGS:
+        mock_app.POSSIBLE_TAGS.append(SD_TAG)
 
     class MockQubesWorkstation(QubesTestWrapper):
         def __init__(self):
             super().__init__()
 
-            # FIXME avoid using module under test. Obtain directly from main tests
-            current_vms = sdw_updater.Updater._get_current_vms()
-
-            # 1. create the templates
-            for template_name in set(current_vms.values()):
+            # 1. Create the SecureDrop templates (tagged `sd-workstation`)
+            for template_name in MOCK_SDW_TEMPLATES:
                 self._qubes[template_name] = MockQube(
                     name=template_name,
                     qapp=self,
                     klass="TemplateVM",
                     netvm="",
+                    tags=[SD_TAG],
                 )
 
-            # 2. create the app qubes
-            for qube_name, template_name in current_vms.items():
+            # 2. Create the Fedora template backing the sys-* VMs (NOT tagged)
+            self._qubes[MOCK_FEDORA_TEMPLATE] = MockQube(
+                name=MOCK_FEDORA_TEMPLATE,
+                qapp=self,
+                klass="TemplateVM",
+                netvm="",
+            )
+
+            # 3. Create the SecureDrop app qubes (tagged `sd-workstation`)
+            for qube_name, template_name in MOCK_SDW_APPVMS.items():
                 MockQube(
                     qube_name,
                     self,
                     template=template_name,
+                    tags=[SD_TAG],
                 )
 
-            # 3. TODO Lastly create the disposables
+            # 4. Create the sys-* VMs (NOT tagged) based on the Fedora template
+            for sys_vm in sdw_updater.Updater.SYSTEM_VMS:
+                MockQube(
+                    sys_vm,
+                    self,
+                    template=MOCK_FEDORA_TEMPLATE,
+                )
+
+            # 5. TODO Lastly create the disposables
 
             self.update_vm_calls()
 

--- a/launcher/tests/test_updater.py
+++ b/launcher/tests/test_updater.py
@@ -12,6 +12,12 @@ import pytest
 from sdw_updater import Updater
 from sdw_updater.Updater import UpdateStatus
 
+skipif_no_qubesadmin = pytest.mark.skipif(
+    importlib.util.find_spec("qubesadmin") is None,
+    reason="qubesadmin module not available (only runs in dom0)",
+)
+
+
 debian_based_vms = [
     "sd-app",
     "sd-log",
@@ -50,12 +56,13 @@ TEST_RESULTS_UPDATES = {
 }
 
 
-def test__get_current_vms():
-    assert len(Updater._get_current_vms()) == 8
-
-
-def test__get_current_templates():
-    assert len(Updater._get_current_templates()) == 3
+@skipif_no_qubesadmin
+def test__get_current_templates(mocked_qubes_app):
+    assert Updater._get_current_templates() == {
+        "sd-inbox-debian-XX",
+        "sd-viewer-debian-XX",
+        "fedora-XX-xfce",
+    }
 
 
 @mock.patch("sdw_updater.Updater._write_updates_status_flag_to_disk")
@@ -356,10 +363,7 @@ def test_read_dom0_update_flag_from_disk_fails(mocked_info, mocked_error, tmp_pa
         ("4.4", "4.3", True),  # System in middle of 4.3 -> 4.4 upgrade
     ],
 )
-@pytest.mark.skipif(
-    importlib.util.find_spec("qubesadmin") is None,
-    reason="qubesadmin module not available (only runs in dom0)",
-)
+@skipif_no_qubesadmin
 def test_is_qubes_mid_upgrade(qubes_ver, agent_ver, is_mid_upgrade, mocker, mocked_qubes_app):
     # Overrding "dnf.rpm.detect_releasever" to simulate being on particular Qubes version
     mocker.patch("dnf.rpm").detect_releasever.return_value = qubes_ver

--- a/sdw_updater/Updater.py
+++ b/sdw_updater/Updater.py
@@ -39,26 +39,50 @@ sdlog = Util.get_logger(module=__name__)
 detail_log = Util.get_logger(prefix=DETAIL_LOGGER_PREFIX, module=__name__)
 
 
-def _get_current_vms() -> dict[str, str]:
-    debian_version = "13"
-
-    # The are the TemplateVMs that require full patch level at boot in order to start the inbox,
-    # as well as their associated TemplateVMs.
-    # In the future, we could use qvm-prefs to extract this information.
-    return {
-        "fedora": "fedora-43-xfce",
-        "sd-viewer": f"sd-viewer-debian-{debian_version}",
-        "sd-app": f"sd-inbox-debian-{debian_version}",
-        "sd-log": f"sd-inbox-debian-{debian_version}",
-        "sd-devices": f"sd-viewer-debian-{debian_version}",
-        "sd-printers": f"sd-viewer-debian-{debian_version}",
-        "sd-proxy": f"sd-inbox-debian-{debian_version}",
-        "sd-gpg": f"sd-inbox-debian-{debian_version}",
-    }
+# sys-* VMs that we manage updates for, but aren't tagged with sd-workstation
+SYSTEM_VMS = ("sys-net", "sys-firewall", "sys-usb")
 
 
 def _get_current_templates() -> set[str]:
-    return set([val for key, val in _get_current_vms().items() if key != "dom0"])
+    """
+    Return the set of TemplateVMs that the updater should update.
+
+    Find:
+    * TemplateVMs tagged sd-workstation with derived_vms
+    * TemplateVMs that back hardcoded SYSTEM_VMS
+
+    Notably this excludes the sd-base-debian-XX template, because
+    nothing directly uses it.
+    """
+    # Lazy import: qubesadmin is a dom0-only system package, not available in
+    # the CI venv.
+    import qubesadmin
+
+    app = qubesadmin.Qubes()
+    app.cache_enabled = True
+
+    templates = set()
+
+    for vm in app.domains:
+        if vm.klass != "TemplateVM":
+            continue
+        if not vm.derived_vms:
+            # Nothing uses this template
+            continue
+        if "prohibit-start" in vm.features:
+            # Someone has disabled this VM
+            continue
+        # Check for sd-workstation tag
+        if "sd-workstation" in vm.tags:
+            templates.add(vm.name)
+
+    for name in SYSTEM_VMS:
+        vm = app.domains[name]
+        while vm.klass != "TemplateVM":
+            vm = vm.template
+        templates.add(vm.name)
+
+    return templates
 
 
 def get_dom0_path(folder: str) -> str:

--- a/stubs/qubesadmin/__init__.pyi
+++ b/stubs/qubesadmin/__init__.pyi
@@ -9,6 +9,7 @@ from qubesadmin.app import VMCollection
 from qubesadmin.vm import QubesVM
 
 class Qubes:
+    cache_enabled: bool
     domains: VMCollection
     default_dispvm: QubesVM
     def __init__(self) -> None: ...


### PR DESCRIPTION
If the updater has a hardcoded list of templates, that means you cannot remove the old template until everyone is off the old updater version.

Instead, fetch the list dynamically so it always uses the correct set of templates. We look at everything tagged `sd-workstation`, plus a hardcoded set of sys-* VMs that use Fedora, figure out the underlying template, and update those.

Fixes #758.
Fixes #1771.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

* [ ] Install 1.7.1 RPM and `sdw-admin --apply`
* [ ] Build RPM based on this branch and install it into dom0 `sudo dnf install ./whatever.rpm`
* [ ] `sdw-updater --skip-delta 0` -> this is basically simulating the updater as if the fixed updater was being used for trixie switch
* [ ] observe in updater logs, the "Applying all updates to VMs" line only lists the newly created debian-13 templates, not the bookworm ones

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
