### PR TITLE
Add RPC policies for securedrop-admin

### DIFF
--- a/files/31-securedrop-admin.policy
+++ b/files/31-securedrop-admin.policy
@@ -1,0 +1,19 @@
+## Configure Qubes RPC "allow" policies for SecureDrop Admin.
+#
+# This file is provisioned by securedrop-admin-dom0-config.
+# Do not modify this file!
+#
+# See 31-securedrop-workstation.policy for details about numbering.
+
+# sd-admin: copy/paste to and from sd-vault
+qubes.ClipboardPaste    *           sd-admin sd-vault allow
+qubes.ClipboardPaste    *           sd-vault sd-admin allow
+
+# sd-firewall-setup: copy/paste to and from sd-vault
+qubes.ClipboardPaste    *           sd-firewall-setup sd-vault allow
+qubes.ClipboardPaste    *           sd-vault sd-firewall-setup allow
+
+# sd-vault: copy/paste to and from sd-app, for combined journalist+admin
+# workstations
+qubes.ClipboardPaste    *           sd-vault sd-app allow
+qubes.ClipboardPaste    *           sd-app sd-vault allow

--- a/files/32-securedrop-admin.policy
+++ b/files/32-securedrop-admin.policy
@@ -1,0 +1,61 @@
+## Configure Qubes RPC "deny" policies for SecureDrop Admin.
+#
+# This file is provisioned by securedrop-admin-dom0-config.
+# Do not modify this file!
+#
+# As a general strategy, in addition to explicit grants, we provide
+# catch-all deny policies for SDW-provisioned VMs.
+#
+# Mostly a mirror of 32-securedrop-workstation.policy.
+
+qubes.GpgImportKey      *           @anyvm @tag:sd-admin deny
+qubes.GpgImportKey      *           @tag:sd-admin @anyvm deny
+
+qubes.Gpg               *           @anyvm @tag:sd-admin deny
+qubes.Gpg               *           @tag:sd-admin @anyvm deny
+
+# Future: qubes-app-linux-split-gpg2
+qubes.Gpg2              *           @anyvm @tag:sd-admin deny
+qubes.Gpg2              *           @tag:sd-admin @anyvm deny
+
+qubes.USBAttach         *           @anyvm @tag:sd-admin deny
+qubes.USBAttach         *           @tag:sd-admin @anyvm deny
+
+qubes.USB               *           @anyvm @tag:sd-admin deny
+qubes.USB               *           @tag:sd-admin @anyvm deny
+
+qubes.PdfConvert        *           @anyvm @tag:sd-admin deny
+qubes.PdfConvert        *           @tag:sd-admin @anyvm deny
+
+qubes.ClipboardPaste    *           @anyvm @tag:sd-admin deny
+qubes.ClipboardPaste    *           @tag:sd-admin @anyvm deny
+
+qubes.FeaturesRequest   *           @anyvm @tag:sd-admin deny
+qubes.FeaturesRequest   *           @tag:sd-admin @anyvm deny
+
+qubes.Filecopy          *           @anyvm @tag:sd-admin deny
+qubes.Filecopy          *           @tag:sd-admin @anyvm deny
+
+qubes.GetImageRGBA      *           @anyvm @tag:sd-admin deny
+qubes.GetImageRGBA      *           @tag:sd-admin @anyvm deny
+
+qubes.OpenInVM          *           @anyvm @tag:sd-admin deny
+qubes.OpenInVM          *           @tag:sd-admin @anyvm deny
+
+qubes.OpenURL           *           @anyvm @tag:sd-admin deny
+qubes.OpenURL           *           @tag:sd-admin @anyvm deny
+
+qubes.StartApp          *           @anyvm @tag:sd-admin deny
+qubes.StartApp          *           @tag:sd-admin @anyvm deny
+
+qubes.VMRootShell       *           @anyvm @tag:sd-admin deny
+qubes.VMRootShell       *           @tag:sd-admin @anyvm deny
+
+qubes.VMShell           *           @anyvm @tag:sd-admin deny
+qubes.VMShell           *           @tag:sd-admin @anyvm deny
+
+qubes.VMExec            *           @anyvm @tag:sd-admin deny
+qubes.VMExec            *           @tag:sd-admin @anyvm deny
+
+qubes.VMExecGUI         *           @anyvm @tag:sd-admin deny
+qubes.VMExecGUI         *           @tag:sd-admin @anyvm deny

--- a/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
+++ b/rpm-build/SPECS/securedrop-workstation-dom0-config.spec
@@ -131,6 +131,10 @@ chmod -R u=rwX,go=rX %{buildroot}/srv/salt/admin_salt
 install -m 644 securedrop_salt/apt_freedom_press.sources.j2 %{buildroot}/srv/salt/admin_salt/
 install -m 644 securedrop_salt/apt-test_freedom_press.sources.j2 %{buildroot}/srv/salt/admin_salt/
 
+install -m 755 -d %{buildroot}/etc/qubes/policy.d/
+install -m 644 files/31-securedrop-admin.policy %{buildroot}/etc/qubes/policy.d/
+install -m 644 files/32-securedrop-admin.policy %{buildroot}/etc/qubes/policy.d/
+
 %files
 %attr(755, root, root) %{_datadir}/%{name}/scripts/clean-salt
 %attr(755, root, root) %{_datadir}/%{name}/scripts/destroy-vm
@@ -175,6 +179,8 @@ install -m 644 securedrop_salt/apt-test_freedom_press.sources.j2 %{buildroot}/sr
 
 %files -n securedrop-admin-dom0-config
 /srv/salt/admin_salt/*
+%attr(664, root, root) /etc/qubes/policy.d/31-securedrop-admin.policy
+%attr(664, root, root) /etc/qubes/policy.d/32-securedrop-admin.policy
 %doc README.md
 %license LICENSE
 

--- a/tests/test_rpc_policy.py
+++ b/tests/test_rpc_policy.py
@@ -8,6 +8,19 @@ from qubesadmin.vm import QubesVM
 
 from tests.base import is_managed_qube
 
+# Policies shipped by the opt-in securedrop-admin-dom0-config subpackage
+ADMIN_POLICY_FILES = [
+    "/etc/qubes/policy.d/31-securedrop-admin.policy",
+    "/etc/qubes/policy.d/32-securedrop-admin.policy",
+]
+
+# Clipboard pairings granted by 31-securedrop-admin.policy
+ADMIN_CLIPBOARD_PAIRS = [
+    ("sd-admin", "sd-vault"),
+    ("sd-firewall-setup", "sd-vault"),
+    ("sd-vault", "sd-app"),
+]
+
 
 @functools.cache
 def qrexec_policy_graph(service: str) -> str:
@@ -28,6 +41,53 @@ def test_policy_files_exist() -> None:
     """verify the policies are installed"""
     assert os.path.exists("/etc/qubes/policy.d/31-securedrop-workstation.policy")
     assert os.path.exists("/etc/qubes/policy.d/32-securedrop-workstation.policy")
+
+
+@pytest.mark.provisioning
+@pytest.mark.parametrize(("first", "second"), ADMIN_CLIPBOARD_PAIRS)
+def test_admin_clipboard_allowed(all_vms: VMCollection, first: str, second: str) -> None:
+    """
+    The admin needs to move credentials between the qube that stores them
+    (sd-vault) and the qubes that use them, in both directions.
+    """
+    if not all(os.path.exists(policy) for policy in ADMIN_POLICY_FILES):
+        pytest.skip("securedrop-admin-dom0-config is not installed")
+    for vm in (first, second):
+        if vm not in all_vms:
+            pytest.skip(f"{vm} does not exist")
+
+    assert policy_exists(first, second, "qubes.ClipboardPaste")
+    assert policy_exists(second, first, "qubes.ClipboardPaste")
+
+
+@pytest.mark.provisioning
+def test_admin_clipboard_from_other_denied(all_vms: VMCollection) -> None:
+    """
+    Clipboard access to and from admin qubes is otherwise denied, even for
+    qubes that are themselves part of SecureDrop Workstation.
+    """
+    if not all(os.path.exists(policy) for policy in ADMIN_POLICY_FILES):
+        pytest.skip("securedrop-admin-dom0-config is not installed")
+
+    allowed = {
+        pair
+        for first, second in ADMIN_CLIPBOARD_PAIRS
+        for pair in ((first, second), (second, first))
+    }
+    admin_vms = [vm for vm in all_vms if "sd-admin" in vm.tags]
+    if not admin_vms:
+        pytest.skip("no sd-admin-tagged qubes exist")
+
+    for admin_vm in admin_vms:
+        for vm in all_vms:
+            if vm.name == admin_vm.name:
+                continue
+            for pair in ((admin_vm.name, vm.name), (vm.name, admin_vm.name)):
+                if pair in allowed:
+                    continue
+                assert not policy_exists(
+                    pair[0], pair[1], "qubes.ClipboardPaste"
+                ), f"qubes.ClipboardPaste from {pair[0]} to {pair[1]} should be denied"
 
 
 @pytest.mark.provisioning


### PR DESCRIPTION
We allow access to and from sd-vault for sd-admin, sd-firewall-setup, and sd-app.

Copy over the blanket denial of all policies from the journalist workstation too.

Fixes #1578.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] smoke test that most RPC policies are denied
* [ ] we can't test the other policies yet because those VMs don't exist yet so I think visual review is sufficient.
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
