### PR TITLE
Don't have any wildcard versions in pyproject.toml

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2301,4 +2301,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13"
-content-hash = "94e941ff4ea6327071936c7698b95d22f73dee707761068775652b7f78cbfff9"
+content-hash = "d40c7caa3e9da74c4b26badd68813b6ee68c3ab8c7ae3fae4eef0ba5074bee8d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,9 @@ types-setuptools = "^75.6.0"
 ruff = "^0.8.5"
 python-debian = "^0.1.49"
 pysequoia = "^0.1.25"
-zizmor = "*"
+zizmor = "^1.0.0"
 python-systemd = "^0.0.9"
-semgrep = "*"
+semgrep = "^1.161.0"
 pytest-mock = "^3.15.1"
 
 [tool.poetry.group.system-package-equivalents.dependencies]


### PR DESCRIPTION
dependabot gets confused and thinks because any version is acceptable, it can do dependency resolution by e.g. downgrading semgrep, which we don't want.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
just visual review should be fine
