### PR TITLE
fix(policy): prevent qubes.USBAttach wildcard from shadowing sd-works…

### DIFF
--- a/files/31-securedrop-workstation.policy
+++ b/files/31-securedrop-workstation.policy
@@ -32,6 +32,11 @@ qubes.GpgImportKey      *           @tag:sd-client sd-gpg allow
 qubes.Gpg2              *           @tag:sd-client sd-gpg allow target=sd-gpg
 
 qubes.USBAttach         *           sys-usb @tag:sd-export-target allow  user=root
+# Deny USB attachment to/from all sd-workstation-tagged VMs explicitly before
+# the wildcard ask rule below, preventing the deny rules in
+# 32-securedrop-workstation.policy from being shadowed (first-match-wins).
+qubes.USBAttach         *           @anyvm @tag:sd-workstation deny
+qubes.USBAttach         *           @tag:sd-workstation @anyvm deny
 qubes.USBAttach         *           @anyvm @anyvm ask
 
 qubes.USB               *           @tag:sd-export-target sys-usb allow

--- a/tests/test_rpc_policy.py
+++ b/tests/test_rpc_policy.py
@@ -101,3 +101,46 @@ def test_policy_from_sdgpg_to_dom0_allowed(sdw_tagged_vms: list[QubesVM], qubes_
             assert allowed
         else:
             assert not allowed
+
+
+@pytest.mark.provisioning
+def test_usbattach_policy_denies_sd_workstation(sdw_tagged_vms: list[QubesVM]) -> None:
+    """
+    Regression test: qubes.USBAttach to or from any @tag:sd-workstation VM must
+    be denied and must NOT resolve to an 'ask' prompt.
+
+    Previously, the wildcard 'qubes.USBAttach * @anyvm @anyvm ask' rule in
+    31-securedrop-workstation.policy was evaluated before the deny rules in
+    32-securedrop-workstation.policy (first-match-wins), making the deny rules
+    unreachable dead code. The fix adds explicit deny rules for @tag:sd-workstation
+    directly in file 31, before the wildcard ask rule.
+    """
+    # Representative non-SDW VMs that should not be able to attach USB to an
+    # sd-workstation-tagged VM (or have USB attached from one).
+    non_sdw_sources = ["sys-net", "sys-firewall", "sys-usb"]
+
+    for vm in sdw_tagged_vms:
+        # Skip sd-export-target VMs: sys-usb -> @tag:sd-export-target is
+        # intentionally allowed via an explicit allow rule above the deny rules.
+        if "sd-export" in vm.name:
+            continue
+
+        # No external VM should be able to attach USB to an sd-workstation VM.
+        for source in non_sdw_sources:
+            assert not policy_exists(
+                source, vm.name, "qubes.USBAttach"
+            ), (
+                f"qubes.USBAttach from {source} to {vm.name} should be denied, "
+                f"but a policy route was found. The @anyvm @anyvm ask wildcard in "
+                f"31-securedrop-workstation.policy may be shadowing the deny rule."
+            )
+
+        # No sd-workstation VM should be able to initiate a USB attach to
+        # an external VM either.
+        for target in non_sdw_sources:
+            assert not policy_exists(
+                vm.name, target, "qubes.USBAttach"
+            ), (
+                f"qubes.USBAttach from {vm.name} to {target} should be denied, "
+                f"but a policy route was found."
+            )


### PR DESCRIPTION
…tation deny rules

The wildcard rule 'qubes.USBAttach * @anyvm @anyvm ask' in 31-securedrop-workstation.policy was evaluated before the deny rules in 32-securedrop-workstation.policy (Qubes first-match-wins evaluation order). This made the deny rules in file 32 unreachable dead code, meaning a USB attach request targeting any @tag:sd-workstation VM would result in an interactive 'ask' prompt instead of being silently denied.

Fix: Add explicit deny rules for @tag:sd-workstation targets directly in 31-securedrop-workstation.policy, immediately before the wildcard ask rule, ensuring they are evaluated first within the same file.

  qubes.USBAttach * @anyvm @tag:sd-workstation deny
  qubes.USBAttach * @tag:sd-workstation @anyvm deny

The sd-export-target allow rule (sys-usb -> @tag:sd-export-target) is intentionally preserved above the new deny rules since that allow is the correct and expected policy for USB export operations.

Add regression test test_usbattach_policy_denies_sd_workstation() to tests/test_rpc_policy.py to verify that qubes.USBAttach from external VMs (sys-net, sys-firewall, sys-usb) to any non-export sd-workstation VM is denied, and that sd-workstation VMs cannot initiate USB attaches to those external VMs either.

Fixes #

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
