### PR TITLE
Use shellcheck-py package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ build-deps: ## Install package dependencies to build RPMs
 
 .PHONY: test-deps
 test-deps: build-deps ## Install package dependencies for running tests
-	dnf install -y xorg-x11-server-Xvfb rpmlint which libfaketime ShellCheck \
+	dnf install -y xorg-x11-server-Xvfb rpmlint which libfaketime \
 		hostname python3-setuptools
 	dnf --setopt=install_weak_deps=False -y install reprotest
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2019,6 +2019,21 @@ urllib3 = ">=2.0,<3.0"
 wcmatch = ">=8.3,<9.0"
 
 [[package]]
+name = "shellcheck-py"
+version = "0.11.0.1"
+description = "Python wrapper around invoking shellcheck (https://www.shellcheck.net/)"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "shellcheck_py-0.11.0.1-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:b6a3fee28efda2e16e38d6e6d59faf7224300256456639727370d404730849e8"},
+    {file = "shellcheck_py-0.11.0.1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:6b88d0a244c82ed07e06a53e444da841f69330ca59ae15d4a66c391655dae7a0"},
+    {file = "shellcheck_py-0.11.0.1-py2.py3-none-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1b274df81de5b000ff78db433e7328b87e52e3c38481c60f8e488c3095beef05"},
+    {file = "shellcheck_py-0.11.0.1-py2.py3-none-win_amd64.whl", hash = "sha256:784156289ecb17e91c692cd783ab5152333309588cabb10032a047331c63e759"},
+    {file = "shellcheck_py-0.11.0.1.tar.gz", hash = "sha256:5c620c88901e8f1d3be5934b31ea99e3310065e1245253741eafd0a275c8c9cc"},
+]
+
+[[package]]
 name = "sse-starlette"
 version = "3.4.1"
 description = "SSE plugin for Starlette"
@@ -2301,4 +2316,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13"
-content-hash = "d40c7caa3e9da74c4b26badd68813b6ee68c3ab8c7ae3fae4eef0ba5074bee8d"
+content-hash = "818f7360273535d3282af4ed1778e7e24a19333b6bb065fe73ef557c9f611350"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ zizmor = "^1.0.0"
 python-systemd = "^0.0.9"
 semgrep = "^1.161.0"
 pytest-mock = "^3.15.1"
+shellcheck-py = "^0.11.0.1"
 
 [tool.poetry.group.system-package-equivalents.dependencies]
 # In production these are installed as a system package so match the

--- a/scripts/shellcheck.sh
+++ b/scripts/shellcheck.sh
@@ -2,18 +2,7 @@
 
 set -e
 
-source "$(dirname "$0")/common.sh"
-
-function run_native_or_in_container () {
-    EXCLUDE_RULES="SC1090,SC1091"
-    if [ "$(command -v shellcheck)" ]; then
-        shellcheck -x --exclude="$EXCLUDE_RULES" "$@"
-    else
-        $OCI_BIN run --rm -v "$(pwd):/sd:Z" -w /sd \
-            -t docker.io/koalaman/shellcheck:stable \
-            -x --exclude=$EXCLUDE_RULES "$@"
-    fi
-}
+EXCLUDE_RULES="SC1090,SC1091"
 
 # Omitting:
 # - the `.git/` directory since its hooks won't pass # validation, and
@@ -37,4 +26,4 @@ readarray -t FILES <<<"$(find "." \
     | awk '$2 ~ /x-shellscript/ { print $1 }' \
     | sed 's/://')"
 
-run_native_or_in_container "${FILES[@]}"
+poetry run shellcheck -x --exclude="$EXCLUDE_RULES" "${FILES[@]}"


### PR DESCRIPTION
As we do in the server; this greatly simplifies how we run shellcheck and means we're using the same version everywhere and are no longer relying on a third-party docker image.

----

I noticed this when working on the rpmlint PR and was confused why we were pulling in the docker image.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] CI is happy
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
