### PR TITLE
Deploy locally built RPMs as a server (for updater testing)

### DIFF
--- a/scripts/clone-to-dom0
+++ b/scripts/clone-to-dom0
@@ -6,6 +6,8 @@ set -e
 set -u
 set -o pipefail
 
+source "$(dirname "$0")/common.sh"
+
 # Ensure we're running in dom0, otherwise clone action could destroy
 # active work in AppVM.
 if [[ "$(hostname)" != "dom0" ]]; then
@@ -13,34 +15,27 @@ if [[ "$(hostname)" != "dom0" ]]; then
     exit 1
 fi
 
-# Support environment variable overrides, but provide sane defaults.
-dev_vm="${SECUREDROP_DEV_VM:-sd-dev}"
-dev_dir="${SECUREDROP_DEV_DIR:-/home/user/securedrop-workstation}"
-
-# The dest directory in dom0 is not customizable.
-dom0_dev_dir="$HOME/securedrop-workstation"
-
 # Call out to target AppVM, to build an RPM containing
 # the latest Salt config for dom0. The RPM will be included
 # in the subsequent tarball, which is fetched to dom0.
 function build-dom0-rpm() {
-    printf "Building RPM on %s ...\n" "${dev_vm}"
+    printf "Building RPM on %s ...\n" "${DEV_VM}"
     dom0_fedora_version="$(rpm --eval '%{fedora}')"
-    qvm-run --pass-io "$dev_vm" "FEDORA_VERSION=$dom0_fedora_version make -C $dev_dir build-rpm"
+    qvm-run --pass-io "$DEV_VM" "FEDORA_VERSION=$dom0_fedora_version make -C $DEV_DIR build-rpm"
 }
 
 # Call out to target AppVM to create a tarball in dom0
 function create-tarball() {
-    printf "Cloning code from %s:%s ...\n" "${dev_vm}" "${dev_dir}"
-    qvm-run --pass-io "$dev_vm" \
+    printf "Cloning code from %s:%s ...\n" "${DEV_VM}" "${DEV_DIR}"
+    qvm-run --pass-io "$DEV_VM" \
         "tar -c --exclude-vcs \
-        -C '$(dirname "$dev_dir")' \
-        '$(basename "$dev_dir")'" > /tmp/sd-proj.tar
+        -C '$(dirname "$DEV_DIR")' \
+        '$(basename "$DEV_DIR")'" > /tmp/sd-proj.tar
 }
 
 function unpack-tarball() {
-    rm -rf "${dom0_dev_dir:?}/"*
-    tar xf /tmp/sd-proj.tar -C "${dom0_dev_dir}" --strip-components=1
+    rm -rf "${DOM0_DEV_DIR:?}/"*
+    tar xf /tmp/sd-proj.tar -C "${DOM0_DEV_DIR}" --strip-components=1
 }
 
 # By default we build the RPM, but the step can be skipped, which is useful

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -18,3 +18,14 @@ else
 fi
 
 export OCI_BIN
+
+
+# Support environment variable overrides, but provide sane defaults.
+DEV_VM="${SECUREDROP_DEV_VM:-sd-dev}"
+export DEV_VM
+DEV_DIR="${SECUREDROP_DEV_DIR:-/home/user/securedrop-workstation}"
+export DEV_DIR
+
+# The dest directory in dom0 is not customizable.
+DOM0_DEV_DIR="$HOME/securedrop-workstation"
+export DOM0_DEV_DIR

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,5 +1,8 @@
-TOPLEVEL=$(git rev-parse --show-toplevel)
-export TOPLEVEL
+if which git >/dev/null 2>&1; then
+    TOPLEVEL=$(git -C $(dirname "$0") rev-parse --show-toplevel)
+    export TOPLEVEL
+fi
+
 PROJECT="securedrop-workstation-dom0-config"
 export PROJECT
 export FEDORA_VERSION="${FEDORA_VERSION:-41}"

--- a/scripts/install-admin-rpm
+++ b/scripts/install-admin-rpm
@@ -3,16 +3,17 @@
 # This is opt-in and separate from the main prep-dev workflow.
 set -euo pipefail
 
-dom0_dev_dir="$HOME/securedrop-workstation"
+source "$(dirname "$0")/common.sh"
+
 rpm_name="securedrop-admin-dom0-config"
 
 function find_latest_rpm() {
     fedora_version="$(rpm --eval '%{fedora}')"
-    find "${dom0_dev_dir}/rpm-build/RPMS/" -type f -iname "${rpm_name}*fc${fedora_version}.noarch.rpm" -print0 | xargs -r -0 ls -t | head -n 1
+    find "${DOM0_DEV_DIR}/rpm-build/RPMS/" -type f -iname "${rpm_name}*fc${fedora_version}.noarch.rpm" -print0 | xargs -r -0 ls -t | head -n 1
 }
 
 function find_any_rpm() {
-    find "${dom0_dev_dir}/rpm-build/RPMS/" -type f -iname "${rpm_name}*.rpm" -print0 | xargs -r -0 ls -t | head -n 1
+    find "${DOM0_DEV_DIR}/rpm-build/RPMS/" -type f -iname "${rpm_name}*.rpm" -print0 | xargs -r -0 ls -t | head -n 1
 }
 
 latest_rpm="$(find_latest_rpm)"

--- a/scripts/local-rpm-server.sh
+++ b/scripts/local-rpm-server.sh
@@ -7,6 +7,9 @@
 
 set -euo pipefail
 
+# Import shared variables
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
 ANSI_COLORS=${ANSI_COLORS:-'1'}
 
 log() {
@@ -27,7 +30,7 @@ dom0_import_signing_key() {
 
     log "Importing local singning into dom0's RPM database (so packages can be validated)"
     local_pub_key_path=$(mktemp)
-    qvm-run -p "$SECUREDROP_DEV_VM" -- \
+    qvm-run -p "$DEV_VM" -- \
       "env GNUPGHOME=$SD_DEV_GNUPGHOME gpg --export --armor \"$LOCAL_SIG_KEY_NAME\"" > "$local_pub_key_path"
     sudo rpm --import "$local_pub_key_path"
 }
@@ -36,8 +39,8 @@ dom0_set_up() {
     # Save the old updatevm so it can later be restored
     old_updatevm=$(qubes-prefs updatevm)
 
-    log "Changing UpdateVM: $old_updatevm -> $SECUREDROP_DEV_VM"
-    qubes-prefs updatevm "$SECUREDROP_DEV_VM"
+    log "Changing UpdateVM: $old_updatevm -> $DEV_VM"
+    qubes-prefs updatevm "$DEV_VM"
 
     log "yum.repos.d: modifying to disable https and gpgcheck"
     sudo sed -i 's/https:/http:/g' /etc/yum.repos.d/securedrop-workstation-dom0.repo
@@ -83,13 +86,17 @@ EOF
 }
 
 vm_set_up_from_dom0() {
+    # get relative script path
+    script_abs_path="$(realpath "${BASH_SOURCE[0]}")"
+    script_rel_path="${script_abs_path#"$DOM0_DEV_DIR"/}"
+
     # Import the signing key generated on dev vm
-    log "Generating GPG RPM signing key in $SECUREDROP_DEV_VM"
-    qvm-run -p "$SECUREDROP_DEV_VM" -- "ANSI_COLORS=0 $SECUREDROP_DEV_DIR/$0 generate-key"
+    log "Generating GPG RPM signing key in $DEV_VM"
+    qvm-run -p "$DEV_VM" -- "ANSI_COLORS=0 $DEV_DIR/$script_rel_path generate-key"
     dom0_import_signing_key
 
-    log "Running $(basename "$0") in $SECUREDROP_DEV_VM (in background)"
-    qvm-run -p "$SECUREDROP_DEV_VM" -- "ANSI_COLORS=0 $SECUREDROP_DEV_DIR/$0 run-server"
+    log "Running $(basename "$0") in $DEV_VM (in background)"
+    qvm-run -p "$DEV_VM" -- "ANSI_COLORS=0 $DEV_DIR/$0 run-server"
 
 }
 
@@ -111,6 +118,7 @@ vm_set_up() {
     log "Creating repo to serve artifacts at $build_artifacts_dir"
     mkdir -p "$yum_local_rpm_dir"
     scripts_dir=$(dirname "$0")
+
     project_git_root=$(cd "$scripts_dir" && git rev-parse --show-toplevel)
     cp "$project_git_root/$build_artifacts_dir"/*.rpm "$yum_local_rpm_dir"
 

--- a/scripts/local-rpm-server.sh
+++ b/scripts/local-rpm-server.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# This sets up a local yum repo server in the development VM.
+# A GPG key is generated to sign those RPM files and it's installed
+# in dom0's RPM keyring database. This is necessary because dom0
+# always validates keyring signature regardless of whether or not gpg
+# validation as set in the .repo file.
+
+set -euo pipefail
+
+ANSI_COLORS=${ANSI_COLORS:-'1'}
+
+log() {
+    if [[ $ANSI_COLORS == '1' ]]; then
+        printf '\n\e[36m%s\e[0m\n' "$*"
+    else
+        echo "$*"
+    fi
+}
+
+# Tmp location for local signing keys (so we don't mess with existing keyrings)
+SD_DEV_GNUPGHOME="/tmp/local_dev_gnupg"
+LOCAL_SIG_KEY_NAME="SD dom0 local updates"
+
+dom0_import_signing_key() {
+    # Places the GPG key components in dom0 and the dev VM, such that
+    # packages can be authenticated by /etc/qubes-rpc/qubes.ReceiveUpdates
+
+    log "Importing local singning into dom0's RPM database (so packages can be validated)"
+    local_pub_key_path=$(mktemp)
+    qvm-run -p "$SECUREDROP_DEV_VM" -- \
+      "env GNUPGHOME=$SD_DEV_GNUPGHOME gpg --export --armor \"$LOCAL_SIG_KEY_NAME\"" > "$local_pub_key_path"
+    sudo rpm --import "$local_pub_key_path"
+}
+
+dom0_set_up() {
+    # Save the old updatevm so it can later be restored
+    old_updatevm=$(qubes-prefs updatevm)
+
+    log "Changing UpdateVM: $old_updatevm -> $SECUREDROP_DEV_VM"
+    qubes-prefs updatevm "$SECUREDROP_DEV_VM"
+
+    log "yum.repos.d: modifying to disable https and gpgcheck"
+    sudo sed -i 's/https:/http:/g' /etc/yum.repos.d/securedrop-workstation-dom0.repo
+    sudo sed -i 's/gpgcheck=1/gpgcheck=0/g' /etc/yum.repos.d/securedrop-workstation-dom0.repo
+}
+
+dom0_clean_up() {
+    log "Restoring UpdateVM to original value ($old_updatevm)"
+    qubes-prefs updatevm "$old_updatevm"
+
+    log "Restoring workstation .repo modifications"
+    sudo sed -i 's/http:/https:/g' /etc/yum.repos.d/securedrop-workstation-dom0.repo
+    sudo sed -i 's/gpgcheck=0/gpgcheck=1/g' /etc/yum.repos.d/securedrop-workstation-dom0.repo
+
+    log "Deleting temporarily trusted RPM signing keys"
+    rpm -q gpg-pubkey --qf '%{NVR}\t%{SUMMARY}\n' | grep "$LOCAL_SIG_KEY_NAME" | cut -f1 | xargs -r sudo rpm -e --allmatches
+}
+
+
+vm_gen_signing_key() {
+    # Generate local signing key (if needed). This key will be present in dom0's keyring and
+    # in the dev vm in order to sign the packages. It makes no difference security-wise because
+    # the locally-built pacakges were already being cloned from dom0 without verification.
+
+    # Idempotence: return if key already exists
+    rc=$(gpg -K "$LOCAL_SIG_KEY_NAME" >/dev/null 2>/dev/null; echo $?)
+    if [ "$rc" -eq 0 ]; then
+        log "local signing key already generated"
+        return
+    fi
+
+    log "Creating GPG keyring dir with correct permissions at $GNUPGHOME"
+    mkdir -p $GNUPGHOME && chmod 700 $GNUPGHOME
+
+    gpg --batch --generate-key <<EOF
+%no-protection
+Key-Type: RSA
+Subkey-Type: RSA
+Name-Real: SD dom0 local updates
+Name-Email: local@example.com
+Expire-Date: 0
+EOF
+}
+
+vm_set_up_from_dom0() {
+    # Import the signing key generated on dev vm
+    log "Generating GPG RPM signing key in $SECUREDROP_DEV_VM"
+    qvm-run -p "$SECUREDROP_DEV_VM" -- "ANSI_COLORS=0 $SECUREDROP_DEV_DIR/$0 generate-key"
+    dom0_import_signing_key
+
+    log "Running $(basename "$0") in $SECUREDROP_DEV_VM (in background)"
+    qvm-run -p "$SECUREDROP_DEV_VM" -- "ANSI_COLORS=0 $SECUREDROP_DEV_DIR/$0 run-server"
+
+}
+
+vm_set_up() {
+    build_artifacts_dir="rpm-build/RPMS/noarch"
+    yum_local_root_dir="$(mktemp -d)"
+    yum_local_rpm_dir="$yum_local_root_dir/workstation/dom0/r4.3"
+    yum_url_real="yum.securedrop.org"
+    yum_server_port=80
+
+    log "Killing old servers processes"
+    # Needed because Ctrl+C on dom0 running qvm-run may not kill the process
+    pgrep -f "python3 -m http.server $yum_server_port" | xargs -r sudo kill -9 || :
+
+    log "Patching /etc/hosts to redirect $yum_url_real"
+    sudo cp /etc/hosts /etc/hosts.orig
+    echo 127.0.0.1 $yum_url_real | sudo tee -a /etc/hosts > /dev/null
+
+    log "Creating repo to serve artifacts at $build_artifacts_dir"
+    mkdir -p "$yum_local_rpm_dir"
+    scripts_dir=$(dirname "$0")
+    project_git_root=$(cd "$scripts_dir" && git rev-parse --show-toplevel)
+    cp "$project_git_root/$build_artifacts_dir"/*.rpm "$yum_local_rpm_dir"
+
+    # Sign each RPM file with the key already trusted by dom0
+    for rpm_file in "$yum_local_rpm_dir"/*.rpm; do
+        log "Signing $rpm_file"
+        rpm --addsign "$rpm_file" \
+            --define "%_signature gpg" \
+            --define "%_gpg_name $LOCAL_SIG_KEY_NAME" \
+            --define "%_gpg_path $GNUPGHOME" \
+            --define "%__gpg_sign_command %{__gpg} --no-verbose -u %{_gpg_name} --detach-sign %{__plaintext_filename} --output %{__signature_filename}"
+    done
+
+    # Create a local yum repository
+    createrepo_c "$yum_local_rpm_dir"
+
+    log "Serving directory on $yum_url_real:$yum_server_port"
+    # Serve local server on specified port
+    cd "$yum_local_root_dir"
+    sudo python3 -m http.server "$yum_server_port" # sudo needed to serve on reserved port
+}
+
+vm_clean_up() {
+    log "Restoring UpdateVM to original hosts file"
+    sudo mv /etc/hosts.orig /etc/hosts
+    rm -r "$yum_local_root_dir"
+}
+
+
+vm_main() {
+    # Entry point in case this runs in a VM
+
+    export GNUPGHOME=$SD_DEV_GNUPGHOME
+
+    if [[ "$1" == "generate-key" ]]; then
+        vm_gen_signing_key
+    elif [[ "$1" == "run-server" ]]; then
+        # Ensure cleanup happens because the server component is blocking
+        trap vm_clean_up EXIT
+
+        # Set up server and run it
+        vm_set_up
+    else
+        echo "usage: $0 [generate-key|run-server]" >&2
+        exit 1
+    fi
+}
+
+if [[ "$(hostname)" == "dom0" ]]; then
+    trap dom0_clean_up EXIT
+    dom0_set_up
+    vm_set_up_from_dom0
+else
+    vm_main "$@"
+fi

--- a/scripts/prep-dev
+++ b/scripts/prep-dev
@@ -4,9 +4,7 @@
 # locally built RPM in order to deploy the Salt config.
 set -euo pipefail
 
-
-# The dest directory in dom0 is not customizable.
-dom0_dev_dir="$HOME/securedrop-workstation"
+source "$(dirname "$0")/common.sh"
 
 # Substring to ensure that the primary dom0 config RPM is selected;
 # used to differentiate between the the default RPM and the WIP sd-admin RPM.
@@ -15,13 +13,13 @@ rpm_name="securedrop-workstation-dom0-config"
 function find_latest_rpm() {
     # Look up which version of dom0 we're using.
     fedora_version="$(rpm --eval '%{fedora}')"
-    find "${dom0_dev_dir}/rpm-build/RPMS/" -type f -iname "${rpm_name}*fc${fedora_version}.noarch.rpm" -print0 | xargs -r -0 ls -t | head -n 1
+    find "${DOM0_DEV_DIR}/rpm-build/RPMS/" -type f -iname "${rpm_name}*fc${fedora_version}.noarch.rpm" -print0 | xargs -r -0 ls -t | head -n 1
 }
 
 function find_any_rpm() {
     # Fallback for CI, which renames rpms. Try installing
     # any rpm present in the RPMS directory.
-    find "${dom0_dev_dir}/rpm-build/RPMS/" -type f -iname "${rpm_name}*.rpm" -print0 | xargs -r -0 ls -t | head -n 1
+    find "${DOM0_DEV_DIR}/rpm-build/RPMS/" -type f -iname "${rpm_name}*.rpm" -print0 | xargs -r -0 ls -t | head -n 1
 }
 
 latest_rpm="$(find_latest_rpm)"


### PR DESCRIPTION
Adds an RPM server from the built RPMs. This enables the testing of the
update process. This is only intended to be used for development and in
terms of threat model, it should not change regarding the previous
approach.

It also generates a GPG key to sign the artifacts, as qubes-dom0-update
requires it (see qubes.ReceiveUpdates RPC service). This needs to happen
even in cases where signature checking is disabled.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
- [ ] have some old version installed (e.g. 1.8.0)
- [ ] in dom0 run `./scripts/local-rpm-server.sh`
- [ ] run `sdw-updater`
- [ ] Ensure the installed version is the one from your local build

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
