### PR TITLE
Install packages via securedrop-admin-qubes metapackage

### DIFF
--- a/admin_salt/sd-admin-packages.sls
+++ b/admin_salt/sd-admin-packages.sls
@@ -17,17 +17,6 @@ update-apt-cache:
   cmd.run:
     - name: apt-get update --allow-releaseinfo-change
 
-# Install qubes VM kernel support here, activate PVH in the sd-admin AppVM later
-# TODO: add an fpf metapackage to manage these dependencies
-install-qubes-packages:
-  pkg.installed:
-    - pkgs:
-      - qubes-vm-recommended
-      - linux-image-amd64
-      - grub2
-      - qubes-kernel-vm-support
-      - xfce4-terminal
-
 autoremove-old-packages:
   cmd.run:
     - name: apt-get autoremove -y
@@ -57,7 +46,7 @@ install-securedrop-packages:
   pkg.installed:
     - pkgs:
       - securedrop-keyring
-      - securedrop-admin
+      - securedrop-admin-qubes
       - securedrop-workstation-grsec
     - require:
       - cmd: update-apt-cache-with-fpf


### PR DESCRIPTION
This package pulls in what we need in the template. Depends on https://github.com/freedomofpress/securedrop/pull/7909 which creates the new package.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] fresh provision of sd-admin works + boots the template
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
