### PR TITLE
Don't access VMs during test collection

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -125,6 +125,13 @@ class QubeWrapper:
             devices_attachable -- VM can have devices attached to it
         """
 
+        if "PYTEST_CURRENT_TEST" not in os.environ:
+            raise RuntimeError(
+                f"QubeWrapper({name!r}) was instantiated outside a fixture or test "
+                "(likely at import/collection time). Instantiating it talks to qubesd "
+                "and starts the VM, so it must happen inside a fixture or a test."
+            )
+
         self.name = name
         self.app = Qubes()
         self.vm = self.app.domains[self.name]

--- a/tests/test_vm_sd_devices.py
+++ b/tests/test_vm_sd_devices.py
@@ -3,6 +3,8 @@ Integration tests for validating SecureDrop Workstation config,
 specifically for the "sd-devices" VM and related functionality.
 """
 
+from collections.abc import Callable
+
 import pytest
 from qubesadmin.app import VMCollection
 
@@ -17,37 +19,51 @@ from tests.base import (
 # NOTE: this file needs includes tests for the functionally similar 'sd-devices'
 # and 'sd-printers'. Some tests overlap (tested on both through the 'qube' fixture)
 # and some only happen in one VM. In this last case dedicated qube fixtures are used
-_qubes = {
-    "sd-devices": QubeWrapper(
-        "sd-devices",
-        expected_config_keys={"SD_MIME_HANDLING"},
-        mime_types_handling=True,
-        devices_attachable=True,
-    ),
-    "sd-printers": QubeWrapper(
-        "sd-printers",
-        expected_config_keys={"SD_MIME_HANDLING"},
-        mime_types_handling=True,
-        mime_vars_vm_name="sd-devices",  # MIME-wise it behaves similarly
-        devices_attachable=True,
-    ),
+_qube_kwargs = {
+    "sd-devices": {
+        "expected_config_keys": {"SD_MIME_HANDLING"},
+        "mime_types_handling": True,
+        "devices_attachable": True,
+    },
+    "sd-printers": {
+        "expected_config_keys": {"SD_MIME_HANDLING"},
+        "mime_types_handling": True,
+        "mime_vars_vm_name": "sd-devices",  # MIME-wise it behaves similarly
+        "devices_attachable": True,
+    },
 }
 
 
 @pytest.fixture(scope="module")
-def qube_sd_devices() -> QubeWrapper:
-    return _qubes["sd-devices"]
+def qube_factory() -> Callable[[str], QubeWrapper]:
+    """
+    Build (and cache) QubeWrapper instances lazily, so that merely collecting
+    this module does not talk to qubesd or boot any VM.
+    """
+    cache: dict[str, QubeWrapper] = {}
+
+    def _get(name: str) -> QubeWrapper:
+        if name not in cache:
+            cache[name] = QubeWrapper(name, **_qube_kwargs[name])  # type: ignore[arg-type]
+        return cache[name]
+
+    return _get
 
 
 @pytest.fixture(scope="module")
-def qube_sd_printers() -> QubeWrapper:
-    return _qubes["sd-printers"]
+def qube_sd_devices(qube_factory: Callable[[str], QubeWrapper]) -> QubeWrapper:
+    return qube_factory("sd-devices")
+
+
+@pytest.fixture(scope="module")
+def qube_sd_printers(qube_factory: Callable[[str], QubeWrapper]) -> QubeWrapper:
+    return qube_factory("sd-printers")
 
 
 # Parameterize: tests calling this fixture will run for each qube
-@pytest.fixture(scope="module", params=list(_qubes.values()), ids=list(_qubes.keys()))
-def qube(request: pytest.FixtureRequest) -> QubeWrapper:
-    return request.param  # returns a fixture for each qube
+@pytest.fixture(scope="module", params=list(_qube_kwargs))
+def qube(request: pytest.FixtureRequest, qube_factory: Callable[[str], QubeWrapper]) -> QubeWrapper:
+    return qube_factory(request.param)  # returns a fixture for each qube
 
 
 def test_files_are_properly_copied(qube: QubeWrapper) -> None:


### PR DESCRIPTION
QubeWrapper ensures that VMs are running, which means that test collection ends up slow. This isn't an actual problem but just a smell.

Add a check that all VM interactions via QubeWrapper only happens in the context of a fixture or active test and not during import.

[This was entirely written by Claude]

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] shut down all SDW VMs; then running e.g. `pytest --collect-only` is near instant and doesn't wait for VMs to boot up.
* [ ] CI passes
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
