### PR TITLE
Specify OpenQA scenarios in this repo

### DIFF
--- a/.github/openqa-scenarios.yml
+++ b/.github/openqa-scenarios.yml
@@ -1,0 +1,42 @@
+products:
+  qubesos-*-securedrop-x86_64:
+    distri: qubesos
+    flavor: securedrop
+    version: '*'
+    arch: "x86_64"
+    settings:
+      KERNEL_VERSION: "stable"
+      WORKER_CLASS: "local,smep"
+
+job_templates:
+  securedrop_install:
+    product: "qubesos-*-securedrop-x86_64"
+    machine: "64bit"
+    settings:
+      HDD_1: "disk_unencrypted_%VERSION%_%MACHINE%_%KERNEL_VERSION%.qcow2"
+      KERNEL_VERSION: "stable"
+      SECUREDROP_INSTALL: "1"
+      STORE_HDD_1: "disk_securedrop.qcow2"
+  securedrop_upgrade:
+    product: "qubesos-*-securedrop-x86_64"
+    machine: "64bit"
+    settings:
+      HDD_1: "disk_securedrop_installed.qcow2"
+      SECUREDROP_UPGRADE: "1"
+      START_AFTER_TEST: "securedrop_install"
+      STORE_HDD_1: "disk_securedrop.qcow2"
+      WORKER_CLASS: "local,smep"
+  securedrop_test_dom0:
+    product: "qubesos-*-securedrop-x86_64"
+    machine: "64bit"
+    settings:
+      HDD_1: "disk_securedrop.qcow2"
+      SECUREDROP_TEST: "test_dom0"
+      START_AFTER_TEST: "securedrop_install"
+  securedrop_test_gui:
+    product: "qubesos-*-securedrop-x86_64"
+    machine: "64bit"
+    settings:
+      HDD_1: "disk_securedrop.qcow2"
+      SECUREDROP_TEST: "test_dom0"
+      START_AFTER_TEST: "securedrop_install"

--- a/.github/openqa-scenarios/dev_clean-install.yml
+++ b/.github/openqa-scenarios/dev_clean-install.yml
@@ -1,13 +1,3 @@
-products:
-  qubesos-*-securedrop-x86_64:
-    distri: qubesos
-    flavor: securedrop
-    version: '*'
-    arch: "x86_64"
-    settings:
-      KERNEL_VERSION: "stable"
-      WORKER_CLASS: "local,smep"
-
 job_templates:
   securedrop_install:
     product: "qubesos-*-securedrop-x86_64"

--- a/.github/openqa-scenarios/dev_clean-install.yml
+++ b/.github/openqa-scenarios/dev_clean-install.yml
@@ -1,0 +1,33 @@
+products:
+  qubesos-*-securedrop-x86_64:
+    distri: qubesos
+    flavor: securedrop
+    version: '*'
+    arch: "x86_64"
+    settings:
+      KERNEL_VERSION: "stable"
+      WORKER_CLASS: "local,smep"
+
+job_templates:
+  securedrop_install:
+    product: "qubesos-*-securedrop-x86_64"
+    machine: "64bit"
+    settings:
+      HDD_1: "disk_unencrypted_%VERSION%_%MACHINE%_%KERNEL_VERSION%.qcow2"
+      KERNEL_VERSION: "stable"
+      SECUREDROP_INSTALL: "1"
+      STORE_HDD_1: "disk_securedrop.qcow2"
+  securedrop_test_dom0:
+    product: "qubesos-*-securedrop-x86_64"
+    machine: "64bit"
+    settings:
+      HDD_1: "disk_securedrop.qcow2"
+      SECUREDROP_TEST: "test_dom0"
+      START_AFTER_TEST: "securedrop_install"
+  securedrop_test_gui:
+    product: "qubesos-*-securedrop-x86_64"
+    machine: "64bit"
+    settings:
+      HDD_1: "disk_securedrop.qcow2"
+      SECUREDROP_TEST: "test_dom0"
+      START_AFTER_TEST: "securedrop_install"

--- a/.github/openqa-scenarios/dev_upgrade-from-prod.yml
+++ b/.github/openqa-scenarios/dev_upgrade-from-prod.yml
@@ -1,13 +1,3 @@
-products:
-  qubesos-*-securedrop-x86_64:
-    distri: qubesos
-    flavor: securedrop
-    version: '*'
-    arch: "x86_64"
-    settings:
-      KERNEL_VERSION: "stable"
-      WORKER_CLASS: "local,smep"
-
 job_templates:
   securedrop_install:
     product: "qubesos-*-securedrop-x86_64"

--- a/.github/openqa-scenarios/dev_upgrade-from-prod.yml
+++ b/.github/openqa-scenarios/dev_upgrade-from-prod.yml
@@ -16,7 +16,8 @@ job_templates:
       HDD_1: "disk_unencrypted_%VERSION%_%MACHINE%_%KERNEL_VERSION%.qcow2"
       KERNEL_VERSION: "stable"
       SECUREDROP_INSTALL: "1"
-      STORE_HDD_1: "disk_securedrop.qcow2"
+      STORE_HDD_1: "disk_securedrop_installed.qcow2"
+      SECUREDROP_ENV: "prod"
   securedrop_upgrade:
     product: "qubesos-*-securedrop-x86_64"
     machine: "64bit"
@@ -32,11 +33,11 @@ job_templates:
     settings:
       HDD_1: "disk_securedrop.qcow2"
       SECUREDROP_TEST: "test_dom0"
-      START_AFTER_TEST: "securedrop_install"
+      START_AFTER_TEST: "securedrop_upgrade"
   securedrop_test_gui:
     product: "qubesos-*-securedrop-x86_64"
     machine: "64bit"
     settings:
       HDD_1: "disk_securedrop.qcow2"
       SECUREDROP_TEST: "test_dom0"
-      START_AFTER_TEST: "securedrop_install"
+      START_AFTER_TEST: "securedrop_upgrade"

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -130,7 +130,9 @@ jobs:
       fail-fast: false
       matrix:
         qubes_version: ["4.3"]
+        scenario: ["upgrade-from-prod", "clean-install"]
     with:
       environment: "dev"
+      scenario: ${{ matrix.scenario }}
       git_ref: ${{ needs.get-main-commit.outputs.main-commit}}
       qubes_ver: ${{ matrix.qubes_version }}

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -5,9 +5,7 @@ on:
   push:
     branches:
       - main
-  pull_request:  # To test changes in this workflow
-    paths:
-      - '.github/workflows/nightlies.yml'
+  workflow_dispatch:  # To test changes in this workflow
 
 # Only allow one job to run at a time because we're pushing to git repos;
 # the string value doesn't matter, just that it's a fixed string.

--- a/.github/workflows/openqa-pull-request.yml
+++ b/.github/workflows/openqa-pull-request.yml
@@ -72,11 +72,12 @@ jobs:
       fail-fast: false
       matrix:
         qubes_version: ${{ fromJSON(needs.check.outputs.qubes-versions) }}
+        scenario: ["upgrade-from-prod", "clean-install"]
     uses: ./.github/workflows/openqa.yml
     secrets: inherit
     with:
       environment: "dev"
-      scenario: "upgrade-from-prod"
+      scenario: ${{ matrix.scenario }}
       git_ref: ${{ github.event.pull_request.head.sha }}
       qubes_ver: ${{ matrix.qubes_version }}
 

--- a/.github/workflows/openqa-pull-request.yml
+++ b/.github/workflows/openqa-pull-request.yml
@@ -76,6 +76,7 @@ jobs:
     secrets: inherit
     with:
       environment: "dev"
+      scenario: "upgrade-from-prod"
       git_ref: ${{ github.event.pull_request.head.sha }}
       qubes_ver: ${{ matrix.qubes_version }}
 

--- a/.github/workflows/openqa.yml
+++ b/.github/workflows/openqa.yml
@@ -46,6 +46,7 @@ jobs:
       OPENQA_HOST: "https://openqa.qubes-os.org/"
       OPENQA_KEY: ${{ secrets.OPENQA_KEY }}
       OPENQA_SECRET: ${{ secrets.OPENQA_SECRET }}
+      OPENQA_JOB_NAME: "Qubes ${{ inputs.qubes_ver }} / ${{ inputs.scenario }} / ${{ inputs.environment }}"
       GIT_REF: ${{ inputs.git_ref }}
       GH_TOKEN: ${{ github.token }}
       SECUREDROP_ENV: ${{ inputs.environment }}
@@ -126,7 +127,7 @@ jobs:
             -H "Authorization: Bearer $GH_TOKEN"\
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{ github.repository }}/commits/$GIT_REF/statuses \
-            -d "{\"state\": \"pending\", \"target_url\": \"${OPENQA_HOST}tests/${id}\", \"context\": \"OpenQA / ${QUBES_VER} / $TEST_NAME\"}"
+            -d "{\"state\": \"pending\", \"target_url\": \"${OPENQA_HOST}tests/${id}\", \"context\": \"${OPENQA_JOB_NAME} / $TEST_NAME\"}"
 
           done
       - name: Wait for openQA
@@ -177,7 +178,7 @@ jobs:
             -H "Authorization: Bearer $GH_TOKEN"\
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{ github.repository }}/commits/$GIT_REF/statuses \
-            -d "{\"state\": \"$github_state\", \"target_url\": \"${OPENQA_HOST}tests/${id}\", \"context\": \"OpenQA / ${QUBES_VER} / $TEST_NAME\"}"
+            -d "{\"state\": \"$github_state\", \"target_url\": \"${OPENQA_HOST}tests/${id}\", \"context\": \"${OPENQA_JOB_NAME} / $TEST_NAME\"}"
 
           done
           exit $workflow_exit_status
@@ -199,5 +200,5 @@ jobs:
             -H "Authorization: Bearer $GH_TOKEN"\
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{ github.repository }}/commits/$GIT_REF/statuses \
-            -d "{\"state\": \"error\", \"target_url\": \"${OPENQA_HOST}tests/${id}\", \"context\": \"OpenQA / ${QUBES_VER} / $TEST_NAME\"}" ||:
+            -d "{\"state\": \"error\", \"target_url\": \"${OPENQA_HOST}tests/${id}\", \"context\": \"${OPENQA_JOB_NAME} / $TEST_NAME\"}" ||:
           done

--- a/.github/workflows/openqa.yml
+++ b/.github/workflows/openqa.yml
@@ -7,6 +7,9 @@ on:
       environment:
         required: true
         type: string
+      scenario:
+        required: true
+        type: string
       git_ref:
         required: true
         type: string
@@ -51,6 +54,7 @@ jobs:
       SECUREDROP_OPENQA_REPO_BRANCH: "main"
       # The URL to clone the remote OpenQA repo from (useful for forks):
       SECUREDROP_OPENQA_REPO_URL: "https://github.com/freedomofpress/openqa-tests-qubesos"
+      SCENARIO_FILENAME: "${{ inputs.environment }}_${{ inputs.scenario }}.yml"
       QUBES_VER: ${{ inputs.qubes_ver }}
     container:
       image: debian:trixie
@@ -60,14 +64,24 @@ jobs:
           apt-get update
           apt-get install --yes openqa-client jq yq curl
 
+      - name: Fetch OpenQA scenario definition from repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.ref }}
+          path: sdw
+          sparse-checkout: .github/openqa-scenarios/${{ inputs.environment }}_${{ inputs.scenario }}.yml
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
       # Customize the test jobs and their configuration variables
       - name: Build OpenQA scenario definitions
         run: |
           set -euo pipefail
-          curl -fsSL -o openqa-scenarios.yml \
-            "https://raw.githubusercontent.com/${{ github.repository }}/${GIT_REF}/.github/openqa-scenarios.yml"
           curl -fsSL -o templates.json \
             "https://raw.githubusercontent.com/QubesOS/openqa-tests-qubesos/main/templates.json"
+
+          # Move to generic location
+          cp "${GITHUB_WORKSPACE}/sdw/.github/openqa-scenarios/${SCENARIO_FILENAME}" openqa-scenarios.yml
 
           # NOTE: scenarios.yml seems to be a standalone file that also needs the
           # OpenQA machines list, so we need to upstream worker machines list into it

--- a/.github/workflows/openqa.yml
+++ b/.github/workflows/openqa.yml
@@ -25,7 +25,7 @@ on:
 #      in a no-op, but importantly, the previous OpenQA job is cancelled since
 #      through concurrency there can only be one
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.environment }}-${{ inputs.qubes_ver }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.scenario }}-${{ inputs.environment }}-${{ inputs.qubes_ver }}
   cancel-in-progress: true
 
 jobs:
@@ -55,13 +55,28 @@ jobs:
     container:
       image: debian:trixie
     steps:
-      - uses: actions/checkout@v7
-        with:
-          persist-credentials: false
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install --yes openqa-client jq curl
+          apt-get install --yes openqa-client jq yq curl
+
+      # Customize the test jobs and their configuration variables
+      - name: Build OpenQA scenario definitions
+        run: |
+          set -euo pipefail
+          curl -fsSL -o openqa-scenarios.yml \
+            "https://raw.githubusercontent.com/${{ github.repository }}/${GIT_REF}/.github/openqa-scenarios.yml"
+          curl -fsSL -o templates.json \
+            "https://raw.githubusercontent.com/QubesOS/openqa-tests-qubesos/main/templates.json"
+
+          # NOTE: scenarios.yml seems to be a standalone file that also needs the
+          # OpenQA machines list, so we need to upstream worker machines list into it
+          yq -y '
+            .Machines
+            | INDEX(.name)["64bit"]
+            | {machines: {(.name): (del(.name) | .settings |= from_entries)}}
+          ' templates.json >> openqa-scenarios.yml
+
       - name: Start openQA jobs
         run: |
           echo "Queuing openQA jobs for commit ${GIT_REF}"
@@ -69,6 +84,7 @@ jobs:
             --host "$OPENQA_HOST" \
             --apikey "$OPENQA_KEY" \
             --apisecret "$OPENQA_SECRET" \
+            --param-file SCENARIO_DEFINITIONS_YAML=./openqa-scenarios.yml \
             isos -X post \
             VERSION=${QUBES_VER} \
             BUILD=$(date +%Y%m%d%H%M)-${QUBES_VER} \

--- a/.github/workflows/openqa.yml
+++ b/.github/workflows/openqa.yml
@@ -92,6 +92,13 @@ jobs:
             | {machines: {(.name): (del(.name) | .settings |= from_entries)}}
           ' templates.json >> openqa-scenarios.yml
 
+          # Build add products from templates.json (in the future we may hard-code these)
+          yq -y '
+            .Products
+            | INDEX(.flavor)["securedrop"]
+            | {products: {"\(.distri)-\(.version)-\(.flavor)-\(.arch)": (.settings |= from_entries)}}
+          ' templates.json >> openqa-scenarios.yml
+
       - name: Start openQA jobs
         run: |
           echo "Queuing openQA jobs for commit ${GIT_REF}"


### PR DESCRIPTION
Uses [`SCENARIO_DEFINITIONS_YAML`](https://open.qa/docs/#defining-test-scenarios-in-yaml) to replace scenarios defined in OpenQA directly. This was needed as we couldn't change the OpenQA job templates. It also adds two scenarios: clean install and upgrade from prod.


 **TIP:** For the review to get a better grasp of how this parameter works:
> 1. Create a `openqa-scenarios.yml` (see [example](https://gist.github.com/deeplow/3d368d36be4651ff8b37a9d58577a8d6))
> 2. Call the cli tool with the following parameters
> 
> <details>
>
> ```
> openqa-cli api -X POST isos --host openqa.qubes-os.org --param-file SCENARIO_DEFINITIONS_YAML=./openqa-scenarios.yml VERSION=4.3 BUILD=$(date +%Y%m%d%H)-4.3 DISTRI=qubesos ARCH=x86_64 FLAVOR=securedrop MAX_JOB_TIME=21600 SECUREDROP_UPGRADE=1 SECUREDROP_ENV=dev GIT_REF=main NEEDLES_DIR="%%CASEDIR%%/needles" CPU_FLAGS=mba CASEDIR="https://github.com/freedomofpress/openqa-tests-qubesos.git#main" XRES=1920 YRES=1080
> ```
> </details>

Implementation notes:
- _Hard-coded scenarios_: simpler for now. Plans on future work to to template those files so that we don't repeat ourselves. This should be helpful as we add more scenarios (e.g. weekly prod install).  
- _Scenario naming_: it calls `upgrade` and `clean-install` to the scenario names. In [the wiki](https://github.com/freedomofpress/securedrop-workstation/wiki/QA-Testing#testing-rcs) we're calling them: `Upgrade testing` and `Clean Installation`.
- _Machine / Product not hard-coded_: OpenQA was complaining about a missing list of machines / product definition. If absent I'd have expected it to grab it from the [instance's list of machines](https://openqa.qubes-os.org/admin/machines), but apparently not. Instead of hard-coding it, I'm pulling at runtime directly from the data on [Qubes' OpenQA repo](https://github.com/QubesOS/openqa-tests-qubesos/blob/3e7bd97/templates.json#L45-L91) (this is only done for the machine we had in our tests).
- _Nightlies were interfering_ :warning: — I disabled nightlies testing in the same branch hoping we could run it via `workflow_dispatch`, but I didn't manage to find the trigger button. Maybe it's because the `workflow_dispatch` trigger is not yet on main :thinking:.

Future tasks suggestions (in separate PR):
- [ ] _Templated scenarios_: avoid duplication as scenarios grow. The duplication can't be a trivial file merge merging since `START_AFTER_TEST` for the actual tests (gui, dom0 tests, etc.) is different for clean install tests and upgrade tests.
- [ ] Consider running only clean install testing by default and but a way to trigger upgrade testing scenarios prior to merging.

## Suggested Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

Code-review:
- [ ] visual review
- [ ] Scenarios files correctly adapted from SDW's [job template](https://openqa.qubes-os.org/admin/job_templates/14) (lists the scenarios) and the [variables for each test](https://openqa.qubes-os.org/admin/test_suites) are correct (on this page, search for "securedrop")

Dynamic testing: 
- [ ] two scenarios triggered: clean install + upgrade from prod
- [ ] GitHub statuses shown for each scenario maps to what's in its scenario YAML (count # of tests matches, at least)
- [ ] Figure out how to trigger the nightlies and see that it creates similar jobs


## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
