### PR TITLE
Use Debian 13 in CI

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -50,7 +50,7 @@ jobs:
 
   commit-and-push:
     runs-on: ubuntu-latest
-    container: debian:bookworm
+    container: debian:trixie
     needs:
       - build-rpm
     steps:


### PR DESCRIPTION
Fixes #1711.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] commit-and-push CI job passes
* [ ] no other bookworm references in CI (still a few in salt)
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
