### PR TITLE
Run `rpmlint` against built RPMs

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -38,8 +38,9 @@ jobs:
       - name: Build RPM
         run: |
           git config --global --add safe.directory '*'
-          # Version format is "${VERSION}-0.YYYYMMDDHHMMSS.fXX", which sorts lower than "${VERSION}-1"
-          rpmdev-bumpspec --new="$(cat VERSION)-0.$(date +%Y%m%d%H%M%S)%{?dist}" rpm-build/SPECS/*.spec
+          # Version format is "${VERSION}-0.YYYYMMDDHHMMSS.fXX", which sorts lower than "${VERSION}-1".
+          version="$(rpmspec -q --srpm --qf '%{version}' rpm-build/SPECS/*.spec)"
+          rpmdev-bumpspec --new="${version}-0.$(date +%Y%m%d%H%M%S)%{?dist}" rpm-build/SPECS/*.spec
           make build-rpm
       - uses: actions/upload-artifact@v7
         id: upload

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build RPM
         run: |
           git config --global --add safe.directory '*'
-          # Version format is "${VERSION}-0.YYYYMMDDHHMMSS.fXX", which sorts lower than "${VERSION}-1".
+          # Version format is "${version}-0.YYYYMMDDHHMMSS.fXX", which sorts lower than "${version}-1".
           version="$(rpmspec -q --srpm --qf '%{version}' rpm-build/SPECS/*.spec)"
           rpmdev-bumpspec --new="${version}-0.$(date +%Y%m%d%H%M%S)%{?dist}" rpm-build/SPECS/*.spec
           make build-rpm

--- a/Makefile
+++ b/Makefile
@@ -92,12 +92,12 @@ reprotest: ## Check RPM package reproducibility
 .PHONY: build-deps
 build-deps: ## Install package dependencies to build RPMs
 # Note: build dependencies are specified in the spec file, not here
-	dnf install -y git file rpmdevtools dnf-plugins-core rpm-build
+	dnf install -y git file rpmdevtools dnf-plugins-core rpm-build rpmlint
 	dnf builddep -y $(SPEC_FILE)
 
 .PHONY: test-deps
 test-deps: build-deps ## Install package dependencies for running tests
-	dnf install -y xorg-x11-server-Xvfb rpmlint which libfaketime \
+	dnf install -y xorg-x11-server-Xvfb rpmlint which libfaketime ShellCheck \
 		hostname python3-setuptools
 	dnf --setopt=install_weak_deps=False -y install reprotest
 
@@ -228,7 +228,7 @@ venv: ## Provision a Python 3 virtualenv for development (ensure to also install
 check: lint test ## Runs linters and tests
 
 .PHONY: lint
-lint: check-ruff mypy rpmlint shellcheck zizmor semgrep ## Runs all linters
+lint: check-ruff mypy shellcheck zizmor semgrep ## Runs all linters
 
 
 ifneq ($(HOST),dom0)  # Not necessary in dom0
@@ -251,10 +251,6 @@ fix: ## Fix Python source code formatting with ruff
 .PHONY: mypy
 mypy:  ## Type check Python files
 	poetry run mypy .
-
-.PHONY: rpmlint
-rpmlint: ## Runs rpmlint on the spec file
-	$(CONTAINER) rpmlint rpm-build/SPECS/*.spec
 
 .PHONY: shellcheck
 shellcheck: ## Runs shellcheck on all shell scripts

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.rpmlintrc
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.rpmlintrc
@@ -1,0 +1,27 @@
+# this file contains suppressions for rpmlint
+
+# we use /tmp for our migration flag system
+addFilter(r"use-tmp-in-%\w+")
+
+# our update-xfce-settings script
+addFilter(r"subdir-in-bin /usr/bin/securedrop/")
+
+# we don't want conffile semantics, our version should always win
+addFilter(r"non-conffile-in-etc /etc/qubes-rpc/")
+addFilter(r"non-conffile-in-etc /etc/qubes/policy.d/")
+addFilter(r"non-conffile-in-etc /etc/systemd/logind.conf.d/")
+
+# don't care about man pages
+addFilter(r"no-manual-page-for-binary")
+
+# FIXME: our versioning schema is a bit busted
+addFilter(r"incoherent-version-in-changelog")
+addFilter(r"invalid-version")
+
+# TODO: can we de-dupe these?
+addFilter(r"files-duplicate /usr/share/securedrop/icons/sd-logo.png")
+
+# we build in place from a git checkout, so there's nothing to unpack, and the
+# test suite runs outside of rpmbuild
+addFilter(r"no-%prep-section")
+addFilter(r"no-%check-section")

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.rpmlintrc
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.rpmlintrc
@@ -14,10 +14,6 @@ addFilter(r"non-conffile-in-etc /etc/systemd/logind.conf.d/")
 # don't care about man pages
 addFilter(r"no-manual-page-for-binary")
 
-# FIXME: our versioning schema is a bit busted
-addFilter(r"incoherent-version-in-changelog")
-addFilter(r"invalid-version")
-
 # TODO: can we de-dupe these?
 addFilter(r"files-duplicate /usr/share/securedrop/icons/sd-logo.png")
 

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -72,6 +72,7 @@ install -m 644 sdw_util/*.py %{buildroot}%{python3_sitelib}/sdw_util/
 
 install -m 755 -d %{buildroot}/srv/salt/
 cp -a securedrop_salt %{buildroot}/srv/salt/
+chmod -R u=rwX,go=rX %{buildroot}/srv/salt/securedrop_salt
 
 install -m 755 -d %{buildroot}%{_datadir}/%{name}/scripts
 install -m 755 -d %{buildroot}%{_bindir}
@@ -122,6 +123,7 @@ install -m 644 files/securedrop-user-xfce-settings.service %{buildroot}%{_userun
 install -m 644 files/securedrop-user-xfce-icon-size.service %{buildroot}%{_userunitdir}/
 
 cp -a admin_salt %{buildroot}/srv/salt/admin_salt
+chmod -R u=rwX,go=rX %{buildroot}/srv/salt/admin_salt
 
 # Install shared apt source templates into admin_salt so the admin package
 # can reference them via salt://admin_salt/ without depending on the

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -1,7 +1,7 @@
-Name:		securedrop-workstation-dom0-config
-Version:	1.10.0rc1
-Release:	1%{?dist}
-Summary:	SecureDrop Workstation
+Name:           securedrop-workstation-dom0-config
+Version:        1.10.0rc1
+Release:        1%{?dist}
+Summary:        SecureDrop Workstation
 
 # For reproducible builds:
 #
@@ -25,14 +25,12 @@ Summary:	SecureDrop Workstation
 # root policy.
 %undefine py_auto_byte_compile
 
-License:	AGPLv3
-URL:		https://github.com/freedomofpress/securedrop-workstation
-# See: https://docs.fedoraproject.org/en-US/packaging-guidelines/SourceURL/#_troublesome_urls
-Source:		%{url}/archive/refs/tags/%{version}.tar.gz#/%{name}-%{version}.tar.gz
+License:        AGPL-3.0-or-later
+URL:            https://github.com/freedomofpress/securedrop-workstation
 
-BuildArch:		noarch
-BuildRequires:	python3-devel
-BuildRequires:	systemd-rpm-macros
+BuildArch:      noarch
+BuildRequires:  python3-devel
+BuildRequires:  systemd-rpm-macros
 
 # This package installs all standard VMs in Qubes
 Requires:   qubes-mgmt-salt-dom0-virtual-machines
@@ -52,8 +50,8 @@ in dom0, or AdminVM, context, in order to manage updates to the VM
 configuration over time.
 
 %package -n securedrop-admin-dom0-config
-Summary: SecureDrop Admin
-Requires: qubes-mgmt-salt-dom0-virtual-machines
+Summary:        SecureDrop Admin
+Requires:       qubes-mgmt-salt-dom0-virtual-machines
 %description -n securedrop-admin-dom0-config
 This package contains VM configuration files for the Qubes-based
 SecureDrop Admin project. The package should be installed
@@ -175,6 +173,7 @@ install -m 644 securedrop_salt/apt-test_freedom_press.sources.j2 %{buildroot}/sr
 
 %files -n securedrop-admin-dom0-config
 /srv/salt/admin_salt/*
+%doc README.md
 %license LICENSE
 
 %post

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -1,5 +1,5 @@
 Name:           securedrop-workstation-dom0-config
-Version:        1.10.0rc1
+Version:        1.10.0~rc1
 Release:        1%{?dist}
 Summary:        SecureDrop Workstation
 
@@ -215,7 +215,7 @@ touch /tmp/sdw-migrations/debian-13-bump
 qubesctl top.disable securedrop_salt.sd-workstation
 
 %changelog
-* Wed Sep 02 2026 SecureDrop Team <securedrop@freedom.press> - 1.10.0rc1
+* Wed Sep 02 2026 SecureDrop Team <securedrop@freedom.press> - 1.10.0~rc1-1
 - See changelog.md
 
 * Tue Sep 01 2026 SecureDrop Team <securedrop@freedom.press> - 1.9.0

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -29,4 +29,4 @@ rpmlint --strict --rpmlintrc "rpm-build/SPECS/${PROJECT}.rpmlintrc" \
     rpm-build/RPMS/noarch/*.rpm
 
 printf '\nBuild complete! RPMs and their checksums are:\n\n'
-find rpm-build/ -type f -iname "securedrop-*-$(cat "${TOPLEVEL}/VERSION")*.rpm" -print0 | sort -zV | xargs -0 sha256sum
+find rpm-build/ -type f -iname "securedrop-*-$(cat "${TOPLEVEL}/VERSION")*.rpm" -print0 | sort -zV | xargs -r -0 sha256sum

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -23,5 +23,10 @@ rpmbuild \
 # Check reproducibility
 python3 scripts/verify_rpm_mtime.py
 
+# Lint .spec and built RPMs
+rpmlint --strict --rpmlintrc "rpm-build/SPECS/${PROJECT}.rpmlintrc" \
+    "rpm-build/SPECS/${PROJECT}.spec" \
+    rpm-build/RPMS/noarch/*.rpm
+
 printf '\nBuild complete! RPMs and their checksums are:\n\n'
 find rpm-build/ -type f -iname "securedrop-*-$(cat "${TOPLEVEL}/VERSION")*.rpm" -print0 | sort -zV | xargs -0 sha256sum

--- a/update_version.py
+++ b/update_version.py
@@ -2,6 +2,7 @@
 
 import argparse
 import datetime
+import re
 from pathlib import Path
 
 spec = Path("rpm-build/SPECS/securedrop-workstation-dom0-config.spec")
@@ -12,21 +13,24 @@ parser = argparse.ArgumentParser()
 parser.add_argument("version", help="new version")
 args = parser.parse_args()
 
-# We want the Python and RPM versions to match, so we'll use a PEP 440
-# compatible version, e.g. 0.9.0rc1 or 0.9.0.
+# VERSION is a PEP 440 compatible version, e.g. 0.9.0rc1 or 0.9.0.
 new_version = args.version.replace("-", "").replace("~", "")
+
+# RPM compares "0.9.0rc1" as greater than "0.9.0", so pre-releases need a "~"
+# to sort below the release they precede, e.g. 0.9.0~rc1.
+rpm_version = re.sub(r"(a|b|rc)(\d+)$", r"~\1\2", new_version)
 
 # Update the version in the spec file and VERSION.
 Path("VERSION").write_text(new_version + "\n")
 spec_lines = spec.read_text().splitlines()
 for i, line in enumerate(spec_lines):
     if line.startswith("Version:"):
-        spec_lines[i] = f"Version:\t{new_version}"
+        spec_lines[i] = f"Version:\t{rpm_version}"
     elif line.startswith("%changelog"):
         current_date = datetime.datetime.now().strftime("%a %b %d %Y")
-        changelog_entry = f"* {current_date} {author} - {new_version}\n- {message}\n"
+        changelog_entry = f"* {current_date} {author} - {rpm_version}-1\n- {message}\n"
         spec_lines.insert(i + 1, changelog_entry)
 
 spec.write_text("\n".join(spec_lines) + "\n")
 
-print(f"Updated version to {new_version}")
+print(f"Updated version to {new_version} (RPM: {rpm_version})")

--- a/update_version.py
+++ b/update_version.py
@@ -25,7 +25,7 @@ Path("VERSION").write_text(new_version + "\n")
 spec_lines = spec.read_text().splitlines()
 for i, line in enumerate(spec_lines):
     if line.startswith("Version:"):
-        spec_lines[i] = f"Version:\t{rpm_version}"
+        spec_lines[i] = f"Version:        {rpm_version}"
     elif line.startswith("%changelog"):
         current_date = datetime.datetime.now().strftime("%a %b %d %Y")
         changelog_entry = f"* {current_date} {author} - {rpm_version}-1\n- {message}\n"


### PR DESCRIPTION
See individual commits for rationales.

Fixes #1757.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] visual review
* [x] CI is happy
* [x] no functional changes, if you diffoscoped the only change should be that the version format has changed.
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
