### PR TITLE
Undo dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,6 @@ updates:
       - dependency-type: "all"
     ignore:
       - dependency-name: "pyqt*"
-    groups:
-        dependencies:
-          patterns: ["*"]
     cooldown:
       default-days: 7
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
We have too many dependencies bundled in one right now, until we catch up it would be good to have them be individual PRs so we can more easily review and verify them.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
