### PR TITLE
Have `make test-launcher` fully pass locally

### DIFF
--- a/launcher/tests/test_updater.py
+++ b/launcher/tests/test_updater.py
@@ -1,3 +1,4 @@
+import importlib.util
 import json
 import os
 import subprocess
@@ -356,7 +357,8 @@ def test_read_dom0_update_flag_from_disk_fails(mocked_info, mocked_error, tmp_pa
     ],
 )
 @pytest.mark.skipif(
-    os.environ.get("CI") == "true", reason="Skipping on CI (should only run in Qubes)"
+    importlib.util.find_spec("qubesadmin") is None,
+    reason="qubesadmin module not available (only runs in dom0)",
 )
 def test_is_qubes_mid_upgrade(qubes_ver, agent_ver, is_mid_upgrade, mocker, mocked_qubes_app):
     # Overrding "dnf.rpm.detect_releasever" to simulate being on particular Qubes version

--- a/poetry.lock
+++ b/poetry.lock
@@ -1559,6 +1559,24 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.15.1"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d"},
+    {file = "pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f"},
+]
+
+[package.dependencies]
+pytest = ">=6.2.5"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "python-debian"
 version = "0.1.49"
 description = "Debian package related modules"
@@ -2283,4 +2301,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13"
-content-hash = "d7dfb38f143aac0a7824f6dfd9b61b746855c95b36e3641109a5cd4305ca10d0"
+content-hash = "94e941ff4ea6327071936c7698b95d22f73dee707761068775652b7f78cbfff9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ pysequoia = "^0.1.25"
 zizmor = "*"
 python-systemd = "^0.0.9"
 semgrep = "*"
+pytest-mock = "^3.15.1"
 
 [tool.poetry.group.system-package-equivalents.dependencies]
 # In production these are installed as a system package so match the


### PR DESCRIPTION
* Add missing pytest-mock package in poetry
* Skip tests that require qubesadmin by checking for that instead of a CI=true environment variable

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] Running `poetry sync && make test-launcher` passes
* [ ] OpenQA output shows that these tests are not skipped there
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
