### PR TITLE
Update all templates with `sd-updater` tag

### DIFF
--- a/admin_salt/sd-admin-template.sls
+++ b/admin_salt/sd-admin-template.sls
@@ -20,6 +20,6 @@ sd-admin-debian-13:
         - sd-workstation
         - sd-workstation-trixie
         - sd-admin
+        - sd-updater
     - require:
       - qvm: dom0-install-debian-13-template
-

--- a/launcher/tests/conftest.py
+++ b/launcher/tests/conftest.py
@@ -5,6 +5,7 @@ import tempfile
 import pytest
 
 import sdw_updater.Updater
+from sdw_updater.Updater import SD_UPDATER_TAG
 
 
 @pytest.fixture
@@ -60,8 +61,8 @@ SD_TAG = "sd-workstation"
 MOCK_FEDORA_TEMPLATE = "fedora-XX-xfce"
 
 # SecureDrop-managed TemplateVMs, all tagged `sd-workstation`.
+MOCK_SDW_BASE_TEMPLATE = "sd-base-debian-XX"
 MOCK_SDW_TEMPLATES = [
-    "sd-base-debian-XX",
     "sd-inbox-debian-XX",
     "sd-viewer-debian-XX",
 ]
@@ -84,23 +85,32 @@ def mocked_qubes_app(mocker):
     from qubesadmin.tests.mock_app import MockQube, QubesTestWrapper
 
     # The mock only registers `admin.vm.tag.Get` calls for tags it knows about,
-    # so register `sd-workstation` to allow `"sd-workstation" in vm.tags` checks
-    # against untagged VMs (e.g. the Fedora template).
-    if SD_TAG not in mock_app.POSSIBLE_TAGS:
-        mock_app.POSSIBLE_TAGS.append(SD_TAG)
+    # so register our tags to allow `"sd-workstation" in vm.tags` checks against
+    # untagged VMs (e.g. the Fedora template).
+    for tag in (SD_TAG, SD_UPDATER_TAG):
+        if tag not in mock_app.POSSIBLE_TAGS:
+            mock_app.POSSIBLE_TAGS.append(tag)
 
     class MockQubesWorkstation(QubesTestWrapper):
         def __init__(self):
             super().__init__()
 
             # 1. Create the SecureDrop templates (tagged `sd-workstation`)
+            self._qubes[MOCK_SDW_BASE_TEMPLATE] = MockQube(
+                name=MOCK_SDW_BASE_TEMPLATE,
+                qapp=self,
+                klass="TemplateVM",
+                netvm="",
+                tags=[SD_TAG],
+            )
+
             for template_name in MOCK_SDW_TEMPLATES:
                 self._qubes[template_name] = MockQube(
                     name=template_name,
                     qapp=self,
                     klass="TemplateVM",
                     netvm="",
-                    tags=[SD_TAG],
+                    tags=[SD_TAG, SD_UPDATER_TAG],
                 )
 
             # 2. Create the Fedora template backing the sys-* VMs (NOT tagged)

--- a/launcher/tests/conftest.py
+++ b/launcher/tests/conftest.py
@@ -78,9 +78,19 @@ MOCK_SDW_APPVMS = {
     "sd-printers": "sd-viewer-debian-XX",
 }
 
+# The admin-only TemplateVM and AppVM (also tagged `sd-workstation`).
+MOCK_SDW_ADMIN_TEMPLATE = "sd-admin-debian-XX"
+MOCK_SDW_ADMIN_APPVMS = {
+    "sd-admin": MOCK_SDW_ADMIN_TEMPLATE,
+}
 
-@pytest.fixture
-def mocked_qubes_app(mocker):
+
+def _make_mocked_qubes_app(mocker, journalist: bool, admin: bool):
+    """
+    Build a mock Qubes app with the journalist qubes, the admin qubes, or both.
+
+    The Fedora template and the sys-* VMs it backs are always present.
+    """
     from qubesadmin.tests import mock_app
     from qubesadmin.tests.mock_app import MockQube, QubesTestWrapper
 
@@ -95,16 +105,24 @@ def mocked_qubes_app(mocker):
         def __init__(self):
             super().__init__()
 
-            # 1. Create the SecureDrop templates (tagged `sd-workstation`)
-            self._qubes[MOCK_SDW_BASE_TEMPLATE] = MockQube(
-                name=MOCK_SDW_BASE_TEMPLATE,
-                qapp=self,
-                klass="TemplateVM",
-                netvm="",
-                tags=[SD_TAG],
-            )
+            templates = []
+            appvms = {}
+            if journalist:
+                self._qubes[MOCK_SDW_BASE_TEMPLATE] = MockQube(
+                    name=MOCK_SDW_BASE_TEMPLATE,
+                    qapp=self,
+                    klass="TemplateVM",
+                    netvm="",
+                    tags=[SD_TAG],
+                )
+                templates.extend(MOCK_SDW_TEMPLATES)
+                appvms.update(MOCK_SDW_APPVMS)
+            if admin:
+                templates.append(MOCK_SDW_ADMIN_TEMPLATE)
+                appvms.update(MOCK_SDW_ADMIN_APPVMS)
 
-            for template_name in MOCK_SDW_TEMPLATES:
+            # 1. Create the SecureDrop templates (tagged `sd-workstation`)
+            for template_name in templates:
                 self._qubes[template_name] = MockQube(
                     name=template_name,
                     qapp=self,
@@ -122,7 +140,7 @@ def mocked_qubes_app(mocker):
             )
 
             # 3. Create the SecureDrop app qubes (tagged `sd-workstation`)
-            for qube_name, template_name in MOCK_SDW_APPVMS.items():
+            for qube_name, template_name in appvms.items():
                 MockQube(
                     qube_name,
                     self,
@@ -147,5 +165,23 @@ def mocked_qubes_app(mocker):
     # Patch "Qubes()" to allow tests to run on this fake mock
     mocker.patch("qubesadmin.Qubes").return_value = mock_qubes_app
 
-    # yield the mock to allow for further modifications in tests
+    # return the mock to allow for further modifications in tests
     return mock_qubes_app
+
+
+@pytest.fixture
+def mocked_journalist_qubes(mocker):
+    """A journalist workstation: no admin qubes."""
+    return _make_mocked_qubes_app(mocker, journalist=True, admin=False)
+
+
+@pytest.fixture
+def mocked_admin_qubes(mocker):
+    """An admin-only workstation: no journalist qubes."""
+    return _make_mocked_qubes_app(mocker, journalist=False, admin=True)
+
+
+@pytest.fixture
+def mocked_combined_qubes(mocker):
+    """A workstation with both the journalist and the admin qubes."""
+    return _make_mocked_qubes_app(mocker, journalist=True, admin=True)

--- a/launcher/tests/test_updater.py
+++ b/launcher/tests/test_updater.py
@@ -56,13 +56,32 @@ TEST_RESULTS_UPDATES = {
 }
 
 
+@pytest.mark.parametrize(
+    ("fixture_name", "expected"),
+    [
+        (
+            "mocked_journalist_qubes",
+            {"sd-inbox-debian-XX", "sd-viewer-debian-XX", "fedora-XX-xfce"},
+        ),
+        (
+            "mocked_admin_qubes",
+            {"sd-admin-debian-XX", "fedora-XX-xfce"},
+        ),
+        (
+            "mocked_combined_qubes",
+            {
+                "sd-inbox-debian-XX",
+                "sd-viewer-debian-XX",
+                "sd-admin-debian-XX",
+                "fedora-XX-xfce",
+            },
+        ),
+    ],
+)
 @skipif_no_qubesadmin
-def test__get_current_templates(mocked_qubes_app):
-    assert Updater._get_current_templates() == {
-        "sd-inbox-debian-XX",
-        "sd-viewer-debian-XX",
-        "fedora-XX-xfce",
-    }
+def test__get_current_templates(fixture_name, expected, request):
+    request.getfixturevalue(fixture_name)
+    assert Updater._get_current_templates() == expected
 
 
 @mock.patch("sdw_updater.Updater._write_updates_status_flag_to_disk")
@@ -364,14 +383,16 @@ def test_read_dom0_update_flag_from_disk_fails(mocked_info, mocked_error, tmp_pa
     ],
 )
 @skipif_no_qubesadmin
-def test_is_qubes_mid_upgrade(qubes_ver, agent_ver, is_mid_upgrade, mocker, mocked_qubes_app):
+def test_is_qubes_mid_upgrade(
+    qubes_ver, agent_ver, is_mid_upgrade, mocker, mocked_journalist_qubes
+):
     # Overrding "dnf.rpm.detect_releasever" to simulate being on particular Qubes version
     mocker.patch("dnf.rpm").detect_releasever.return_value = qubes_ver
 
     # Make templates return the version set by the test (MockQubes is just a mock)
-    for qube in mocked_qubes_app.domains:
+    for qube in mocked_journalist_qubes.domains:
         if qube.klass == "TemplateVM":
-            mocked_qubes_app.expected_calls[
+            mocked_journalist_qubes.expected_calls[
                 (qube.name, "admin.vm.feature.Get", "qubes-agent-version", None)
             ] = b"0\x00" + agent_ver.encode()
 

--- a/sdw_updater/Updater.py
+++ b/sdw_updater/Updater.py
@@ -29,6 +29,8 @@ LOG_FILE = "updater.log"
 DETAIL_LOG_FILE = "updater-detail.log"
 DETAIL_LOGGER_PREFIX = "detail"  # For detailed logs such as Salt states
 
+SD_UPDATER_TAG = "sd-updater"  # We update all templates with this tag
+
 # We use a hardcoded temporary directory path in dom0. As dom0 is not
 # a multi-user environment, we can safely assume that only the Updater is
 # managing that filepath. Later on, we should consider porting the check-migration
@@ -48,7 +50,7 @@ def _get_current_templates() -> set[str]:
     Return the set of TemplateVMs that the updater should update.
 
     Find:
-    * TemplateVMs tagged sd-workstation with derived_vms
+    * TemplateVMs tagged with SD_UPDATER_TAG ("sd-updater")
     * TemplateVMs that back hardcoded SYSTEM_VMS
 
     Notably this excludes the sd-base-debian-XX template, because
@@ -66,14 +68,11 @@ def _get_current_templates() -> set[str]:
     for vm in app.domains:
         if vm.klass != "TemplateVM":
             continue
-        if not vm.derived_vms:
-            # Nothing uses this template
-            continue
         if "prohibit-start" in vm.features:
             # Someone has disabled this VM
             continue
-        # Check for sd-workstation tag
-        if "sd-workstation" in vm.tags:
+        # Check for updater tag
+        if SD_UPDATER_TAG in vm.tags:
             templates.add(vm.name)
 
     for name in SYSTEM_VMS:

--- a/securedrop_salt/sd-workstation-template.sls
+++ b/securedrop_salt/sd-workstation-template.sls
@@ -24,6 +24,7 @@ include:
       - add:
         - sd-workstation
         - sd-{{ sdvars.distribution }}
+        - sd-updater
     - features:
       - enable:
         - service.paxctld


### PR DESCRIPTION
This tag is applied to sd-inbox-debian-13, sd-viewer-debian-13, sd-admin-debian-13 and can also be applied to any user-created templates that they want the updater to, well, update.

It is not applied to fedora-XX-xfce templates.

Refs #1158.
Fixes #1598.
Fixes #1816.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] create a new template; tag it with sd-updater but not sd-workstation and then run the updater and see it gets updated
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] any necessary RPM packaging updates (e.g., added/removed files, see `rpm-build/SPECS/securedrop-workstation-dom0-config.spec`)
- [ ] any required documentation
