### PR TITLE
`local-yum-server`: warn when vm dependencies are missing

### DIFF
--- a/scripts/local-rpm-server.sh
+++ b/scripts/local-rpm-server.sh
@@ -163,7 +163,7 @@ vm_main() {
     # Entry point in case this runs in a VM
 
     export GNUPGHOME=$SD_DEV_GNUPGHOME
-    check_pkgs createrepo_c gpg qubes-core-agent-dom0-updates
+    check_pkgs createrepo-c gpg qubes-core-agent-dom0-updates
 
     if [[ "$1" == "generate-key" ]]; then
         vm_gen_signing_key

--- a/scripts/local-rpm-server.sh
+++ b/scripts/local-rpm-server.sh
@@ -20,6 +20,17 @@ log() {
     fi
 }
 
+check_pkgs() {
+    local missing=()
+    for pkg in "$@"; do
+        dpkg-query -W -f='${db:Status-Status}' "$pkg" 2>/dev/null | grep -qx installed \
+            || missing+=("$pkg")
+    done
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo "Error: missing packages: ${missing[*]}" >&2
+        exit 1
+    fi
+}
 # Tmp location for local signing keys (so we don't mess with existing keyrings)
 SD_DEV_GNUPGHOME="/tmp/local_dev_gnupg"
 LOCAL_SIG_KEY_NAME="SD dom0 local updates"
@@ -152,6 +163,7 @@ vm_main() {
     # Entry point in case this runs in a VM
 
     export GNUPGHOME=$SD_DEV_GNUPGHOME
+    check_pkgs createrepo_c gpg qubes-core-agent-dom0-updates
 
     if [[ "$1" == "generate-key" ]]; then
         vm_gen_signing_key


### PR DESCRIPTION
Script would fail mid-way and make it not immediately clear the issue was that createrepo-c was missing on the system.

Reported during 1.9.0 QA. 

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
In dev vm remove some of the dependencies and ensure they are reported as missing.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
