### PR TITLE
Test fixtures improvement

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ from tests.base import (
 )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def proj_root() -> os.PathLike[Any]:
     return Path(__file__).parent.parent
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,13 @@
+import importlib.machinery
+import importlib.util
 import json
 import os
 import warnings
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from datetime import datetime
 from pathlib import Path
+from types import ModuleType
+from typing import Any
 
 import dnf
 import pytest
@@ -21,7 +25,50 @@ from tests.base import (
     is_workstation_qube,
 )
 
-PROJ_ROOT = Path(__file__).parent.parent
+
+@pytest.fixture
+def proj_root() -> os.PathLike[Any]:
+    return Path(__file__).parent.parent
+
+
+@pytest.fixture(autouse=True)
+def load_non_standard_module() -> Callable:
+    """
+    Fixture factory for loading a non-standard python modules
+
+    This is necessary as a workaround due to the fact that some files not
+    following the standard python naming inventions, in particular:
+      1. Files ending in '.py'
+      2. No dashes ('-') in file names
+
+    Example:
+
+    .. code-block:: python
+
+        @pytest.fixture()
+        def custom_module(load_non_standard_module):
+            return load_non_standard_module("custom_module", "/usr/bin/custom-module")
+
+        def test_foo(custom_module):
+            custom_module.custom_fn()
+    """
+
+    def _load_non_standard_module(module_path: os.PathLike) -> ModuleType:
+        # Optional: pythonify the module name. In practice this does not matter since
+        # the fixture effectively acts as the module reference
+        module_name = Path(module_path).stem.replace(".", "_").replace("-", "_")
+
+        # NOTE loader needed since 'importlib.util.spec_from_file_location' only
+        # works with '.py' files and RPC service does not have an extension
+        loader = importlib.machinery.SourceFileLoader(module_name, str(module_path))
+        spec = importlib.util.spec_from_loader(module_name, loader)
+        assert spec is not None
+        assert spec.loader is not None
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    return _load_non_standard_module
 
 
 @pytest.fixture
@@ -56,9 +103,9 @@ def mock_block_device(all_vms: VMCollection, worker_id: str, testrun_uid: str) -
 
 
 @pytest.fixture(scope="session")
-def dom0_config() -> Dom0Config:
+def dom0_config(proj_root: os.PathLike) -> Dom0Config:
     """Make the dom0 "config.json" available to tests."""
-    with open(os.path.join(PROJ_ROOT, "config.json")) as c:
+    with open(os.path.join(proj_root, "config.json")) as c:
         config = json.load(c)
         # TODO: in the future, when "config.json" does not include an env declaration,
         # If the "environment" key is absent from the "config.json" file, assume prod,

--- a/tests/test_rpc_service_getsecretkeys.py
+++ b/tests/test_rpc_service_getsecretkeys.py
@@ -3,32 +3,18 @@
 Tests for securedrop.GetSecretKeys qrexec service.
 """
 
-import importlib.machinery
-import importlib.util
 import logging
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
 import pytest
 
-MODULE_PATH = "/etc/qubes-rpc/securedrop.GetSecretKeys"
-MODULE_NAME = "securedrop_GetSecretKeys"
-
 
 @pytest.fixture
-def rpc_service() -> Any:
+def rpc_service(load_non_standard_module: Callable) -> Any:
     """Load the python RPC server module from its non-standard path"""
-
-    # NOTE: loader needed since 'importlib.util.spec_from_file_location' only
-    # works with '.py' files and RPC service does not have an extension
-    loader = importlib.machinery.SourceFileLoader(MODULE_NAME, MODULE_PATH)
-
-    spec = importlib.util.spec_from_loader(MODULE_NAME, loader)
-    assert spec is not None
-    assert spec.loader is not None
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
+    return load_non_standard_module(Path("/etc/qubes-rpc/securedrop.GetSecretKeys"))
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_sdw_admin.py
+++ b/tests/test_sdw_admin.py
@@ -1,0 +1,26 @@
+from collections.abc import Callable
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+@pytest.fixture
+def sdw_admin(
+    proj_root: Path,
+    load_non_standard_module: Callable[[Path], ModuleType],
+) -> ModuleType:
+    """
+    Equivalent to 'import sdw_admin', except as a pytest fixture.
+
+    Workaround needed due to 'sdw-admin.py' having a non-pythonic '-' in its
+    name and also not currently being in its own python module.
+    """
+
+    # FIXME this is a workaroud. A better approach is to have sdw-admin in
+    # a proper python module, trivially importable in tests. See #1750.
+    return load_non_standard_module(proj_root / "files" / "sdw-admin.py")
+
+
+def test_is_managed(sdw_admin: ModuleType) -> None:
+    assert sdw_admin.is_managed("sd-app")


### PR DESCRIPTION
Split out of from https://github.com/freedomofpress/securedrop-workstation/pull/1754/ to simplify its review.

1. Mark PROJECT_ROOT fixture as session-scoped
2. Adds generic fixture for import non-compliant py files
    
    We already had a way to import non-compliant python files: RPC services.
    These problematic standalone files are not part of any python module and
    may lack the extension and have invalid file names.
    
    This moves that fixture into conftest as a fixture factory so that
    sdw-admin and other non-compliant modules can be imported until we place
    them in proper python modules (see #1750).


## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
